### PR TITLE
docs: Milestone 1 docs, examples, and Docker setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,16 @@
             "command": "FILE=$(jq -r '.tool_input.file_path // empty'); [[ \"$FILE\" == *.py ]] && uv run ruff format \"$FILE\" 2>/dev/null || true"
           }
         ]
+      },
+      {
+        "matcher": "TaskUpdate",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "STATUS=$(jq -r '.tool_input.status // empty'); [[ \"$STATUS\" == \"completed\" ]] && bash /Users/yevheniidehtiar/.projects/hyper-admin/scripts/redeploy-example.sh 2>/dev/null || true",
+            "statusMessage": "Redeploying example app..."
+          }
+        ]
       }
     ]
   }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "STATUS=$(jq -r '.tool_input.status // empty'); [[ \"$STATUS\" == \"completed\" ]] && bash /Users/yevheniidehtiar/.projects/hyper-admin/scripts/redeploy-example.sh 2>/dev/null || true",
+            "command": "STATUS=$(jq -r '.tool_input.status // empty'); [[ \"$STATUS\" == \"completed\" ]] && bash scripts/redeploy-example.sh 2>/dev/null || true",
             "statusMessage": "Redeploying example app..."
           }
         ]

--- a/docs/api/adapters.md
+++ b/docs/api/adapters.md
@@ -1,9 +1,56 @@
 # Adapters
 
-Adapters in HyperAdmin are responsible for providing a bridge between your data sources and the admin interface. They translate your data models into a format that HyperAdmin can understand and use to generate CRUD views.
+Adapters translate between a data source (SQLModel, SQLAlchemy, or custom) and HyperAdmin's view layer.
 
-## SQLModel Adapter
+## Built-in Adapters
 
-The `SQLModel` adapter provides support for `SQLModel` data models.
+| Adapter | Module | Works with |
+|---------|--------|------------|
+| `SQLModelAdapter` | `hyperadmin.adapters.sqlmodel` | SQLModel async models |
+| `SQLAlchemyAdapter` | `hyperadmin.adapters.sqlalchemy` | SQLAlchemy async models |
+
+HyperAdmin auto-selects the right adapter at registration time via the adapter registry.
+
+## Writing a custom adapter
+
+Subclass `BaseAdapter` and implement all abstract methods:
+
+```python
+from hyperadmin.core.adapters import BaseAdapter
+
+class MyAdapter(BaseAdapter):
+    async def get(self, pk):
+        ...
+
+    async def list(self, page=1, page_size=10, search=None, filters=None, order_by=None):
+        # Return (items, total_count)
+        ...
+
+    async def create(self, data):
+        ...
+
+    async def update(self, pk, data):
+        ...
+
+    async def delete(self, pk):
+        ...
+
+    async def get_related(self, pk, field):
+        ...
+
+    async def get_schema(self):
+        ...
+```
+
+Register it with the adapter registry so HyperAdmin can discover it automatically:
+
+```python
+from hyperadmin.adapters.registry import adapter_registry
+adapter_registry.register(MyModel, MyAdapter)
+```
+
+## API Reference
+
+::: hyperadmin.core.adapters.BaseAdapter
 
 ::: hyperadmin.adapters.sqlmodel.SQLModelAdapter

