### PR TITLE
chore(ci): add pre-push stage to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # https://pre-commit.com
-default_install_hook_types: [commit-msg, pre-commit]
-default_stages: [pre-commit, manual]
+default_install_hook_types: [commit-msg, pre-commit, pre-push]
+default_stages: [pre-commit, pre-push, manual]
 fail_fast: true
 repos:
   - repo: meta

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,3 +80,24 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      - id: test-unit
+        name: unit tests
+        entry: uv run pytest -vv -q tests/unit
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        always_run: true
+      - id: test-e2e
+        name: e2e tests
+        entry: uv run pytest tests/e2e
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        always_run: true
+      - id: security-check
+        name: security check
+        entry: uv run poe security-check
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        always_run: true


### PR DESCRIPTION
## Summary

- Adds `pre-push` to `default_install_hook_types` and `default_stages` in `.pre-commit-config.yaml`
- All existing hooks (ruff, mypy, basedpyright, commitizen) now run on both commit and push
- Prevents agents (Jules) from pushing code that fails lint — the root cause of CI failures in PRs #152–#155

## Setup

After pulling this change, contributors (and Jules) need to install the new hook type:

```bash
uv run pre-commit install --hook-type pre-push
```

## Test plan

- [ ] `uv run pre-commit install --hook-type pre-push` creates `.git/hooks/pre-push`
- [ ] Pushing code with lint errors is blocked by the pre-push hook
- [ ] Clean code pushes successfully