### PR TITLE
feat: implement update/delete validation and fix broken actions (#130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,19 +60,39 @@ uv run <cmd>          # Run commands in the virtual environment
 uv run playwright install chromium
 ```
 
-### CSS Class Convention in E2E Tests
+### E2E Selector Convention
 
-Templates use custom `ha-*` CSS classes (not raw Tailwind utilities). Use these class names in Playwright selectors:
+E2E tests use Playwright's accessibility-first locators. Query priority (highest to lowest):
 
-| Element | Class |
-|---------|-------|
-| `body` | `ha-page` |
-| `nav` | `ha-navbar` |
-| `aside` | `ha-sidebar` |
-| `main` | `ha-content` |
-| Validation error list | `ha-field-errors` |
+1. `page.get_by_role()` — buttons, links, headings, rows
+2. `page.get_by_label()` — form inputs (matched via `<label for>`)
+3. `page.get_by_text()` — static content assertions
+4. `page.get_by_test_id()` — elements without a natural accessible role
 
-When templates change class names, update the corresponding E2E selectors to match.
+**Do NOT** use `page.locator('.ha-*')` or positional DOM selectors in E2E tests. `ha-*` classes are for styling only and must not appear in test selectors.
+
+#### `data-testid` reference
+
+| Template element | `data-testid` |
+|-----------------|---------------|
+| Sidebar `<aside>` | `sidebar` |
+| List table | `list-table` |
+| Each table row | `list-row` |
+| View action link | `row-view-link` |
+| Edit action link | `row-edit-link` |
+| Delete action button | `row-delete-btn` |
+| Search input | `search-input` |
+| Pagination info | `pagination-info` |
+| Pagination previous | `pagination-prev` |
+| Pagination next | `pagination-next` |
+| Pagination current page | `pagination-page` |
+| Sort link (per field) | `sort-{field_name}` |
+| Create New link | `create-link` |
+| Form (create/update) | `model-form` |
+| Field error list | `{field_name}-errors` |
+| Detail fields container | `detail-fields` |
+
+When adding new interactive or assertable elements to templates, add a `data-testid` following the `<view>-<element>` naming pattern.
 
 ## Constraints
 

--- a/src/hyperadmin/templates/_sidebar.html
+++ b/src/hyperadmin/templates/_sidebar.html
@@ -1,4 +1,4 @@
-<aside class="ha-sidebar">
+<aside class="ha-sidebar" data-testid="sidebar">
     <div class="ha-sidebar-inner">
         <h2 class="ha-sidebar-title">Menu</h2>
         <ul class="ha-sidebar-nav">

--- a/src/hyperadmin/templates/components/pagination.html
+++ b/src/hyperadmin/templates/components/pagination.html
@@ -1,5 +1,5 @@
 <div class="ha-pagination">
-    <div class="ha-pagination-info">
+    <div class="ha-pagination-info" data-testid="pagination-info">
         Showing {{- pagination.start_index }} to {{ pagination.end_index }} of {{ pagination.total_items }} results
     </div>
     <div class="ha-pagination-controls">
@@ -8,12 +8,13 @@
            hx-get="{{- url_for(model_name|lower ~ '-list') }}?page={{ pagination.page - 1 }}&search={{ search_query }}&sort_by={{ sort_by }}&sort_direction={{ sort_direction -}}"
            hx-target="#model-list"
            hx-swap="outerHTML"
-           class="ha-pagination-btn">
+           class="ha-pagination-btn"
+           data-testid="pagination-prev">
             Previous
         </a>
         {%- endif -%}
 
-        <div class="ha-pagination-page">
+        <div class="ha-pagination-page" data-testid="pagination-page">
             Page {{ pagination.page }} of {{ pagination.total_pages }}
         </div>
 
@@ -22,7 +23,8 @@
            hx-get="{{- url_for(model_name|lower ~ '-list') }}?page={{ pagination.page + 1 }}&search={{ search_query }}&sort_by={{ sort_by }}&sort_direction={{ sort_direction -}}"
            hx-target="#model-list"
            hx-swap="outerHTML"
-           class="ha-pagination-btn">
+           class="ha-pagination-btn"
+           data-testid="pagination-next">
             Next
         </a>
         {%- endif -%}

--- a/src/hyperadmin/templates/components/search_input.html
+++ b/src/hyperadmin/templates/components/search_input.html
@@ -4,6 +4,8 @@
            value="{{- search_query -}}"
            placeholder="Search..."
            class="ha-search-input"
+           data-testid="search-input"
+           aria-label="Search"
            hx-get="{{- url_for(model_name|lower ~ '-list') -}}"
            hx-trigger="keyup changed delay:500ms, search"
            hx-target="#model-list"

--- a/src/hyperadmin/templates/components/sortable_header.html
+++ b/src/hyperadmin/templates/components/sortable_header.html
@@ -3,7 +3,8 @@
        hx-get="{{- url_for(model_name|lower ~ '-list') }}?sort_by={{ field }}&sort_direction={{ 'desc' if sort_by == field and sort_direction == 'asc' else 'asc' }}&search={{ search_query }}&page={{ pagination.page -}}"
        hx-target="#model-list"
        hx-swap="outerHTML"
-       class="ha-table-sort-link">
+       class="ha-table-sort-link"
+       data-testid="sort-{{ field }}">
         {{- field -}}
         {%- if sort_by == field -%}
             {%- if sort_direction == 'asc' -%}

--- a/src/hyperadmin/templates/components/table.html
+++ b/src/hyperadmin/templates/components/table.html
@@ -16,8 +16,8 @@
                 {%- endfor -%}
                 <td class="ha-table-cell ha-table-cell-center">
                     <a href="{{- url_for(model_name|lower ~ '-detail', item_id=item.id) -}}" class="ha-action-link">View</a>
-                    <a href="{{- url_for(model_name|lower ~ '-update', item_id=item.id) -}}" class="ha-action-link">Edit</a>
-                    <button hx-post="{{- url_for(model_name|lower ~ '-delete', item_id=item.id) -}}"
+                    <a href="{{- url_for(model_name|lower ~ '-update-form', item_id=item.id) -}}" class="ha-action-link">Edit</a>
+                    <button hx-delete="{{- url_for(model_name|lower ~ '-delete', item_id=item.id) -}}"
                             hx-confirm="Are you sure you want to delete this item?"
                             hx-target="closest tr"
                             hx-swap="outerHTML"

--- a/src/hyperadmin/templates/components/table.html
+++ b/src/hyperadmin/templates/components/table.html
@@ -1,5 +1,5 @@
 <div id="model-list" class="ha-table-wrapper">
-    <table class="ha-table">
+    <table class="ha-table" data-testid="list-table">
         <thead>
             <tr class="ha-table-header">
                 {%- for field in fields -%}
@@ -10,18 +10,19 @@
         </thead>
         <tbody class="ha-table-body">
             {%- for item in items -%}
-            <tr class="ha-table-row">
+            <tr class="ha-table-row" data-testid="list-row">
                 {%- for field in fields -%}
                     <td class="ha-table-cell">{{- item[field] -}}</td>
                 {%- endfor -%}
                 <td class="ha-table-cell ha-table-cell-center">
-                    <a href="{{- url_for(model_name|lower ~ '-detail', item_id=item.id) -}}" class="ha-action-link">View</a>
-                    <a href="{{- url_for(model_name|lower ~ '-update-form', item_id=item.id) -}}" class="ha-action-link">Edit</a>
+                    <a href="{{- url_for(model_name|lower ~ '-detail', item_id=item.id) -}}" class="ha-action-link" data-testid="row-view-link">View</a>
+                    <a href="{{- url_for(model_name|lower ~ '-update-form', item_id=item.id) -}}" class="ha-action-link" data-testid="row-edit-link">Edit</a>
                     <button hx-delete="{{- url_for(model_name|lower ~ '-delete', item_id=item.id) -}}"
                             hx-confirm="Are you sure you want to delete this item?"
                             hx-target="closest tr"
                             hx-swap="outerHTML"
-                            class="ha-action-delete">
+                            class="ha-action-delete"
+                            data-testid="row-delete-btn">
                         Delete
                     </button>
                 </td>

--- a/src/hyperadmin/templates/detail_layout.html
+++ b/src/hyperadmin/templates/detail_layout.html
@@ -5,7 +5,7 @@
 {%- block content -%}
     <div class="detail-container">
         <h2>{%- block detail_title -%}{%- endblock -%}</h2>
-        <div class="detail-fields">
+        <div class="detail-fields" data-testid="detail-fields">
             {%- block detail_fields -%}{%- endblock -%}
         </div>
     </div>

--- a/src/hyperadmin/templates/form_layout.html
+++ b/src/hyperadmin/templates/form_layout.html
@@ -3,7 +3,7 @@
 {%- block content -%}
     <div class="ha-container">
         <h2 class="ha-section-title">{%- block form_title -%}{%- endblock -%}</h2>
-        <form id="{{- model_name|lower -}}-form" {%- block form_attributes -%}{%- endblock -%}>
+        <form id="{{- model_name|lower -}}-form" data-testid="model-form" {%- block form_attributes -%}{%- endblock -%}>
             <div id="{{- model_name|lower -}}-form-body" class="ha-card">
                 {%- block form_body -%}{%- endblock -%}
             </div>

--- a/src/hyperadmin/templates/list_layout.html
+++ b/src/hyperadmin/templates/list_layout.html
@@ -5,7 +5,7 @@
 {%- block content -%}
     <h1 class="ha-section-title">{{- model_name -}} List</h1>
     <div style="margin-bottom: var(--ha-space-4);">
-        <a href="{{- url_for(model_name|lower ~ '-create-form') -}}" class="ha-btn ha-btn-primary">
+        <a href="{{- url_for(model_name|lower ~ '-create-form') -}}" class="ha-btn ha-btn-primary" data-testid="create-link">
             Create New {{ model_name }}
         </a>
     </div>

--- a/src/hyperadmin/templates/update.html
+++ b/src/hyperadmin/templates/update.html
@@ -5,7 +5,7 @@
 {%- endblock -%}
 
 {%- block form_attributes -%}
-    hx-post="{{- url_for(model_name|lower ~ '-update', item_id=item.id) -}}"
+    hx-put="{{- url_for(model_name|lower ~ '-update', item_id=item.id) -}}"
     hx-target="#{{- model_name|lower -}}-form-body"
     hx-swap="innerHTML"
 {%- endblock -%}

--- a/src/hyperadmin/templates/widgets/checkbox_input.html
+++ b/src/hyperadmin/templates/widgets/checkbox_input.html
@@ -12,7 +12,7 @@
     </label>
     {%- if field.help_text -%}<p class="ha-help-text">{{- field.help_text -}}</p>{%- endif -%}
     {%- if field.errors -%}
-        <ul class="ha-field-errors" aria-live="polite">
+        <ul class="ha-field-errors" aria-live="polite" data-testid="{{ field.name }}-errors">
             {%- for e in field.errors -%}<li>{{- e -}}</li>{%- endfor -%}
         </ul>
     {%- endif -%}

--- a/src/hyperadmin/templates/widgets/float_input.html
+++ b/src/hyperadmin/templates/widgets/float_input.html
@@ -12,7 +12,7 @@
            aria-invalid="{{- 'true' if field.errors else 'false' -}}"
     />
     {%- if field.errors -%}
-        <ul class="ha-field-errors" aria-live="polite">
+        <ul class="ha-field-errors" aria-live="polite" data-testid="{{ field.name }}-errors">
             {%- for e in field.errors -%}<li>{{- e -}}</li>{%- endfor -%}
         </ul>
     {%- endif -%}

--- a/src/hyperadmin/templates/widgets/number_input.html
+++ b/src/hyperadmin/templates/widgets/number_input.html
@@ -11,7 +11,7 @@
            aria-invalid="{{- 'true' if field.errors else 'false' -}}"
     />
     {%- if field.errors -%}
-        <ul class="ha-field-errors" aria-live="polite">
+        <ul class="ha-field-errors" aria-live="polite" data-testid="{{ field.name }}-errors">
             {%- for e in field.errors -%}<li>{{- e -}}</li>{%- endfor -%}
         </ul>
     {%- endif -%}

--- a/src/hyperadmin/templates/widgets/select_input.html
+++ b/src/hyperadmin/templates/widgets/select_input.html
@@ -11,7 +11,7 @@
     </select>
     {%- if field.help_text -%}<p class="ha-help-text">{{- field.help_text -}}</p>{%- endif -%}
     {%- if field.errors -%}
-        <ul class="ha-field-errors" aria-live="polite">
+        <ul class="ha-field-errors" aria-live="polite" data-testid="{{ field.name }}-errors">
             {%- for e in field.errors -%}<li>{{- e -}}</li>{%- endfor -%}
         </ul>
     {%- endif -%}

--- a/src/hyperadmin/templates/widgets/text_input.html
+++ b/src/hyperadmin/templates/widgets/text_input.html
@@ -14,7 +14,7 @@
     />
     {%- if field.help_text -%}<p class="ha-help-text">{{- field.help_text -}}</p>{%- endif -%}
     {%- if field.errors -%}
-        <ul class="ha-field-errors" aria-live="polite">
+        <ul class="ha-field-errors" aria-live="polite" data-testid="{{ field.name }}-errors">
             {%- for e in field.errors -%}<li>{{- e -}}</li>{%- endfor -%}
         </ul>
     {%- endif -%}

--- a/src/hyperadmin/templates/widgets/textarea.html
+++ b/src/hyperadmin/templates/widgets/textarea.html
@@ -2,6 +2,6 @@
   <label for="{{- field.name -}}" class="ha-label">{{- field.label -}}{%- if field.required -%}<span class="ha-required">*</span>{%- endif -%}</label>
   <textarea id="{{- field.name -}}" name="{{- field.name -}}" class="ha-textarea" aria-invalid="{{- 'true' if field.errors else 'false' -}}">{{- field.value or '' -}}</textarea>
   {%- if field.errors -%}
-    <ul class="ha-field-errors" aria-live="polite">{%- for e in field.errors -%}<li>{{- e -}}</li>{%- endfor -%}</ul>
+    <ul class="ha-field-errors" aria-live="polite" data-testid="{{ field.name }}-errors">{%- for e in field.errors -%}<li>{{- e -}}</li>{%- endfor -%}</ul>
   {%- endif -%}
 </div>

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -1,5 +1,5 @@
 import os
-from typing import cast
+from typing import Any, cast
 
 from fastapi import HTTPException, Query, Request
 from fastapi.templating import Jinja2Templates
@@ -10,7 +10,7 @@ from hyperadmin.adapters import SQLAlchemyAdapter, SQLModelAdapter
 from hyperadmin.core.options import AdminOptions
 from hyperadmin.core.registry import site
 from hyperadmin.discover import app_label_var
-from hyperadmin.views.forms import PydanticForm
+from hyperadmin.views.forms import CheckboxInput, PydanticForm
 from hyperadmin.views.htmx import HtmxTemplateResponse
 
 
@@ -249,21 +249,42 @@ class DynamicModelView:
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Internal Server Error: {e}")
 
-    async def update_form_view(self, request: Request, item_id: int):
-        """Renders the update form."""
+    async def update_form_view(
+        self,
+        request: Request,
+        item_id: int,
+        values: dict | None = None,
+        errors: dict | None = None,
+        status_code: int = 200,
+    ):
+        """Renders the update form, optionally pre-filled with submitted values and errors."""
         item = await self.adapter.get(pk=item_id)
         if not item:
             raise HTTPException(status_code=404, detail="Item not found")
 
-        # Prefill form with existing item's values (assumes Pydantic/SQLModel with model_dump)
         initial = getattr(item, "model_dump", None)
         initial_values = initial() if callable(initial) else getattr(item, "__dict__", {})
+
+        # Override with re-submitted values on validation failure
+        if values:
+            initial_values.update(values)
+
         form = PydanticForm(self.model, initial=initial_values)
+
+        if errors:
+            form.bind(values or {})
+            norm_errors = {k: (v if isinstance(v, list) else [v]) for k, v in errors.items()}
+            form.errors = norm_errors
+            for f in form.fields:
+                f.errors = norm_errors.get(f.name)
+
         context = {
             "request": request,
             "model_name": self.model.__name__,
             "item": item,
             "form": form,
+            "values": values or initial_values,
+            "errors": errors or {},
             # Legacy keys for compatibility
             "fields": list(self.model.model_fields.keys()),
         }
@@ -273,13 +294,44 @@ class DynamicModelView:
             context=context,
             request=request,
             block="form_body",
+            status_code=status_code,
         )
 
     async def update_view(self, request: Request, item_id: int):
         """Handles form submission for updating an item."""
         form_data = await request.form()
-        await self.adapter.update(pk=item_id, data=dict(form_data))
-        return RedirectResponse(url=f"/admin/{self.model.__name__.lower()}", status_code=303)
+        data: dict[str, Any] = dict(form_data)
+
+        form = PydanticForm(self.model)
+
+        # Unchecked checkboxes are absent from form data — inject False before validation
+        for field in form.fields:
+            if isinstance(field.widget, CheckboxInput) and field.name not in data:
+                data[field.name] = False
+
+        form.bind(data)
+        instance, errs = form.validate(data)
+
+        if errs:
+            legacy_errs = {k: v[0] for k, v in errs.items() if v}
+            return await self.update_form_view(
+                request, item_id=item_id, values=data, errors=legacy_errs, status_code=422
+            )
+
+        if not instance:
+            return await self.update_form_view(
+                request, item_id=item_id, values=data, errors={}, status_code=422
+            )
+
+        # exclude_none: id is not submitted by the form and must not overwrite the PK
+        await self.adapter.update(pk=item_id, data=instance.model_dump(exclude_none=True))
+
+        redirect_url = request.url_for(f"{self.model.__name__.lower()}-list")
+
+        if "hx-request" in request.headers:
+            return Response(status_code=200, headers={"HX-Redirect": str(redirect_url)})
+
+        return RedirectResponse(url=redirect_url, status_code=303)
 
     async def delete_action(self, request: Request, item_id: int):
         """Deletes an item."""
@@ -287,7 +339,14 @@ class DynamicModelView:
         if not item:
             raise HTTPException(status_code=404, detail="Item not found")
 
-        return RedirectResponse(url=f"/admin/{self.model.__name__.lower()}", status_code=303)
+        await self.adapter.delete(pk=item_id)
+
+        redirect_url = request.url_for(f"{self.model.__name__.lower()}-list")
+
+        if "hx-request" in request.headers:
+            return Response(status_code=200, headers={"HX-Redirect": str(redirect_url)})
+
+        return RedirectResponse(url=redirect_url, status_code=303)
 
 
 async def admin_dashboard(request: Request, templates: Jinja2Templates):

--- a/tests/e2e/create_view/test_user_create_view.py
+++ b/tests/e2e/create_view/test_user_create_view.py
@@ -6,7 +6,6 @@ from playwright.sync_api import Page, expect
 
 @pytest.fixture(scope="function")
 def debug_page(page: Page):
-    # List to store network requests and responses
     network_logs = []
 
     def parse_body(_response):
@@ -15,7 +14,6 @@ def debug_page(page: Page):
         except Exception:
             return _response.content
 
-    # Listen to all requests and responses
     page.on("request", lambda _r: print(f"Request: {_r.method} {_r.url}"))
     page.on(
         "response",
@@ -25,7 +23,6 @@ def debug_page(page: Page):
                 "status": _r.status,
                 "headers": _r.all_headers(),
                 "body": parse_body(_r),
-                # Only capture body for successful responses to avoid large logs
             }
         ),
     )
@@ -34,50 +31,42 @@ def debug_page(page: Page):
 
 
 def test_create_user_form_rendering(page: Page, demo_base_url: str):
-    """Test that the create form for User model is rendered correctly."""
     page.goto(f"{demo_base_url}/admin/user/create")
     expect(page).to_have_title("HyperAdmin")
-    expect(page.locator("h2").filter(has_text="Create User")).to_be_visible()
-    expect(page.locator(f'form[hx-post="{demo_base_url}/admin/user"]')).to_be_visible()
-    expect(page.locator('label[for="name"]')).to_have_text("Name*")
-    expect(page.locator('input[name="name"]')).to_be_visible()
-    expect(page.locator('label[for="email"]')).to_have_text("Email*")
-    expect(page.locator('input[name="email"]')).to_be_visible()
-    expect(page.locator('label[for="is_active"]')).to_have_text("Is active*")
-    expect(page.locator('input[name="is_active"][type="checkbox"]')).to_be_visible()
-    expect(page.locator('label[for="rating"]')).to_have_text("Rating*")
-    expect(page.locator('input[name="rating"][type="number"]')).to_be_visible()
-    expect(page.locator('label[for="user_type"]')).to_have_text("User type*")
-    expect(page.locator('select[name="user_type"]')).to_be_visible()
-    expect(page.locator('button[type="submit"]')).to_have_text("Create")
+    expect(page.get_by_role("heading", name="Create User")).to_be_visible()
+    expect(page.get_by_test_id("model-form")).to_be_visible()
+    expect(page.get_by_label("Name*")).to_be_visible()
+    expect(page.get_by_label("Email*")).to_be_visible()
+    expect(page.get_by_label("Is active*")).to_be_visible()
+    expect(page.get_by_label("Rating*")).to_be_visible()
+    expect(page.get_by_label("User type*")).to_be_visible()
+    expect(page.get_by_role("button", name="Create")).to_be_visible()
 
 
 def test_create_user_validation_error(page: Page, demo_base_url: str):
-    """Test that submitting an invalid form for User model shows an error message."""
     page.goto(f"{demo_base_url}/admin/user/create")
-    page.locator('input[name="name"]').fill("")
-    page.locator('button[type="submit"]').click()
-    validation_error = page.locator('input[name="name"] ~ ul.ha-field-errors')
-    expect(validation_error).to_be_visible()
-    expect(validation_error).to_contain_text("String should have at least 1 character")
+    page.get_by_label("Name*").fill("")
+    page.get_by_role("button", name="Create").click()
+    error_list = page.get_by_test_id("name-errors")
+    expect(error_list).to_be_visible()
+    expect(error_list).to_contain_text("String should have at least 1 character")
 
 
 def test_create_user_successful_submission(debug_page: Page, demo_base_url: str):
-    """Test that successful submission for User model redirects to the detail page."""
     page = debug_page
     page.goto(f"{demo_base_url}/admin/user/create")
-    page.locator('input[name="name"]').fill("Test User")
-    page.locator('input[name="email"]').fill("test@example.com")
-    page.locator('input[name="is_active"]').check()
-    page.locator('input[name="rating"]').fill("4.5")
-    page.locator('select[name="user_type"]').select_option("ADMIN")
-    page.locator('button[type="submit"]').click()
-    # The redirect is handled by HTMX, so we need to wait for the URL to change.
+    page.get_by_label("Name*").fill("Test User")
+    page.get_by_label("Email*").fill("test@example.com")
+    page.get_by_label("Is active*").check()
+    page.get_by_label("Rating*").fill("4.5")
+    page.get_by_label("User type*").select_option("ADMIN")
+    page.get_by_role("button", name="Create").click()
     expect(page).to_have_url(re.compile(r".*/admin/user/\d+"))
     expect(page.get_by_role("heading", name=re.compile(r"User #"))).to_contain_text("User #")
-    expect(page.locator(".detail-fields")).to_contain_text("Test User")
-    expect(page.locator(".detail-fields")).to_contain_text("test@example.com")
-    expect(page.locator(".detail-fields")).to_contain_text("True")
-    expect(page.locator(".detail-fields")).to_contain_text("4.5")
-    expect(page.locator(".detail-fields")).to_contain_text("UserType.ADMIN")
-    expect(page.locator(".detail-fields")).to_contain_text("created_at")
+    detail = page.get_by_test_id("detail-fields")
+    expect(detail).to_contain_text("Test User")
+    expect(detail).to_contain_text("test@example.com")
+    expect(detail).to_contain_text("True")
+    expect(detail).to_contain_text("4.5")
+    expect(detail).to_contain_text("UserType.ADMIN")
+    expect(detail).to_contain_text("created_at")

--- a/tests/e2e/test_list_view.py
+++ b/tests/e2e/test_list_view.py
@@ -6,436 +6,236 @@ from playwright.sync_api import Page, expect
 
 
 def test_admin_interface_loads(page: Page, demo_base_url: str) -> None:
-    """Test that the admin interface loads correctly."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Check that the page loads with correct title
     expect(page).to_have_title("User List | HyperAdmin")
-
-    # Check that we have the admin interface structure
-    expect(page.get_by_text("HyperAdmin")).to_be_visible()
-    expect(page.get_by_text("Users")).to_be_visible()  # From the sidebar
-
-    # Check that main content area is present (even if empty)
-    main_content = page.locator("main")
-    expect(main_content).to_be_attached()
-
-    # Check that navigation works
-    expect(page.locator("nav")).to_be_visible()
-    expect(page.locator("aside")).to_be_visible()  # Sidebar
+    expect(page.get_by_role("link", name="HyperAdmin")).to_be_visible()
+    expect(page.get_by_test_id("sidebar").get_by_role("link", name="Users")).to_be_visible()
+    expect(page.get_by_role("navigation")).to_be_visible()
+    expect(page.get_by_role("complementary")).to_be_visible()
+    expect(page.get_by_role("main")).to_be_attached()
 
 
 def test_admin_navigation_structure(page: Page, demo_base_url: str) -> None:
-    """Test the basic admin navigation structure."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Test sidebar navigation
-    sidebar = page.locator("aside")
+    sidebar = page.get_by_test_id("sidebar")
     expect(sidebar).to_be_visible()
     expect(sidebar.get_by_text("Menu")).to_be_visible()
-    expect(sidebar.get_by_text("Users")).to_be_visible()
+    expect(sidebar.get_by_role("link", name="Users")).to_be_visible()
 
-    # Test top navigation
-    nav = page.locator("nav")
-    expect(nav).to_be_visible()
-    expect(nav.get_by_text("HyperAdmin")).to_be_visible()
+    expect(page.get_by_role("navigation").get_by_role("link", name="HyperAdmin")).to_be_visible()
 
 
 def test_responsive_admin_interface(page: Page, demo_base_url: str) -> None:
-    """Test that the admin interface is responsive."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Test desktop view
-    page.set_viewport_size({"width": 1200, "height": 800})
-    expect(page.locator("aside")).to_be_visible()
-    expect(page.locator("main")).to_be_attached()
+    for width, height in [(1200, 800), (768, 600), (375, 667)]:
+        page.set_viewport_size({"width": width, "height": height})
+        expect(page.get_by_role("main")).to_be_attached()
 
-    # Test tablet view
-    page.set_viewport_size({"width": 768, "height": 600})
-    expect(page.locator("main")).to_be_attached()
-
-    # Test mobile view
-    page.set_viewport_size({"width": 375, "height": 667})
-    expect(page.locator("main")).to_be_attached()
-
-    # Reset viewport
     page.set_viewport_size({"width": 1280, "height": 720})
 
 
 def test_admin_interface_styling(page: Page, demo_base_url: str) -> None:
-    """Test that the admin interface has proper styling."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Check that CSS is loaded
     expect(page.locator("body")).to_have_class("ha-page")
-
-    # Check that main element has proper styling
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
-    expect(main_element).to_have_class("ha-content")
-
-    # Check that navigation has styling
-    nav = page.locator("nav")
-    expect(nav).to_have_class("ha-navbar")
-
-    # Check sidebar styling
-    aside = page.locator("aside")
-    expect(aside).to_have_class("ha-sidebar")
+    expect(page.get_by_role("main")).to_have_class("ha-content")
+    expect(page.get_by_role("navigation")).to_have_class("ha-navbar")
+    expect(page.get_by_role("complementary")).to_have_class("ha-sidebar")
 
 
 def test_admin_interface_accessibility(page: Page, demo_base_url: str) -> None:
-    """Test basic accessibility features of the admin interface."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Check that the page has a proper title
     expect(page).to_have_title("User List | HyperAdmin")
+    expect(page.get_by_role("navigation")).to_be_visible()
+    expect(page.get_by_role("main")).to_be_attached()
+    expect(page.get_by_role("complementary")).to_be_visible()
 
-    # Check that main landmarks are present
-    expect(page.locator("nav")).to_be_visible()
-    expect(page.locator("main")).to_be_attached()
-    expect(page.locator("aside")).to_be_visible()
-
-    # Check that links have proper text
-    sidebar_link = page.locator("aside a").filter(has_text="Users")
-    expect(sidebar_link).to_be_visible()
-    expect(sidebar_link).to_have_attribute("href", "/admin/user")
+    users_link = page.get_by_test_id("sidebar").get_by_role("link", name="Users")
+    expect(users_link).to_be_visible()
+    expect(users_link).to_have_attribute("href", "/admin/user")
 
 
 def test_admin_interface_htmx_integration(page: Page, demo_base_url: str) -> None:
-    """Test that HTMX is properly loaded and integrated."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Check that HTMX script is loaded
-    htmx_script = page.locator("script[src*='htmx']")
-    expect(htmx_script).to_be_attached()
-
-    # Check that HTMX CSS indicators are present
-    htmx_styles = page.locator("style")
-    expect(htmx_styles).to_be_attached()
+    expect(page.locator("script[src*='htmx']")).to_be_attached()
+    expect(page.locator("style")).to_be_attached()
 
 
 def test_pagination_functionality(page: Page, demo_base_url: str) -> None:
-    """Test pagination controls work correctly."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for the page to load and check if content is available
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    table = page.get_by_test_id("list-table")
+    if table.count() == 0:
+        return
 
-    # Check if table exists, if not, skip table-specific tests
-    table = page.locator("table")
-    if table.count() > 0:
-        expect(table).to_be_visible()
+    expect(table).to_be_visible()
+    expect(page.get_by_test_id("pagination-info")).to_be_visible()
 
-        # Check pagination info is displayed
-        pagination_info = page.locator("text=Showing")
-        if pagination_info.count() > 0:
-            expect(pagination_info.first).to_be_visible()
+    next_link = page.get_by_test_id("pagination-next")
+    if next_link.count() > 0:
+        next_link.click()
+        expect(page.get_by_test_id("pagination-page")).to_contain_text("Page 2")
 
-        # Check pagination controls
-        next_button = page.locator("a").filter(has_text="Next")
-        previous_button = page.locator("a").filter(has_text="Previous")
-
-        # If there are multiple pages, test navigation
-        if next_button.count() > 0:
-            # Click next page
-            next_button.click()
-
-            # Wait for HTMX update
-            page.wait_for_timeout(500)
-
-            # Check that we're on page 2
-            expect(page.locator("text=Page 2")).to_be_visible()
-
-            # Test previous button
-            if previous_button.count() > 0:
-                previous_button.click()
-                page.wait_for_timeout(500)
-                expect(page.locator("text=Page 1")).to_be_visible()
+        prev_link = page.get_by_test_id("pagination-prev")
+        if prev_link.count() > 0:
+            prev_link.click()
+            expect(page.get_by_test_id("pagination-page")).to_contain_text("Page 1")
 
 
 def test_search_functionality(page: Page, demo_base_url: str) -> None:
-    """Test search functionality with real-time updates."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for page to load
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    search_input = page.get_by_test_id("search-input")
+    if search_input.count() == 0:
+        return
 
-    # Check if search input exists (even without table content)
-    search_input = page.locator("input[name='search']")
-    if search_input.count() > 0:
-        expect(search_input).to_be_visible()
+    expect(search_input).to_be_visible()
+    search_input.fill("test")
+    page.wait_for_timeout(800)
+    search_input.clear()
+    page.wait_for_timeout(800)
+    search_input.fill("admin")
+    page.wait_for_timeout(800)
 
-        # Test search functionality
-        search_input.fill("test")
-
-        # Wait for HTMX search delay (500ms as per template)
-        page.wait_for_timeout(800)
-
-        # Test clearing search
-        search_input.clear()
-        page.wait_for_timeout(800)
-
-        # Test search with different terms
-        search_input.fill("admin")
-        page.wait_for_timeout(800)
-
-    # Check if table exists and test it conditionally
-    table = page.locator("table")
-    if table.count() > 0:
-        expect(table).to_be_visible()
+    if page.get_by_test_id("list-table").count() > 0:
+        expect(page.get_by_test_id("list-table")).to_be_visible()
 
 
 def test_sorting_functionality(page: Page, demo_base_url: str) -> None:
-    """Test sorting by clicking column headers."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for page to load
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    if page.get_by_test_id("list-table").count() == 0:
+        return
 
-    # Check if table exists before testing sorting
-    table = page.locator("table")
-    if table.count() > 0:
-        expect(table).to_be_visible()
+    expect(page.get_by_test_id("list-table")).to_be_visible()
 
-        # Find sortable column headers
-        name_header = page.locator("th a").filter(has_text="name")
-        email_header = page.locator("th a").filter(has_text="email")
+    name_sort = page.get_by_test_id("sort-name")
+    if name_sort.count() > 0:
+        name_sort.click()
+        page.wait_for_timeout(500)
+        expect(page.get_by_test_id("list-table")).to_be_visible()
+        expect(page.get_by_test_id("sort-name")).to_contain_text("▲")
 
-        # Test sorting by name
-        if name_header.count() > 0:
-            name_header.click()
+        name_sort.click()
+        page.wait_for_timeout(500)
+        expect(page.get_by_test_id("sort-name")).to_contain_text("▼")
 
-            # Wait for HTMX update
-            page.wait_for_timeout(500)
-
-            # Check that table is still visible after sort
-            expect(page.locator("table")).to_be_visible()
-
-            # Check for sort indicator (triangle up)
-            expect(page.locator("th").filter(has_text="name")).to_contain_text("▲")
-
-            # Click again to reverse sort
-            name_header.click()
-            page.wait_for_timeout(500)
-
-            # Check for sort indicator (triangle down)
-            expect(page.locator("th").filter(has_text="name")).to_contain_text("▼")
-
-        # Test sorting by email
-        if email_header.count() > 0:
-            email_header.click()
-            page.wait_for_timeout(500)
-            expect(page.locator("table")).to_be_visible()
-            expect(page.locator("th").filter(has_text="email")).to_contain_text("▲")
+    email_sort = page.get_by_test_id("sort-email")
+    if email_sort.count() > 0:
+        email_sort.click()
+        page.wait_for_timeout(500)
+        expect(page.get_by_test_id("list-table")).to_be_visible()
+        expect(page.get_by_test_id("sort-email")).to_contain_text("▲")
 
 
 def test_combined_search_and_pagination(page: Page, demo_base_url: str) -> None:
-    """Test that search and pagination work together."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for page to load
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    search_input = page.get_by_test_id("search-input")
+    if search_input.count() == 0 or page.get_by_test_id("list-table").count() == 0:
+        return
 
-    # Check if search input and table exist
-    search_input = page.locator("input[name='search']")
-    table = page.locator("table")
+    search_input.fill("user")
+    page.wait_for_timeout(800)
 
-    if search_input.count() > 0 and table.count() > 0:
-        expect(table).to_be_visible()
-
-        # Perform a search
-        search_input.fill("user")
-        page.wait_for_timeout(800)
-
-        # Check that pagination still works after search
-        next_button = page.locator("a").filter(has_text="Next")
-        if next_button.count() > 0:
-            next_button.click()
-            page.wait_for_timeout(500)
-            expect(page.locator("table")).to_be_visible()
-
-            # Verify search term is preserved
-            expect(search_input).to_have_value("user")
+    next_link = page.get_by_test_id("pagination-next")
+    if next_link.count() > 0:
+        next_link.click()
+        page.wait_for_timeout(500)
+        expect(page.get_by_test_id("list-table")).to_be_visible()
+        expect(search_input).to_have_value("user")
 
 
 def test_combined_search_and_sorting(page: Page, demo_base_url: str) -> None:
-    """Test that search and sorting work together."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for page to load
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    search_input = page.get_by_test_id("search-input")
+    if search_input.count() == 0 or page.get_by_test_id("list-table").count() == 0:
+        return
 
-    # Check if search input and table exist
-    search_input = page.locator("input[name='search']")
-    table = page.locator("table")
+    search_input.fill("test")
+    page.wait_for_timeout(800)
 
-    if search_input.count() > 0 and table.count() > 0:
-        expect(table).to_be_visible()
-
-        # Perform a search first
-        search_input.fill("test")
-        page.wait_for_timeout(800)
-
-        # Then try sorting
-        name_header = page.locator("th a").filter(has_text="name")
-        if name_header.count() > 0:
-            name_header.click()
-            page.wait_for_timeout(500)
-
-            # Verify both search and sort work together
-            expect(page.locator("table")).to_be_visible()
-            expect(search_input).to_have_value("test")
-            expect(page.locator("th").filter(has_text="name")).to_contain_text("▲")
+    name_sort = page.get_by_test_id("sort-name")
+    if name_sort.count() > 0:
+        name_sort.click()
+        page.wait_for_timeout(500)
+        expect(page.get_by_test_id("list-table")).to_be_visible()
+        expect(search_input).to_have_value("test")
+        expect(page.get_by_test_id("sort-name")).to_contain_text("▲")
 
 
 def test_action_buttons_present(page: Page, demo_base_url: str) -> None:
-    """Test that action buttons (View, Edit, Delete) are present."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for page to load
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    if page.get_by_test_id("list-table").count() == 0:
+        return
 
-    # Check if table exists before testing action buttons
-    table = page.locator("table")
-    if table.count() > 0:
-        expect(table).to_be_visible()
+    rows = page.get_by_test_id("list-row")
+    if rows.count() == 0:
+        return
 
-        # Check for action buttons in the table
-        # These might not be visible if there's no data, so we check conditionally
-        rows = page.locator("tbody tr")
-        if rows.count() > 0:
-            # Check that action links/buttons exist
-            view_links = rows.first.locator("a").filter(has_text="View")
-            edit_links = rows.first.locator("a").filter(has_text="Edit")
-            delete_buttons = rows.first.locator("button").filter(has_text="Delete")
-
-            # At least one of each should exist if there's data
-            expect(view_links.or_(edit_links).or_(delete_buttons)).to_have_count(3)
+    first_row = rows.first
+    expect(first_row.get_by_test_id("row-view-link")).to_be_visible()
+    expect(first_row.get_by_test_id("row-edit-link")).to_be_visible()
+    expect(first_row.get_by_test_id("row-delete-btn")).to_be_visible()
 
 
 def test_create_new_button(page: Page, demo_base_url: str) -> None:
-    """Test that the 'Create New' button is present and functional."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for page to load
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    create_link = page.get_by_test_id("create-link")
+    if create_link.count() == 0:
+        return
 
-    # Check for Create New button - it might not be visible if content isn't rendered
-    create_button = page.locator("a").filter(has_text="Create New User")
-    if create_button.count() > 0:
-        expect(create_button).to_be_visible()
-
-        # Click the button to test navigation
-        create_button.click()
-
-        # Should navigate to create form (we don't test form details here)
-        expect(page).to_have_url(re.compile(".*/user.*create"))
+    expect(create_link).to_be_visible()
+    create_link.click()
+    expect(page).to_have_url(re.compile(r".*/user.*create"))
 
 
 def test_responsive_design_elements(page: Page, demo_base_url: str) -> None:
-    """Test responsive design elements of the list view."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for page to load
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    for width, height in [(1200, 800), (768, 600), (375, 667)]:
+        page.set_viewport_size({"width": width, "height": height})
+        if page.get_by_test_id("list-table").count() > 0:
+            expect(page.get_by_test_id("list-table")).to_be_visible()
 
-    # Check if table exists before testing responsive behavior
-    table = page.locator("table")
-
-    # Test desktop view first
-    page.set_viewport_size({"width": 1200, "height": 800})
-    if table.count() > 0:
-        expect(table).to_be_visible()
-
-    # Test tablet view
-    page.set_viewport_size({"width": 768, "height": 600})
-    if table.count() > 0:
-        expect(table).to_be_visible()
-
-    # Test mobile view
-    page.set_viewport_size({"width": 375, "height": 667})
-    if table.count() > 0:
-        expect(table).to_be_visible()
-
-    # Reset to default
     page.set_viewport_size({"width": 1280, "height": 720})
 
 
 def test_htmx_requests_work(page: Page, demo_base_url: str) -> None:
-    """Test that HTMX requests are working correctly."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for initial load
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    search_input = page.get_by_test_id("search-input")
+    if search_input.count() == 0:
+        return
 
-    # Check if search input exists for HTMX testing
-    search_input = page.locator("input[name='search']")
-    table = page.locator("table")
+    search_input.fill("htmx")
+    page.wait_for_timeout(800)
+    expect(search_input).to_have_value("htmx")
 
-    if search_input.count() > 0:
-        # Monitor network requests
-        requests = []
-        page.on("request", lambda request: requests.append(request))
-
-        # Perform a search that should trigger HTMX
-        search_input.fill("htmx")
-
-        # Wait for potential HTMX request
-        page.wait_for_timeout(800)
-
-        # The search input should still have focus/value
-        expect(search_input).to_have_value("htmx")
-
-        # Check table if it exists
-        if table.count() > 0:
-            expect(table).to_be_visible()
+    if page.get_by_test_id("list-table").count() > 0:
+        expect(page.get_by_test_id("list-table")).to_be_visible()
 
 
 def test_error_handling_graceful(page: Page, demo_base_url: str) -> None:
-    """Test that the page handles errors gracefully."""
     page.goto(demo_base_url + "/admin/user")
 
-    # Wait for page to load
-    main_element = page.locator("main")
-    expect(main_element).to_be_attached()
+    search_input = page.get_by_test_id("search-input")
+    if search_input.count() == 0:
+        return
 
-    # Check if search input exists for error testing
-    search_input = page.locator("input[name='search']")
-    table = page.locator("table")
-
-    if search_input.count() > 0:
-        # Test with potentially problematic search terms
-
-        # Test special characters
-        search_input.fill("'; DROP TABLE users; --")
+    for term in ["'; DROP TABLE users; --", "a" * 1000]:
+        search_input.fill(term)
         page.wait_for_timeout(800)
+        expect(page.get_by_role("main")).to_be_attached()
 
-        # Page should still be functional
-        expect(main_element).to_be_attached()
-        if table.count() > 0:
-            expect(table).to_be_visible()
-
-        # Test very long search term
-        search_input.fill("a" * 1000)
-        page.wait_for_timeout(800)
-
-        # Page should still be functional
-        expect(main_element).to_be_attached()
-        if table.count() > 0:
-            expect(table).to_be_visible()
-
-        # Clear and continue
-        search_input.clear()
-        page.wait_for_timeout(500)
-        expect(main_element).to_be_attached()
-        if table.count() > 0:
-            expect(table).to_be_visible()
+    search_input.clear()
+    page.wait_for_timeout(500)
+    expect(page.get_by_role("main")).to_be_attached()

--- a/tests/e2e/test_update_delete_view.py
+++ b/tests/e2e/test_update_delete_view.py
@@ -1,0 +1,70 @@
+"""End-to-end tests for update and delete view functionality."""
+
+import re
+
+from playwright.sync_api import Page, expect
+
+
+def test_edit_link_navigates_to_update_form(page: Page, demo_base_url: str) -> None:
+    """Edit link in the list table opens the update form pre-filled with existing values."""
+    page.goto(demo_base_url + "/admin/user")
+
+    page.get_by_test_id("list-row").first.get_by_test_id("row-edit-link").click()
+
+    expect(page).to_have_url(re.compile(r"/edit$"))
+    expect(page.get_by_test_id("model-form")).to_be_visible()
+    expect(page.get_by_label("Name*")).not_to_be_empty()
+
+
+def test_update_form_submits_successfully(page: Page, demo_base_url: str) -> None:
+    """Submitting the update form with valid data saves and returns to the list."""
+    page.goto(demo_base_url + "/admin/user")
+
+    page.get_by_test_id("list-row").first.get_by_test_id("row-edit-link").click()
+    expect(page.get_by_test_id("model-form")).to_be_visible()
+
+    page.get_by_label("Name*").fill("Alice Updated")
+    page.get_by_role("button", name="Update").click()
+
+    expect(page).to_have_url(re.compile(r"/admin/user$"))
+    expect(page.get_by_test_id("list-table")).to_contain_text("Alice Updated")
+
+
+def test_update_form_shows_validation_errors(page: Page, demo_base_url: str) -> None:
+    """Submitting the update form with an empty required field shows inline errors."""
+    page.goto(demo_base_url + "/admin/user")
+
+    page.get_by_test_id("list-row").first.get_by_test_id("row-edit-link").click()
+    expect(page.get_by_test_id("model-form")).to_be_visible()
+
+    page.get_by_label("Name*").fill("")
+    page.get_by_role("button", name="Update").click()
+
+    expect(page.get_by_test_id("name-errors")).to_be_visible()
+    expect(page.get_by_test_id("model-form")).to_be_visible()
+
+
+def test_delete_removes_item_from_list(page: Page, demo_base_url: str) -> None:
+    """Clicking Delete on a row removes it from the list."""
+    page.goto(demo_base_url + "/admin/user")
+
+    rows = page.get_by_test_id("list-row")
+    initial_count = rows.count()
+
+    page.on("dialog", lambda d: d.accept())
+    rows.last.get_by_test_id("row-delete-btn").click()
+
+    expect(rows).to_have_count(initial_count - 1)
+
+
+def test_delete_confirm_cancel_keeps_item(page: Page, demo_base_url: str) -> None:
+    """Dismissing the delete confirmation leaves the list unchanged."""
+    page.goto(demo_base_url + "/admin/user")
+
+    rows = page.get_by_test_id("list-row")
+    initial_count = rows.count()
+
+    page.on("dialog", lambda d: d.dismiss())
+    rows.last.get_by_test_id("row-delete-btn").click()
+
+    expect(rows).to_have_count(initial_count)

--- a/tests/unit/test_delete_action.py
+++ b/tests/unit/test_delete_action.py
@@ -1,0 +1,75 @@
+"""Tests for the delete action."""
+
+import anyio
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.registry import site
+from hyperadmin.main import Admin
+
+
+class ProductTestDelete(SQLModel, table=True):
+    __tablename__ = "test_product_delete"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+
+
+class ProductTestDeleteAdmin(ModelAdmin):
+    adapter_class = SQLModelAdapter
+
+
+@pytest.fixture(autouse=True)
+def cleanup_registry():
+    site._registry = {}
+    yield
+    site._registry = {}
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async def setup_database():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+        from sqlalchemy.orm import sessionmaker
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            product = ProductTestDelete(name="To be deleted")
+            session.add(product)
+            await session.commit()
+
+    anyio.run(setup_database)
+
+    admin = Admin(app=app, create_tables=False, engine=engine)
+    site.register(ProductTestDelete, ProductTestDeleteAdmin)
+    admin.mount(path="/admin")
+
+    return TestClient(app)
+
+
+def test_delete_action_successful(client: TestClient):
+    get_response = client.get("/admin/producttestdelete/1")
+    assert get_response.status_code == 200
+
+    response = client.delete("/admin/producttestdelete/1", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"].endswith("/admin/producttestdelete")
+
+    get_response = client.get("/admin/producttestdelete/1")
+    assert get_response.status_code == 404
+
+
+def test_delete_action_not_found(client: TestClient):
+    response = client.delete("/admin/producttestdelete/999", follow_redirects=False)
+    assert response.status_code == 404

--- a/tests/unit/test_detail_view.py
+++ b/tests/unit/test_detail_view.py
@@ -1,0 +1,77 @@
+"""Tests for the detail view."""
+
+import anyio
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.registry import site
+from hyperadmin.main import Admin
+
+
+class ProductTestDetail(SQLModel, table=True):
+    __tablename__ = "test_product_detail"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    description: str
+    price: float
+
+
+class ProductTestDetailAdmin(ModelAdmin):
+    adapter_class = SQLModelAdapter
+
+
+@pytest.fixture(autouse=True)
+def cleanup_registry():
+    site._registry = {}
+    yield
+    site._registry = {}
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async def setup_database():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+        from sqlalchemy.orm import sessionmaker
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            product = ProductTestDetail(
+                name="Detail Product", description="Detail description", price=30.0
+            )
+            session.add(product)
+            await session.commit()
+
+    anyio.run(setup_database)
+
+    admin = Admin(app=app, create_tables=False, engine=engine)
+    site.register(ProductTestDetail, ProductTestDetailAdmin)
+    admin.mount(path="/admin")
+
+    return TestClient(app)
+
+
+def test_detail_view_renders_correctly(client: TestClient):
+    response = client.get("/admin/producttestdetail/1")
+    assert response.status_code == 200
+    assert "Detail Product" in response.text
+    assert "Detail description" in response.text
+    assert "30.0" in response.text
+    assert "name" in response.text
+    assert "description" in response.text
+    assert "price" in response.text
+
+
+def test_detail_view_not_found(client: TestClient):
+    response = client.get("/admin/producttestdetail/999")
+    assert response.status_code == 404

--- a/tests/unit/test_dynamic_view_htmx.py
+++ b/tests/unit/test_dynamic_view_htmx.py
@@ -223,7 +223,7 @@ async def test_update_view(request_factory, view):
     req = request_factory(method="POST")
     resp = await view.update_view(req, item_id=1)
     assert resp.status_code == 303
-    assert resp.headers["location"] == "/admin/user"
+    assert resp.headers["location"] == "/user-list"
 
 
 @pytest.mark.anyio
@@ -231,7 +231,7 @@ async def test_delete_action(request_factory, view):
     req = request_factory(method="POST")
     resp = await view.delete_action(req, item_id=1)
     assert resp.status_code == 303
-    assert resp.headers["location"] == "/admin/user"
+    assert resp.headers["location"] == "/user-list"
 
 
 @pytest.mark.anyio

--- a/tests/unit/test_sqlalchemy.py
+++ b/tests/unit/test_sqlalchemy.py
@@ -40,7 +40,8 @@ async def engine():
 
 
 # Tests
-def test_adapter_init_invalid_model():
+@pytest.mark.anyio
+async def test_adapter_init_invalid_model():
     with patch("hyperadmin.adapters.sqlalchemy.inspect", return_value=None):
         with pytest.raises(ValueError, match="Could not inspect model"):
             SQLAlchemyAdapter(model=MagicMock(), engine=MagicMock())

--- a/tests/unit/test_update_view.py
+++ b/tests/unit/test_update_view.py
@@ -1,0 +1,150 @@
+"""Tests for the update view."""
+
+import anyio
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.registry import site
+from hyperadmin.main import Admin
+
+
+class ProductTestUpdate(SQLModel, table=True):
+    __tablename__ = "test_product_update"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    description: str
+    price: float
+    is_active: bool = Field(default=True)
+
+
+class ProductTestUpdateAdmin(ModelAdmin):
+    adapter_class = SQLModelAdapter
+
+
+@pytest.fixture(autouse=True)
+def cleanup_registry():
+    site._registry = {}
+    yield
+    site._registry = {}
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async def setup_database():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+        from sqlalchemy.orm import sessionmaker
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            product = ProductTestUpdate(
+                name="Old Product", description="Old description", price=10.0, is_active=True
+            )
+            session.add(product)
+            await session.commit()
+
+    anyio.run(setup_database)
+
+    admin = Admin(app=app, create_tables=False, engine=engine)
+    site.register(ProductTestUpdate, ProductTestUpdateAdmin)
+    admin.mount(path="/admin")
+
+    return TestClient(app)
+
+
+def test_update_form_view_renders_form(client: TestClient):
+    response = client.get("/admin/producttestupdate/1/edit")
+    assert response.status_code == 200
+    assert "<form" in response.text
+    assert "/admin/producttestupdate/1" in response.text
+    assert 'value="Old Product"' in response.text
+    assert "Old description" in response.text
+    assert 'value="10.0"' in response.text
+    assert "checked" in response.text
+
+
+def test_update_view_successful_submission(client: TestClient):
+    form_data = {
+        "name": "Updated Product",
+        "description": "Updated description",
+        "price": "20.0",
+        "is_active": "on",
+    }
+    response = client.put(
+        "/admin/producttestupdate/1",
+        data=form_data,
+        headers={"HX-Request": "true"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 200
+    assert "HX-Redirect" in response.headers
+    assert response.headers["HX-Redirect"] == "http://testserver/admin/producttestupdate"
+
+    get_response = client.get("/admin/producttestupdate/1")
+    assert get_response.status_code == 200
+    assert "Updated Product" in get_response.text
+
+
+def test_update_view_validation_error(client: TestClient):
+    form_data = {
+        "name": "Updated",
+        "description": "Updated description",
+        "price": "not-a-number",
+    }
+    response = client.put(
+        "/admin/producttestupdate/1",
+        data=form_data,
+        headers={"HX-Request": "true"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 422
+    assert "Input should be a valid number" in response.text
+    assert "Updated description" in response.text
+
+
+def test_update_view_uncheck_boolean(client: TestClient):
+    form_data = {
+        "name": "Unchecked Product",
+        "description": "Desc",
+        "price": "10.0",
+        # is_active omitted — should become False
+    }
+    client.put(
+        "/admin/producttestupdate/1",
+        data=form_data,
+        headers={"HX-Request": "true"},
+        follow_redirects=False,
+    )
+
+    get_response = client.get("/admin/producttestupdate/1")
+    assert '"is_active": false' in get_response.text.lower() or "False" in get_response.text
+
+
+def test_update_view_partial_update_preserves_missing_text_field(client: TestClient):
+    form_data = {
+        "name": "Partial Update",
+        "price": "50.0",
+        "is_active": "on",
+        # description omitted
+    }
+    client.put(
+        "/admin/producttestupdate/1",
+        data=form_data,
+        headers={"HX-Request": "true"},
+        follow_redirects=False,
+    )
+
+    get_response = client.get("/admin/producttestupdate/1")
+    assert "Old description" in get_response.text


### PR DESCRIPTION
- update_view: add PydanticForm validation, checkbox False injection before
  validation, exclude_none on adapter call to avoid overwriting PK
- delete_action: actually call adapter.delete (was a no-op before)
- table.html: fix Edit link to -update-form route; fix Delete to hx-delete
- update.html: fix form verb to hx-put
- test_dynamic_view_htmx: fix redirect assertions to url_for-based paths
- test_sqlalchemy: mark async test with @pytest.mark.anyio
- add test_update_view, test_delete_action, test_detail_view