--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -4,9 +4,11 @@
 
 ```python
 from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import create_async_engine
 from hyperadmin import Admin
 
 app = FastAPI()
+engine = create_async_engine("sqlite+aiosqlite:///app.db")
 
 # Minimal setup — register models manually then mount
 admin = Admin(app, engine=engine)

--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -1,5 +1,36 @@
 # Application
 
-The `Admin` class is the main entry point for creating an admin interface. It is responsible for managing admin views, handling requests, and rendering templates.
+## Usage
 
-::: hyperadmin.main.Admin
+```python
+from fastapi import FastAPI
+from hyperadmin import Admin
+
+app = FastAPI()
+
+# Minimal setup — register models manually then mount
+admin = Admin(app, engine=engine)
+admin.mount("/admin")
+
+# Auto-discover admin.py files in your app packages
+admin = Admin(app, engine=engine, discover_apps=["myapp", "otherapp"])
+admin.mount("/admin")
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `app` | `FastAPI` | required | The FastAPI application instance |
+| `engine` | `AsyncEngine` | built-in SQLite | Async SQLAlchemy engine |
+| `discover_apps` | `list[str] \| None` | `None` | Module paths to auto-discover `admin.py` in |
+| `create_tables` | `bool` | `True` | Auto-create DB tables on startup |
+| `template_dirs` | `list[str] \| None` | `None` | Extra Jinja2 template search paths |
+
+## API Reference
+
+::: hyperadmin.core.app.Admin
+
+---
+
+Next: [Views](views.md)

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,15 +1,37 @@
 # Core Components
 
-The core components of HyperAdmin provide the foundational building blocks for creating admin interfaces. These components are responsible for handling the main logic of the admin panel.
+## How Admin and SiteRegistry relate
+
+`Admin` creates no registry of its own — it reads from the module-level `site` singleton in `hyperadmin.core.registry`. When you call `site.register(MyModel)` anywhere in your codebase, that model is automatically available when `admin.mount()` is called later.
+
+```python
+# In myapp/admin.py
+from hyperadmin.core.registry import site
+site.register(Product)
+
+# In main.py
+from hyperadmin import Admin
+admin = Admin(app, engine=engine, discover_apps=["myapp"])
+admin.mount("/admin")  # picks up Product automatically
+```
+
+Alternatively, use `ModelView` subclassing — it calls `site.register()` for you via `__init_subclass__`:
+
+```python
+from hyperadmin.views.dynamic import ModelView
+
+class ProductAdmin(ModelView, model=Product):
+    pass  # registered automatically at import time
+```
 
 ## Admin
-
-The `Admin` class is the main entry point for creating an admin interface. It is responsible for managing admin views, handling requests, and rendering templates.
 
 ::: hyperadmin.core.app.Admin
 
 ## SiteRegistry
 
-The `SiteRegistry` class is a container for registered admin models. It maintains the mapping between models and their admin options.
-
 ::: hyperadmin.core.registry.SiteRegistry
+
+## AdminOptions
+
+::: hyperadmin.core.options.AdminOptions

--- a/docs/api/routing.md
+++ b/docs/api/routing.md
@@ -1,9 +1,21 @@
 # Routing
 
-The routing system in HyperAdmin is responsible for mapping URLs to your admin views. It is built on top of FastAPI's routing layer, providing a flexible and powerful way to define your admin URLs.
+## URL structure
+
+For each registered model (e.g. `Product`), the following routes are generated under your mount prefix (e.g. `/admin`):
+
+| Method | Pattern | View | Controlled by |
+|--------|---------|------|---------------|
+| `GET` | `/admin/product/` | List view | `can_list` |
+| `GET` | `/admin/product/create` | Create form | `can_create` |
+| `POST` | `/admin/product/` | Handle create | `can_create` |
+| `GET` | `/admin/product/{id}` | Detail view | `can_detail` |
+| `GET` | `/admin/product/{id}/edit` | Edit form | `can_edit` |
+| `PUT` | `/admin/product/{id}` | Handle update | `can_edit` |
+| `DELETE` | `/admin/product/{id}` | Delete action | `can_delete` |
+
+Routes are only registered for operations enabled by `AdminOptions`.
 
 ## HyperAdminRouter
-
-The `HyperAdminRouter` is the core of the routing system. It generates FastAPI routes for all registered models and mounts them on the admin application.
 
 ::: hyperadmin.routing.HyperAdminRouter

--- a/docs/api/views.md
+++ b/docs/api/views.md
@@ -1,6 +1,34 @@
 # Views
 
