### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/yevheniidehtiar/hyper-admin/security/code-scanning/2](https://github.com/yevheniidehtiar/hyper-admin/security/code-scanning/2)

The best way to fix this problem is to add a `permissions` block at the root of the workflow file, above the `jobs` section, so it applies to all jobs unless overridden. Set the permission to the minimal necessary access, which is almost always `contents: read` for typical CI/test workflows. This ensures the GITHUB_TOKEN used by the workflow only has read access to the repository contents, preventing accidental or malicious modification of repository data from within the workflow. Edit `.github/workflows/test.yml` to insert:

```yaml
permissions:
  contents: read
```

directly under the workflow `name` (after line 1, before `on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
