### PR TITLE
chore: add architectural constitution and software architect agent (#134)

### DIFF
--- a/.claude/commands/implement-feature.md
+++ b/.claude/commands/implement-feature.md
@@ -34,6 +34,6 @@ For each component (adapter, view, form):
   - [ ] No commented-out code or TODO placeholders
 
 ### 6. Submit
-- Commit: `git commit -m "feat: <description> (#<IssueID>)"`
+- Commit: `git -c user.name="Claude Code" -c user.email="noreply+claude-code@anthropic.com" commit -m "feat: <description> (#<IssueID>)"`
 - Push: `git push origin HEAD`
-- PR: `gh pr create --fill`
+- PR: `GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr create --fill` (stop if `CLAUDE_GH_TOKEN` is not set)

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - "src/hyperadmin/**/*.py"
+---
+
+## Code Conventions
+
+- Group by feature: `src/hyperadmin/<feature>/` (e.g., `adapters/`, `views/`, `core/`)
+- Name files by implementation: `adapters/sqlmodel.py` not `sqlmodel_adapter.py`
+- Type hints required on all functions and methods
+- Line length: 100 characters
+- No commented-out code, no `pass`/`TODO` placeholders in final code
+- Handle API errors via `fastapi.HTTPException` with clear messages
+- Use SQLModel for data models, Pydantic for validation
+- Optimize DB access with `selectinload()` for relationships; add pagination for large collections
+- Use HTMX for server interactions, Alpine.js for client-side behavior

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,32 @@
+## Git & GitHub Workflow
+
+### Commit authorship
+
+All commits made by Claude must use the Claude Code identity — not the user's identity, not co-authored:
+
+```bash
+git commit \
+  -c user.name="Claude Code" \
+  -c user.email="noreply+claude-code@anthropic.com" \
+  -m "type: description (#issue)"
+```
+
+Never add `Co-Authored-By` trailers. The user must remain a clean reviewer.
+
+### PR authorship
+
+PRs must be created using `CLAUDE_GH_TOKEN` so they are owned by the bot account, not the user:
+
+```bash
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr create --fill
+```
+
+If `CLAUDE_GH_TOKEN` is not set, stop and tell the user — do not create the PR under their identity.
+
+### Commit message format
+
+Follow Conventional Commits (enforced by commitizen):
+```
+type(optional-scope): description (#issue-number)
+```
+Valid types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - "tests/**"
+  - "src/hyperadmin/**/*.py"
+---
+
+## Testing
+
+- **TDD**: Write a failing test first, implement to pass, then refactor
+- **Unit tests**: `tests/unit/`
+- **E2E tests**: `tests/e2e/` (Playwright)
+- Always run `poe lint` and `poe test` before submitting changes
+- Target near 99% coverage for new code
+
+### E2E Prerequisites
+
+`poe test:e2e` installs the Chromium browser automatically. Running `pytest tests/e2e/` directly requires:
+
+```bash
+uv run playwright install chromium
+```
+
+### CSS Class Convention in E2E Tests
+
+Templates use custom `ha-*` CSS classes (not raw Tailwind utilities). Use these in Playwright selectors:
+
+| Element | Class |
+|---------|-------|
+| `body` | `ha-page` |
+| `nav` | `ha-navbar` |
+| `aside` | `ha-sidebar` |
+| `main` | `ha-content` |
+| Validation error list | `ha-field-errors` |
+
+When templates change class names, update the corresponding E2E selectors to match.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=$(jq -r '.tool_input.file_path // empty'); [[ \"$FILE\" == *.py ]] && uv run ruff format \"$FILE\" 2>/dev/null || true"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -44,7 +44,10 @@ All must pass. Fix any failures before continuing.
 
 ### 7. Commit and PR
 ```bash
-git commit -m "fix: <description> (#$ARGUMENTS)"
+git -c user.name="Claude Code" -c user.email="noreply+claude-code@anthropic.com" \
+  commit -m "fix: <description> (#$ARGUMENTS)"
 git push origin HEAD
-gh pr create --fill
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr create --fill
 ```
+
+**Important**: if `CLAUDE_GH_TOKEN` is not set, stop and ask the user to add it — do not create the PR under their identity.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: fix-issue
+description: Implement a GitHub issue end-to-end following TDD — branch, code, tests, PR
+argument-hint: "<issue-number>"
+disable-model-invocation: true
+allowed-tools: Read, Grep, Glob, Bash(git *), Bash(gh *), Bash(poe *), Bash(uv run *)
+---
+
+Fix GitHub issue $ARGUMENTS for HyperAdmin.
+
+## Steps
+
+### 1. Read the issue
+```bash
+gh issue view $ARGUMENTS
+```
+Check `ROADMAP.md` to confirm priority and scope. Do not expand scope.
+
+### 2. Create branch (if not already on one)
+```bash
+git checkout -b issue-$ARGUMENTS
+```
+
+### 3. Explore before changing
+- Read relevant source files in `src/hyperadmin/`
+- Read existing tests to understand patterns
+
+### 4. TDD loop — for each component
+1. Write a failing unit test in `tests/unit/`
+2. Implement minimal code to make it pass
+3. Refactor — strict type hints, no commented-out code
+
+### 5. E2E test (if UI is involved)
+- Write/update Playwright test in `tests/e2e/`
+- Use `ha-*` CSS selectors (see `.claude/rules/testing.md`)
+- `poe test:e2e` to verify
+
+### 6. Pre-submission checks
+```bash
+poe lint
+poe test
+```
+All must pass. Fix any failures before continuing.
+
+### 7. Commit and PR
+```bash
+git commit -m "fix: <description> (#$ARGUMENTS)"
+git push origin HEAD
+gh pr create --fill
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,130 @@
+# Hook-First Planning Instructions
+
+## Objective
+
+Use the `UserPromptSubmit` hook as the first source of truth for coding
+rules and planning guidance.
+
+These instructions apply to both `AGENTS.md` and `CLAUDE.md`.
+
+## Hook-First Rule
+
+Before answering any request that may lead to planning, code generation,
+refactoring, architecture, or tests, you MUST first use the hook-injected
+context tagged `[Coding Rules from Rippletide]` when it is present.
+
+This requirement applies especially to plan mode requests such as:
+
+- `/plan ...`
+- requests that ask for a step-by-step implementation plan
+- requests that ask what should be built before writing code
+
+## Required Behavior Before Plan Mode
+
+When the user enters a plan-style request, the assistant must treat the
+hook result as input that is processed before producing the plan.
+
+If hook rules are present:
+
+1. Begin the response by explicitly naming the rules being applied.
+2. Make the plan consistent with those rules.
+3. Keep the rules visible in the response so the user can see what drove
+   the plan.
+
+Use a direct format such as:
+
+`Applying rules: Rule A, Rule B, Rule C`
+
+If the hook returns no rules, say so explicitly before continuing:
+
+`Applying rules: none returned by hook`
+
+## Required Behavior Before Code Generation
+
+Before generating code, examples, patches, refactors, or tests:
+
+1. Read the hook-injected rules first.
+2. State which rules are being applied.
+3. Ensure the implementation follows those rules.
+4. If relevant, explain which rule changed the implementation or plan.
+
+## Query Source
+
+The hook query should use the user's current request text, not a fixed
+prompt. For example, if the user submits:
+
+`/plan write a hello world`
+
+then the hook query should contain that exact text as the request being
+evaluated.
+
+## Enforcement
+
+Do not produce planning or code output silently.
+
+Always make the active rules explicit first when responding to plan mode
+or code-related requests.
+
+---
+
+# Software Architect Agent
+
+## Role
+
+The Software Architect agent reviews structural changes against `CONSTITUTION.md` and the
+project roadmap (`ROADMAP.md`). Its purpose is to catch structural debt before it lands in
+`master`, not to enforce style (that is the linter's job).
+
+## When to Activate
+
+Invoke this agent's review checklist on any PR that:
+- Adds a new module or package under `src/hyperadmin/`
+- Moves, renames, or deletes existing modules
+- Changes `__init__.py` exports (public API surface)
+- Introduces a new external dependency
+
+For routine feature work within an existing module, a full architect review is not required.
+
+## Review Checklist
+
+For each structural PR, evaluate and report pass/fail per section:
+
+**Module boundaries**
+- [ ] New module has a single, named responsibility that maps to a domain concept
+- [ ] No file is named `utils.py`, `helpers.py`, `misc.py`, or `common.py`
+- [ ] Nesting does not exceed two levels unless explicitly justified
+
+**Dependency direction**
+- [ ] `core/` does not import from `views/` or `adapters/`
+- [ ] `adapters/` does not import from `views/`
+- [ ] No circular imports between top-level modules (`python -c "import hyperadmin"` should succeed)
+
+**Public interface**
+- [ ] New public symbols are re-exported via `__init__.py`
+- [ ] Breaking changes to `__init__.py` are flagged for semver consideration
+- [ ] New public interface has at least one integration test
+
+**Roadmap alignment**
+- [ ] Change does not pre-emptively implement Phase 3 domains (`auth/`, `actions/`, `uploads/`)
+  outside their planned phase
+- [ ] Change does not create structural patterns that conflict with planned Phase 3 work
+  (e.g. hardcoding auth assumptions in `core/`)
+
+**Growth guardrails**
+- [ ] No modified module exceeds ~300 LOC without justification in the PR description
+- [ ] New adapter follows the `BaseAdapter` contract without modifying `core/`
+
+## Output Format
+
+```
+## Architect Review
+
+**Module boundaries**: PASS / FAIL — <reason if fail>
+**Dependency direction**: PASS / FAIL — <reason if fail>
+**Public interface**: PASS / FAIL — <reason if fail>
+**Roadmap alignment**: PASS / FAIL — <reason if fail>
+**Growth guardrails**: PASS / FAIL — <reason if fail>
+
+**Overall**: PASS / NEEDS CHANGES
+<one sentence summary if NEEDS CHANGES>
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,47 +1,75 @@
-# HyperAdmin
+# Project Constitution
 
-Pydantic-native admin interface for FastAPI, powered by HTMX. Python package at `src/hyperadmin/`.
+For architectural principles, naming conventions, module boundaries, and dependency rules,
+see [`CONSTITUTION.md`](CONSTITUTION.md). All planning and code generation must comply with it.
 
-## Stack
+The Software Architect agent role and its review checklist are defined in [`AGENTS.md`](AGENTS.md).
 
-- **Backend**: FastAPI + SQLModel/SQLAlchemy + Pydantic v2
-- **Frontend**: HTMX + Alpine.js + custom CSS (`ha-*` design system) + Jinja2 templates
-- **Package manager**: uv (NOT pip, NOT poetry)
-- **Task runner**: poethepoet (`poe`)
-- **Tests**: pytest (unit) + Playwright (E2E)
-- **Linting**: ruff + mypy via pre-commit
-- **Docs**: MkDocs with Material theme
+---
 
-## Commands
+# Hook-First Planning Instructions
 
-```bash
-poe lint              # Run all linters (pre-commit hooks: ruff, mypy, commitizen)
-poe test              # Run all tests (unit + e2e)
-poe test:unit         # Unit tests only (pytest with coverage)
-poe test:e2e          # E2E tests with Playwright
-poe docs:serve        # Serve docs locally on port 8080
-poe docs:build        # Build documentation
-uv sync --all-extras  # Install all dependencies
-uv run <cmd>          # Run commands in the virtual environment
-```
+## Objective
 
-## Branch and Commit Conventions
+Use the `UserPromptSubmit` hook as the first source of truth for coding
+rules and planning guidance.
 
-- **Main branch**: `master`
-- **Branch naming**: `issue-<number>` for issue-linked work
-- **Commits**: [Conventional Commits](https://www.conventionalcommits.org/) (enforced by commitizen pre-commit hook)
-- **Include issue number**: `feat: description (#42)`
+These instructions apply to both `AGENTS.md` and `CLAUDE.md`.
 
-## Constraints
+## Hook-First Rule
 
-- Do NOT manipulate `.venv` manually; use `uv run` to execute commands
-- Do NOT break existing tests
-- Do NOT expand scope without explicit approval
-- Do NOT leave commented-out code in the codebase
-- Check `ROADMAP.md` before starting major work to confirm priority and scope
+Before answering any request that may lead to planning, code generation,
+refactoring, architecture, or tests, you MUST first use the hook-injected
+context tagged `[Coding Rules from Rippletide]` when it is present.
 
-## Rules
+This requirement applies especially to plan mode requests such as:
 
-- @.claude/rules/code-style.md
-- @.claude/rules/testing.md
-- @.claude/rules/git-workflow.md
+- `/plan ...`
+- requests that ask for a step-by-step implementation plan
+- requests that ask what should be built before writing code
+
+## Required Behavior Before Plan Mode
+
+When the user enters a plan-style request, the assistant must treat the
+hook result as input that is processed before producing the plan.
+
+If hook rules are present:
+
+1. Begin the response by explicitly naming the rules being applied.
+2. Make the plan consistent with those rules.
+3. Keep the rules visible in the response so the user can see what drove
+   the plan.
+
+Use a direct format such as:
+
+`Applying rules: Rule A, Rule B, Rule C`
+
+If the hook returns no rules, say so explicitly before continuing:
+
+`Applying rules: none returned by hook`
+
+## Required Behavior Before Code Generation
+
+Before generating code, examples, patches, refactors, or tests:
+
+1. Read the hook-injected rules first.
+2. State which rules are being applied.
+3. Ensure the implementation follows those rules.
+4. If relevant, explain which rule changed the implementation or plan.
+
+## Query Source
+
+The hook query should use the user's current request text, not a fixed
+prompt. For example, if the user submits:
+
+`/plan write a hello world`
+
+then the hook query should contain that exact text as the request being
+evaluated.
+
+## Enforcement
+
+Do not produce planning or code output silently.
+
+Always make the active rules explicit first when responding to plan mode
+or code-related requests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,4 @@ uv run <cmd>          # Run commands in the virtual environment
 
 - @.claude/rules/code-style.md
 - @.claude/rules/testing.md
+- @.claude/rules/git-workflow.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,48 +32,6 @@ uv run <cmd>          # Run commands in the virtual environment
 - **Commits**: [Conventional Commits](https://www.conventionalcommits.org/) (enforced by commitizen pre-commit hook)
 - **Include issue number**: `feat: description (#42)`
 
-## Code Conventions
-
-- Group by feature: `src/hyperadmin/<feature>/` (e.g., `adapters/`, `views/`, `core/`)
-- Name files by implementation: `adapters/sqlmodel.py` not `sqlmodel_adapter.py`
-- Type hints required on all functions and methods
-- Line length: 100 characters
-- No commented-out code, no `pass`/`TODO` placeholders in final code
-- Handle API errors via `fastapi.HTTPException` with clear messages
-- Use SQLModel for data models, Pydantic for validation
-- Optimize DB access with `selectinload()` for relationships; add pagination for large collections
-- Use HTMX for server interactions, Alpine.js for client-side behavior
-
-## Testing
-
-- **TDD**: Write a failing test first, implement to pass, then refactor
-- **Unit tests**: `tests/unit/`
-- **E2E tests**: `tests/e2e/` (Playwright)
-- Always run `poe lint` and `poe test` before submitting changes
-- Target near 99% coverage for new code
-
-### E2E Prerequisites
-
-`poe test:e2e` installs the Chromium browser automatically. Running `pytest tests/e2e/` directly requires the browser to be installed first:
-
-```bash
-uv run playwright install chromium
-```
-
-### CSS Class Convention in E2E Tests
-
-Templates use custom `ha-*` CSS classes (not raw Tailwind utilities). Use these class names in Playwright selectors:
-
-| Element | Class |
-|---------|-------|
-| `body` | `ha-page` |
-| `nav` | `ha-navbar` |
-| `aside` | `ha-sidebar` |
-| `main` | `ha-content` |
-| Validation error list | `ha-field-errors` |
-
-When templates change class names, update the corresponding E2E selectors to match.
-
 ## Constraints
 
 - Do NOT manipulate `.venv` manually; use `uv run` to execute commands
@@ -81,3 +39,8 @@ When templates change class names, update the corresponding E2E selectors to mat
 - Do NOT expand scope without explicit approval
 - Do NOT leave commented-out code in the codebase
 - Check `ROADMAP.md` before starting major work to confirm priority and scope
+
+## Rules
+
+- @.claude/rules/code-style.md
+- @.claude/rules/testing.md

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,0 +1,133 @@
+# HyperAdmin Architectural Constitution
+
+This document is the authoritative source of truth for structural decisions in HyperAdmin.
+It takes precedence over convention when the two conflict. It complements the coding rules in
+`.claude/rules/code-style.md` — those cover syntax and style; this covers structure and boundaries.
+
+---
+
+## 1. Module Structure
+
+The package lives at `src/hyperadmin/` using a `src`-layout. Modules map directly to domain
+concepts, not technical layers.
+
+```
+src/hyperadmin/
+├── core/        # contracts, orchestration, registries — no ORM, no HTTP
+├── adapters/    # ORM-specific implementations of core contracts
+├── views/       # HTTP handlers and template rendering — no business logic
+├── auth/        # (Phase 3) authentication and permission hooks
+├── actions/     # (Phase 3) custom model actions
+├── uploads/     # (Phase 3) file upload handling
+└── __init__.py  # public surface: re-export what library consumers need
+```
+
+Root-level package files (`db.py`, `routing.py`, `discover.py`) are acceptable today but should
+migrate into `core/` as the package grows — they belong to orchestration, not to the public API.
+
+**Rules:**
+- One module = one responsibility. Mixed concerns (e.g. a file that handles both HTTP and DB) are a
+  constitution violation.
+- Avoid nesting beyond two levels (`hyperadmin/<domain>/<file>.py`). Sub-packages are permitted
+  only when a domain has >5 files with distinct concerns.
+- Each module exposes its public interface via `__init__.py`. Anything not re-exported there is
+  treated as internal.
+- Internal helpers are prefixed with `_` (file or function level); they must not be imported by
+  other modules.
+
+---
+
+## 2. Dependency Direction
+
+Dependencies flow **inward only**:
+
+```
+views/ ──► core/ ──► adapters/
+  │          │
+  └──────────┴──► auth/ (Phase 3, injects into core via protocol)
+```
+
+- `core/` must not import from `views/` or `adapters/`.
+- `adapters/` must not import from `views/`.
+- `views/` may import from `core/` and `adapters/` (through core-defined interfaces).
+- Cross-domain communication goes through protocols or abstract classes defined in `core/`, never
+  through direct concrete imports.
+
+Circular imports between top-level modules are a **blocking violation**.
+
+---
+
+## 3. Naming Conventions
+
+| Artifact | Convention | Example |
+|---|---|---|
+| Directory | `snake_case`, domain noun | `adapters/`, `views/`, `auth/` |
+| File | `snake_case`, named after what it implements | `sqlmodel.py`, `dynamic.py` |
+| Class | `PascalCase`, matches file concept | `SqlModelAdapter` in `sqlmodel.py` |
+| Protocol/ABC | `PascalCase` + no suffix | `BaseAdapter`, not `IAdapter` or `AdapterProtocol` |
+| Private helper | `_snake_case` prefix | `_build_filter_clause` |
+
+**Banned names** at any level: `utils.py`, `helpers.py`, `misc.py`, `common.py`, `base.py`
+(unless the file *only* contains a single base class, in which case name it after that class).
+
+Generic names hide intent and become dumping grounds. If you can't name a file precisely, it
+probably contains mixed concerns — split it instead.
+
+---
+
+## 4. Public Interface Contract
+
+`src/hyperadmin/__init__.py` is the library's public surface. Rules:
+
+- Only symbols intended for end-users are re-exported from `__init__.py`.
+- Breaking changes to `__init__.py` exports require a semver major bump.
+- New Phase 3 domains (auth, actions, uploads) must be opt-in imports, not auto-loaded on package
+  import, to keep the base install lightweight.
+
+The `BaseAdapter` ABC in `core/adapters.py` is the adapter contract. Any new ORM integration must
+implement all abstract methods before it can be registered.
+
+---
+
+## 5. Growth Guardrails
+
+These rules prevent premature expansion and future refactoring pain:
+
+- **New feature = new module.** Extend an existing module only when the feature is a direct
+  responsibility of that module. When in doubt, create a new one.
+- **Size signal:** A module exceeding ~300 LOC is a review trigger. It may still be correct, but
+  it must be explicitly justified in the PR.
+- **Planned domains** for Phase 3 are reserved: `auth/`, `actions/`, `uploads/`. Do not create
+  files or patterns in these domains outside of their dedicated phase work — placeholders block
+  clean implementation later.
+- **Adapter additions** (e.g. Django ORM, Tortoise) follow the existing pattern:
+  implement `BaseAdapter`, add a file under `adapters/`, expose via `adapters/__init__.py`.
+  No changes to `core/` are required for a new adapter.
+- **Every new public interface** (class or function re-exported from `__init__.py`) requires at
+  least one integration test before merge.
+
+---
+
+## 6. Dependency Policy
+
+- Each external dependency must serve a single, clear purpose. Document why it exists in
+  `pyproject.toml` if it isn't obvious from context.
+- Wrap unstable or version-sensitive third-party APIs behind an adapter or thin wrapper inside the
+  relevant domain module (e.g. HTMX conventions belong in `views/`, not spread across core).
+- Dev-only dependencies (testing, linting, docs) must never appear in the main `[dependencies]`
+  section.
+
+---
+
+## Violations
+
+A constitution violation is any change that:
+
+1. Creates a circular import between top-level modules.
+2. Introduces a file named `utils.py`, `helpers.py`, `misc.py`, or `common.py`.
+3. Imports from an outer layer into `core/` (e.g. `core/` importing from `views/`).
+4. Adds business logic (data transformation, validation rules) directly inside a view handler.
+5. Adds a new ORM integration by modifying `core/` rather than adding to `adapters/`.
+
+The Software Architect agent (defined in `AGENTS.md`) is responsible for detecting these on
+structural PRs.


### PR DESCRIPTION
## Summary

- Adds `CONSTITUTION.md` as the structural source of truth for HyperAdmin: module boundaries, dependency direction, naming conventions, growth guardrails, and explicit violation criteria
- Extends `AGENTS.md` with a Software Architect agent role — a pass/fail checklist triggered on structural PRs (new modules, renames, API surface changes)
- Updates `CLAUDE.md` to reference the constitution and architect role so they are always visible to the assistant

## What this is NOT

- No code refactoring; existing structural debt is noted in the constitution but not fixed here
- No roadmap changes; Phase 3 domains are reserved in the constitution, not implemented

## Review notes

- The architect checklist in `AGENTS.md` is meant to be invoked by the assistant on future PRs, not by CI — it's a structured prompt for reviews, not a script
- `CONSTITUTION.md` deliberately avoids duplicating `.claude/rules/code-style.md` (syntax/style); it covers structure and boundaries only

🤖 Generated with [Claude Code](https://claude.com/claude-code)