-Views are the core components of HyperAdmin that are responsible for rendering the admin interface for your models. They define how data is displayed and how users can interact with it.
+## ModelView class attributes
+
+When subclassing `ModelView`, these class-level attributes control the generated admin UI:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `column_list` | `list` | Fields shown as columns in the list view |
+| `column_details_list` | `list` | Fields shown on the detail page |
+| `column_searchable_list` | `list` | Fields searched when using the search box |
+| `column_sortable_list` | `list` | Fields that render a sort link in the list header |
+| `column_filters` | `list` | Fields available as filter dropdowns |
+| `form_columns` | `list` | Fields included in create/edit forms |
+| `icon` | `str` | Sidebar icon name (from the icon set) |
+| `name_plural` | `str` | Human-readable plural name shown in the sidebar |
+
+Example:
+
+```python
+from hyperadmin.views.dynamic import ModelView
+from myapp.models import User
+
+class UserAdmin(ModelView, model=User):
+    column_list = [User.username, User.email, User.is_active]
+    column_searchable_list = [User.username, User.email]
+    column_sortable_list = [User.username, User.created_at]
+    form_columns = [User.username, User.email, User.first_name, User.last_name]
+    icon = "person"
+    name_plural = "Users"
+```
 
 ## DynamicModelView
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -20,7 +20,7 @@ class User(SQLModel, table=True):
     name: str
     email: str
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI()
 admin = Admin(app, engine=engine, discover_apps=["examples"])
 admin.mount("/admin")
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,77 @@
+# Examples
+
+Two runnable example apps ship with HyperAdmin.
+
+## simple_app — Basic CRUD
+
+Shows a single-model admin with auto-discovery and async SQLite.
+
+```python
+# examples/simple_app.py
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel, Field
+from hyperadmin.main import Admin
+
+engine = create_async_engine("sqlite+aiosqlite:///simple_app.db")
+
+class User(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    email: str
+
+app = FastAPI(lifespan=lifespan)
+admin = Admin(app, engine=engine, discover_apps=["examples"])
+admin.mount("/admin")
+```
+
+**Run locally:**
+
+```bash
+uv run uvicorn examples.simple_app:app --reload
+```
+
+Open [http://localhost:8000/admin/](http://localhost:8000/admin/)
+
+---
+
+## rbac_app — Full RBAC Demo
+
+Shows 5 related models (User, Group, UserGroup, Permission, UserPermissions) with search, sort, filters, and file/image uploads. Sample data is seeded automatically.
+
+**Run with Docker** (recommended — zero setup):
+
+```bash
+docker compose -f examples/docker-compose.yml up --build
+```
+
+Open [http://localhost:8000/admin/](http://localhost:8000/admin/)
+
+**Run locally:**
+
+```bash
+uv sync --all-extras
+uv run uvicorn examples.rbac_app.main:app --reload
+```
+
+### Seeded data
+
+| Entity | Values |
+|--------|--------|
+| Users | `admin`, `editor`, `viewer` |
+| Groups | Administrators, Editors, Viewers |
+| Permissions | 8 permissions (add/change/delete/view for user and group) |
+
+### Models overview
+
+| Model | Description |
+|-------|-------------|
+| `User` | Profile with avatar (image) and personal key (file) fields |
+| `Group` | Named group for organizing users |
+| `UserGroup` | Many-to-many join: User ↔ Group |
+| `Permission` | Codename-based permission definition |
+| `UserPermissions` | Many-to-many join: User ↔ Permission |
+
+---
+
+Next: [Frontend](frontend/overview.md)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -29,7 +29,8 @@ The minimal setup needs three things: an engine, model registration, and a mount
 
 ```python
 from fastapi import FastAPI
-from sqlmodel import SQLModel, Field, create_engine
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel, Field
 from hyperadmin import Admin
 from hyperadmin.core.registry import site
 
@@ -40,6 +41,7 @@ class Product(SQLModel, table=True):
     price: float
 
 # 2. Create app and admin
+engine = create_async_engine("sqlite+aiosqlite:///app.db")
 app = FastAPI()
 admin = Admin(app, engine=engine)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,36 +1,131 @@
 # Getting Started
 
-This page will guide you through setting up HyperAdmin.
+## Prerequisites
 
-## Template Overriding
+- Python 3.10+
+- A FastAPI application
+- SQLModel or SQLAlchemy for your data models
 
-HyperAdmin allows you to override the default templates for the admin interface. This is useful when you want to customize the look and feel of your admin panel.
+## Installation
 
-### Providing Custom Template Directories
+=== "pip"
+    ```bash
+    pip install hyperadmin
+    ```
 
-You can provide a list of custom template directories to the `Admin` instance using the `template_dirs` argument:
+=== "uv"
+    ```bash
+    uv add hyperadmin
+    ```
+
+=== "poetry"
+    ```bash
+    poetry add hyperadmin
+    ```
+
+## Quickstart
+
+The minimal setup needs three things: an engine, model registration, and a mount path.
 
 ```python
 from fastapi import FastAPI
+from sqlmodel import SQLModel, Field, create_engine
 from hyperadmin import Admin
+from hyperadmin.core.registry import site
 
+# 1. Define a model
+class Product(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    price: float
+
+# 2. Create app and admin
 app = FastAPI()
-admin = Admin(app, template_dirs=["my_templates/"])
+admin = Admin(app, engine=engine)
+
+# 3. Register the model
+site.register(Product)
+
+# 4. Mount the admin interface
+admin.mount("/admin")
 ```
 
-### Template Naming Convention
+Navigate to `http://localhost:8000/admin/` to see your admin panel.
 
-HyperAdmin uses a specific naming convention to resolve templates. The templates are searched in the following order:
+## Registering models
 
-1.  `{app_label}/{model_name}/{view_name}.html`
-2.  `{app_label}/{model_name}/default.html`
-3.  `{app_label}/{view_name}.html`
-4.  `{app_label}/default.html`
-5.  `{view_name}.html`
-6.  `default.html`
+### Option A — direct registration
 
--   `app_label`: The name of the application module where the model is defined.
--   `model_name`: The lowercase name of the model class.
--   `view_name`: The name of the view, e.g., `list`, `detail`, `create`, `update`.
+```python
+from hyperadmin.core.registry import site
+from hyperadmin.core.options import AdminOptions
 
-For example, to override the list view for a `User` model in a `users` app, you would create a file named `my_templates/users/user/list.html`.
+site.register(Product)
+
+# With options (disable delete)
+site.register(Order, options=AdminOptions(can_delete=False))
+```
+
+### Option B — ModelView subclassing
+
+```python
+from hyperadmin.views.dynamic import ModelView
+
+class ProductAdmin(ModelView, model=Product):
+    column_searchable_list = [Product.name]
+    icon = "inventory"
+    name_plural = "Products"
+```
+
+`ModelView` subclasses call `site.register()` automatically at import time.
+
+### Option C — auto-discovery
+
+Place a `admin.py` file in your app package and pass the package name to `Admin`:
+
+```python
+# myapp/admin.py
+from hyperadmin.core.registry import site
+from myapp.models import Product
+site.register(Product)
+
+# main.py
+admin = Admin(app, engine=engine, discover_apps=["myapp"])
+```
+
+## Customisation
+
+### Restrict operations
+
+```python
+from hyperadmin.core.options import AdminOptions
+
+site.register(Invoice, options=AdminOptions(
+    can_create=False,
+    can_delete=False,
+))
+```
+
+### Override templates
+
+Provide custom template directories searched before the built-in ones:
+
+```python
+admin = Admin(app, engine=engine, template_dirs=["my_templates/"])
+```
+
+HyperAdmin resolves templates in this order:
+
+1. `{app_label}/{model_name}/{view_name}.html`
+2. `{app_label}/{model_name}/default.html`
+3. `{app_label}/{view_name}.html`
+4. `{app_label}/default.html`
+5. `{view_name}.html`
+6. `default.html`
+
+For example, to override the list view for a `User` model in a `users` app, create:
+`my_templates/users/user/list.html`
+
+---
+
+Next: [Tutorial](tutorial.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,49 +8,48 @@
 
 ---
 
-**HyperAdmin** is a framework for building administrative interfaces on top of FastAPI applications. It leverages the power of **Pydantic** for data validation and **HTMX** for creating dynamic, modern user interfaces with minimal JavaScript. It is designed to be highly extensible and easy to use, allowing developers to quickly create rich, data-driven admin panels.
+```bash
+pip install hyperadmin
+```
 
-## ✨ Key Features
+**HyperAdmin** is a framework for building administrative interfaces on top of FastAPI. It uses **Pydantic** for data validation and **HTMX** for dynamic UIs with minimal JavaScript.
 
-- **Pydantic-Native:** Define your admin interfaces directly from your Pydantic models.
-- **FastAPI Integration:** Mounts seamlessly into any FastAPI application.
-- **HTMX-Powered:** Delivers a rich, interactive user experience without writing complex JavaScript.
-- **SQLModel & SQLAlchemy Support:** Works out-of-the-box with popular database libraries.
-- **Automatic CRUD:** Generates list, detail, create, and update views from your data models.
-- **Extensible:** Easily customize views, templates, and actions to fit your needs.
-
-## 📚 Navigation
-
-- **[Getting Started](getting-started.md):** A guide to installing and configuring HyperAdmin.
-- **[Tutorial](tutorial.md):** A step-by-step tutorial on how to use HyperAdmin.
-- **[API Reference](api/):** Detailed documentation of the HyperAdmin API.
-
-## 🚀 Example Usage
+## Quick example
 
 ```python
 from fastapi import FastAPI
-from hyperadmin.admin import Admin
-from hyperadmin.views import ModelView
 from sqlmodel import SQLModel, Field
+from hyperadmin import Admin
+from hyperadmin.core.registry import site
 
-# 1. Define your data model
 class Product(SQLModel, table=True):
-    id: int = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     name: str
     price: float
 
-# 2. Create a FastAPI app
 app = FastAPI()
-
-# 3. Create an admin instance and register your model
-admin = Admin()
-admin.register_model(ModelView(Product))
-
-# 4. Mount the admin to your app
-admin.mount_to(app)
+admin = Admin(app, engine=engine)
+site.register(Product)
+admin.mount("/admin")
 ```
-This will automatically create a full CRUD interface for your `Product` model at `/admin`.
 
-## 🤝 Contributing
+## Where to go next
 
-Contributions are welcome! Please see the [Contributing Guide](https://github.com/yevheniidehtiar/hyper-admin/blob/main/CONTRIBUTING.md) for more details on how to get started.
+- [Getting Started](getting-started.md) — Installation, prerequisites, and your first admin
+- [Tutorial](tutorial.md) — Step-by-step walkthrough building a complete app
+- [Examples](examples.md) — Two runnable example apps (simple + full RBAC)
+- [Frontend](frontend/overview.md) — Templates, CSS tokens, widgets, and HTMX patterns
+- [API Reference](api/application.md) — Full class and method documentation
+
+## Key features
+
+- **Pydantic-native** — define admin interfaces directly from your models
+- **FastAPI integration** — mounts seamlessly into any FastAPI app
+- **HTMX-powered** — rich interactive UI without complex JavaScript
+- **SQLModel & SQLAlchemy** — works out of the box with both ORMs
+- **Automatic CRUD** — list, detail, create, and update views generated automatically
+- **Extensible** — override templates, customize views, and add custom actions
+
+---
+
+Next: [Getting Started](getting-started.md)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -59,3 +59,7 @@ The available options are:
 - `can_delete`: Enable or disable the delete functionality.
 - `can_list`: Enable or disable the list view.
 - `can_detail`: Enable or disable the detail view.
+
+---
+
+Next: [Examples](examples.md)

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  rbac_app:
+    build:
+      context: ..
+      dockerfile: examples/rbac_app/Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - rbac_db:/app/data
+    environment:
+      - DATABASE_URL=sqlite:////app/data/rbac.db
+
+volumes:
+  rbac_db:

--- a/examples/rbac_app/Dockerfile
+++ b/examples/rbac_app/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.13-slim
+
+# System packages needed for Pillow (fastapi-storages uses ImageType)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libjpeg-dev \
+    zlib1g-dev \
+    libpng-dev \
+    libwebp-dev \
+    libfreetype6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy entire repo so src/hyperadmin is available
+COPY . .
+
+# Install hyperadmin from source, aiosqlite (async SQLite driver), then rbac_app deps
+RUN pip install --no-cache-dir -e /app aiosqlite && \
+    pip install --no-cache-dir -r /app/examples/rbac_app/requirements.txt
+
+# Directories for uploaded files and persistent DB
+RUN mkdir -p /app/uploads/avatars /app/uploads/user_pk /app/data
+
+EXPOSE 8000
+
+CMD ["uvicorn", "examples.rbac_app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/examples/rbac_app/README.md
+++ b/examples/rbac_app/README.md
@@ -1,0 +1,42 @@
+# rbac_app — HyperAdmin RBAC Example
+
+A full-featured example showing 5 related models with search, sort, filters, and file uploads.
+
+## Quick start (Docker)
+
+From the repo root:
+
+```bash
+docker compose -f examples/docker-compose.yml up --build
+```
+
+Open http://localhost:8000/admin/
+
+Data is seeded automatically on first startup and persists in a named Docker volume across restarts.
+
+## Seeded data
+
+| Entity | Values |
+|--------|--------|
+| Users | `admin`, `editor`, `viewer` |
+| Groups | Administrators, Editors, Viewers |
+| Permissions | 8 permissions (add/change/delete/view for user and group) |
+
+## Models
+
+| Model | Description |
+|-------|-------------|
+| `User` | User with profile, avatar (image upload), and personal key (file upload) |
+| `Group` | Named group for organizing users |
+| `UserGroup` | Many-to-many join between User and Group |
+| `Permission` | Codename-based permission definition |
+| `UserPermissions` | Many-to-many join between User and Permission |
+
+## Local development (without Docker)
+
+```bash
+uv sync --all-extras
+uv run uvicorn examples.rbac_app.main:app --reload
+```
+
+Open http://localhost:8000/admin/

--- a/examples/rbac_app/admin.py
+++ b/examples/rbac_app/admin.py
@@ -1,7 +1,6 @@
 from typing import ClassVar
 
-from rbac_app.models import Group, Permission, User, UserGroup, UserPermissions
-
+from examples.rbac_app.models import Group, Permission, User, UserGroup, UserPermissions
 from hyperadmin.views import ModelView
 
 

--- a/examples/rbac_app/db.py
+++ b/examples/rbac_app/db.py
@@ -1,6 +1,14 @@
+import os
+
 from sqlalchemy import create_engine
 
-# Database setup
-SQLITE_PATH = "rbac_app.db"
-DATABASE_URL = f"sqlite:///{SQLITE_PATH}"
+# DATABASE_URL can be overridden via environment variable.
+# Docker sets it to a named volume path; local dev defaults to a file in cwd.
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./rbac_app.db")
+
+# Extract the raw file path for sqlite:/// URLs (used to create parent dirs).
+SQLITE_PATH = (
+    DATABASE_URL.removeprefix("sqlite:///") if DATABASE_URL.startswith("sqlite:///") else ""
+)
+
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})

--- a/examples/rbac_app/main.py
+++ b/examples/rbac_app/main.py
@@ -11,17 +11,17 @@ from hyperadmin import Admin
 
 @asynccontextmanager
 async def lifespan(app_: FastAPI):
-    # Cleanup old db
-    if os.path.exists(SQLITE_PATH):
-        os.remove(SQLITE_PATH)
-    # create sample data
+    # Ensure parent directory exists (needed when DATABASE_URL points to a volume path)
+    if SQLITE_PATH:
+        db_dir = os.path.dirname(SQLITE_PATH)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+
+    # Create tables and seed sample data (idempotent — skips if data exists)
     create_tables()
     create_sample_data()
 
     yield
-    # Remove existing database if it exists
-    if os.path.exists(SQLITE_PATH):
-        os.remove(SQLITE_PATH)
 
 
 # Create FastAPI app
@@ -31,16 +31,9 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# Create admin interface
-admin = Admin(app, engine, title="Demo Admin", base_url="/admin")
-
-
-# # Add views to admin
-# admin.add_view(UserAdmin)
-# admin.add_view(GroupAdmin)
-# admin.add_view(UserGroupAdmin)
-# admin.add_view(PermissionAdmin)
-# admin.add_view(UserPermissionsAdmin)
+# Create admin interface — discover admin.py from the rbac_app package
+admin = Admin(app, engine=engine, create_tables=False, discover_apps=["examples.rbac_app"])
+admin.mount("/admin")
 
 
 @app.get("/")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
   - Introduction: "index.md"
   - Getting Started: "getting-started.md"
   - Tutorial: "tutorial.md"
+  - Examples: "examples.md"
   - Frontend:
       - Overview: "frontend/overview.md"
       - Widgets: "frontend/widgets.md"

--- a/scripts/redeploy-example.sh
+++ b/scripts/redeploy-example.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Rebuild and restart the rbac_app Docker container.
+# Safe to run repeatedly — named volume preserves DB data between restarts.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Redeploying rbac_app..."
+docker compose -f "$REPO_ROOT/examples/docker-compose.yml" up --build -d
+echo "rbac_app redeployed → http://localhost:8000/admin/"

--- a/src/hyperadmin/core/adapters.py
+++ b/src/hyperadmin/core/adapters.py
@@ -4,13 +4,19 @@ from typing import Any
 
 
 class BaseAdapter(ABC):
-    model: Any
-    """
-    Abstract base class for data adapters.
+    """Abstract base class for data adapters.
 
-    This class defines the contract for all data operations (get, list, create, update, delete)
-    in HyperAdmin. It serves as the foundation for all ORM-specific adapters.
+    Defines the contract for all data operations (get, list, create, update, delete).
+    Subclass this to add support for a new ORM or data source.
+
+    Example:
+        ```python
+        class MyAdapter(BaseAdapter):
+            async def get(self, pk): ...
+        ```
     """
+
+    model: Any
 
     def __init__(self, model: Any, engine: Any) -> None:
         self.model = model

--- a/src/hyperadmin/core/app.py
+++ b/src/hyperadmin/core/app.py
@@ -11,7 +11,21 @@ from hyperadmin.discover import discover_admin_modules
 
 
 class Admin:
-    """The main Admin class that holds the admin interface."""
+    """The main entry point for HyperAdmin.
+
+    Mounts static files, wires the database engine, optionally discovers admin
+    modules, and registers all model routes on the FastAPI application.
+
+    Example:
+        ```python
+        from fastapi import FastAPI
+        from hyperadmin import Admin
+
+        app = FastAPI()
+        admin = Admin(app, engine=engine, discover_apps=["myapp"])
+        admin.mount("/admin")
+        ```
+    """
 
     def __init__(
         self,
@@ -21,6 +35,19 @@ class Admin:
         engine: Any = None,
         template_dirs: list[str] | None = None,
     ):
+        """Initialise HyperAdmin and attach it to a FastAPI application.
+
+        Args:
+            app: The FastAPI application instance to attach the admin to.
+            discover_apps: List of Python module paths to auto-discover
+                ``admin.py`` files in (e.g. ``["myapp", "otherapp"]``).
+            create_tables: When ``True``, registers an ``on_event("startup")``
+                handler that calls ``SQLModel.metadata.create_all``.
+            engine: An async SQLAlchemy engine. Defaults to the built-in
+                ``hyperadmin.db.engine`` if not provided.
+            template_dirs: Additional Jinja2 template directories searched
+                before the built-in HyperAdmin templates.
+        """
         self.app = app
         self.router = APIRouter()
         self.engine = engine or default_engine

--- a/src/hyperadmin/core/options.py
+++ b/src/hyperadmin/core/options.py
@@ -2,10 +2,27 @@ from pydantic import BaseModel
 
 
 class AdminOptions(BaseModel):
-    """Configuration options for a model in the admin interface."""
+    """Per-model configuration for the HyperAdmin interface.
+
+    Pass an instance to ``site.register()`` or set it as a class attribute on
+    a ``ModelView`` subclass to control which views are generated.
+
+    Example:
+        ```python
+        from hyperadmin.core.options import AdminOptions
+        from hyperadmin.core.registry import site
+
+        site.register(Product, options=AdminOptions(can_delete=False))
+        ```
+    """
 
     can_create: bool = True
+    """Whether the Create form and POST endpoint are generated."""
     can_edit: bool = True
+    """Whether the Edit form and PUT endpoint are generated."""
     can_delete: bool = True
+    """Whether the Delete action and DELETE endpoint are generated."""
     can_list: bool = True
+    """Whether the List view and GET (collection) endpoint are generated."""
     can_detail: bool = True
+    """Whether the Detail view and GET (single item) endpoint are generated."""

--- a/src/hyperadmin/core/registry.py
+++ b/src/hyperadmin/core/registry.py
@@ -33,7 +33,7 @@ class SiteRegistry:
         Args:
             model: The model class or instance to register.
             admin_class: The admin class to associate with the model. If None,
-              ModelAdmin will be used.
+                ModelAdmin will be used.
             options: The admin options to associate with the model. If None,
                 default options will be used.
             app_label: The label of the application that the model belongs to.

--- a/src/hyperadmin/routing.py
+++ b/src/hyperadmin/routing.py
@@ -99,6 +99,16 @@ def create_admin_router(
 
 
 class HyperAdminRouter:
+    """Generates and owns all FastAPI routers for HyperAdmin.
+
+    Called internally by ``Admin.mount()``. Iterates ``SiteRegistry`` and
+    calls ``create_admin_router`` for each registered model.
+
+    Args:
+        engine: The async SQLAlchemy engine passed to every adapter.
+        templates: The shared ``Jinja2Templates`` instance used across all views.
+    """
+
     def __init__(self, engine: Any, templates: Jinja2Templates):
         self.engine = engine
         # Enable global whitespace trimming

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -28,6 +28,13 @@ class ModelView:
 
 
 class DynamicModelView:
+    """View handler that serves all CRUD endpoints for a registered model.
+
+    One instance is created per model by ``HyperAdminRouter``. It delegates
+    all database operations to its ``adapter`` and renders Jinja2 templates
+    resolved through the template-search hierarchy.
+    """
+
     def __init__(
         self,
         adapter: SQLAlchemyAdapter | SQLModelAdapter,


### PR DESCRIPTION
## Summary

- **Docker example app**: `examples/rbac_app/` is now fully runnable via `docker compose -f examples/docker-compose.yml up --build`. Seeds 3 users, 3 groups, 8 permissions on first start; data persists in a named volume.
- **Docs navigation fixed**: `docs/index.md` rewritten as a hub page with install snippet, quick example, and links to every section. New `docs/examples.md` page. `getting-started.md` fully rewritten with installation, quickstart, and 3 registration patterns.
- **API reference enriched**: all 5 `docs/api/*.md` pages now have usage examples, parameter tables, and URL structure reference. Google-style docstrings added to `Admin`, `AdminOptions`, `BaseAdapter`, `DynamicModelView`, `HyperAdminRouter`, and `SiteRegistry`.
- **Auto-redeploy hook**: `scripts/redeploy-example.sh` + `.claude/settings.json` hook rebuilds the Docker container whenever a task is marked completed.

## Test plan

- [ ] `docker compose -f examples/docker-compose.yml up --build` → open http://localhost:8000/admin/ and click through all 5 model list views
- [ ] `uv run mkdocs serve` → verify every nav link opens without 404
- [ ] `uv run mkdocs build` → zero warnings/errors
- [ ] `poe test` → existing test suite stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)