### PR TITLE
feat(auth): implement authorization & user management (Epic 1.5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "typing-extensions>=4.14.1",
   "typer>=0.12",
   "argon2-cffi",
+  "itsdangerous>=2.0",
 ]
 
 [project.scripts]

--- a/src/hyperadmin/auth/__init__.py
+++ b/src/hyperadmin/auth/__init__.py
@@ -1,4 +1,19 @@
 from hyperadmin.auth.backend import hash_password
-from hyperadmin.auth.models import User
+from hyperadmin.auth.models import (
+    Group,
+    GroupPermission,
+    Permission,
+    User,
+    UserGroup,
+    UserPermission,
+)
 
-__all__ = ["User", "hash_password"]
+__all__ = [
+    "Group",
+    "GroupPermission",
+    "Permission",
+    "User",
+    "UserGroup",
+    "UserPermission",
+    "hash_password",
+]

--- a/src/hyperadmin/auth/middleware.py
+++ b/src/hyperadmin/auth/middleware.py
@@ -1,0 +1,53 @@
+"""Authentication middleware for HyperAdmin.
+
+Redirects unauthenticated requests to the login page and populates
+``request.state.user`` for authenticated requests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import RedirectResponse, Response
+
+
+class AuthenticationMiddleware(BaseHTTPMiddleware):
+    """Starlette middleware that enforces authentication on admin routes."""
+
+    # Paths that don't require authentication (relative to admin prefix)
+    PUBLIC_SUFFIXES = ("/login", "/login/")
+
+    def __init__(self, app: Any, auth_backend: Any, admin_prefix: str = "/admin") -> None:
+        super().__init__(app)
+        self.auth_backend = auth_backend
+        self.admin_prefix = admin_prefix.rstrip("/")
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        path = request.url.path
+
+        # Only enforce auth on admin routes
+        if not path.startswith(self.admin_prefix):
+            return await call_next(request)
+
+        # Allow public paths (login page, static assets)
+        relative = path[len(self.admin_prefix) :]
+        if any(
+            relative == suffix or relative.startswith(suffix) for suffix in self.PUBLIC_SUFFIXES
+        ):
+            request.state.user = None
+            return await call_next(request)
+
+        # Allow static assets
+        if relative.startswith("/static"):
+            return await call_next(request)
+
+        # Check authentication
+        user = await self.auth_backend.get_current_user(request)
+        if user is None:
+            login_url = f"{self.admin_prefix}/login"
+            return RedirectResponse(url=login_url, status_code=302)
+
+        request.state.user = user
+        return await call_next(request)

--- a/src/hyperadmin/auth/models.py
+++ b/src/hyperadmin/auth/models.py
@@ -1,4 +1,6 @@
-from sqlmodel import Field, SQLModel
+from datetime import datetime
+
+from sqlmodel import Field, Relationship, SQLModel
 
 
 class User(SQLModel, table=True):
@@ -10,4 +12,146 @@ class User(SQLModel, table=True):
     username: str = Field(index=True, max_length=50, unique=True)
     email: str = Field(index=True, max_length=100, unique=True)
     password_hash: str = Field(max_length=255)
+    first_name: str = Field(default="", max_length=50)
+    last_name: str = Field(default="", max_length=50)
+    is_active: bool = Field(default=True)
     is_superuser: bool = Field(default=False)
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime | None = Field(default=None)
+
+    user_groups: list["UserGroup"] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs={
+            "foreign_keys": "UserGroup.user_id",
+            "lazy": "selectin",
+        },
+    )
+    user_permissions: list["UserPermission"] = Relationship(
+        back_populates="user",
+        sa_relationship_kwargs={
+            "foreign_keys": "UserPermission.user_id",
+            "lazy": "selectin",
+        },
+    )
+
+    def __str__(self) -> str:
+        if self.first_name or self.last_name:
+            return f"{self.first_name} {self.last_name}".strip()
+        return self.username
+
+
+class Group(SQLModel, table=True):
+    """Group model for organizing users and assigning permissions."""
+
+    __tablename__ = "hyperadmin_groups"  # type: ignore[reportIncompatibleVariableOverride]
+
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(index=True, max_length=80, unique=True)
+    description: str | None = Field(default=None, max_length=255)
+    is_active: bool = Field(default=True)
+    created_at: datetime = Field(default_factory=datetime.now)
+
+    user_groups: list["UserGroup"] = Relationship(
+        back_populates="group",
+        sa_relationship_kwargs={
+            "foreign_keys": "UserGroup.group_id",
+            "lazy": "selectin",
+        },
+    )
+    group_permissions: list["GroupPermission"] = Relationship(
+        back_populates="group",
+        sa_relationship_kwargs={
+            "foreign_keys": "GroupPermission.group_id",
+            "lazy": "selectin",
+        },
+    )
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class Permission(SQLModel, table=True):
+    """Permission model with unique codename for authorization checks."""
+
+    __tablename__ = "hyperadmin_permissions"  # type: ignore[reportIncompatibleVariableOverride]
+
+    id: int | None = Field(default=None, primary_key=True)
+    codename: str = Field(index=True, max_length=100, unique=True)
+    name: str = Field(max_length=200)
+    content_type: str | None = Field(default=None, max_length=100)
+    created_at: datetime = Field(default_factory=datetime.now)
+
+    user_permissions: list["UserPermission"] = Relationship(
+        back_populates="permission",
+        sa_relationship_kwargs={
+            "foreign_keys": "UserPermission.permission_id",
+            "lazy": "selectin",
+        },
+    )
+    group_permissions: list["GroupPermission"] = Relationship(
+        back_populates="permission",
+        sa_relationship_kwargs={
+            "foreign_keys": "GroupPermission.permission_id",
+            "lazy": "selectin",
+        },
+    )
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class UserGroup(SQLModel, table=True):
+    """Junction table: User <-> Group."""
+
+    __tablename__ = "hyperadmin_user_groups"  # type: ignore[reportIncompatibleVariableOverride]
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="hyperadmin_users.id", index=True)
+    group_id: int = Field(foreign_key="hyperadmin_groups.id", index=True)
+
+    user: User | None = Relationship(
+        back_populates="user_groups",
+        sa_relationship_kwargs={"foreign_keys": "UserGroup.user_id"},
+    )
+    group: Group | None = Relationship(
+        back_populates="user_groups",
+        sa_relationship_kwargs={"foreign_keys": "UserGroup.group_id"},
+    )
+
+
+class UserPermission(SQLModel, table=True):
+    """Junction table: User <-> Permission (direct grants)."""
+
+    __tablename__ = "hyperadmin_user_permissions"  # type: ignore[reportIncompatibleVariableOverride]
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="hyperadmin_users.id", index=True)
+    permission_id: int = Field(foreign_key="hyperadmin_permissions.id", index=True)
+
+    user: User | None = Relationship(
+        back_populates="user_permissions",
+        sa_relationship_kwargs={"foreign_keys": "UserPermission.user_id"},
+    )
+    permission: Permission | None = Relationship(
+        back_populates="user_permissions",
+        sa_relationship_kwargs={"foreign_keys": "UserPermission.permission_id"},
+    )
+
+
+class GroupPermission(SQLModel, table=True):
+    """Junction table: Group <-> Permission."""
+
+    __tablename__ = "hyperadmin_group_permissions"  # type: ignore[reportIncompatibleVariableOverride]
+
+    id: int | None = Field(default=None, primary_key=True)
+    group_id: int = Field(foreign_key="hyperadmin_groups.id", index=True)
+    permission_id: int = Field(foreign_key="hyperadmin_permissions.id", index=True)
+
+    group: Group | None = Relationship(
+        back_populates="group_permissions",
+        sa_relationship_kwargs={"foreign_keys": "GroupPermission.group_id"},
+    )
+    permission: Permission | None = Relationship(
+        back_populates="group_permissions",
+        sa_relationship_kwargs={"foreign_keys": "GroupPermission.permission_id"},
+    )

--- a/src/hyperadmin/auth/permissions.py
+++ b/src/hyperadmin/auth/permissions.py
@@ -1,0 +1,111 @@
+"""Permission checking and auto-registration services.
+
+Implements ``PermissionChecker`` and ``PermissionRegistry`` protocols.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlmodel import select
+
+from hyperadmin.auth.models import (
+    Group,
+    GroupPermission,
+    Permission,
+    User,
+    UserGroup,
+    UserPermission,
+)
+
+_ACTIONS = ("view", "add", "change", "delete")
+
+
+def generate_default_permissions(model_name: str) -> list[tuple[str, str]]:
+    """Return the 4 default (codename, human_name) tuples for a model."""
+    name = model_name.lower()
+    return [(f"{action}_{name}", f"Can {action} {name}") for action in _ACTIONS]
+
+
+class PermissionSyncService:
+    """Syncs auto-generated and custom permissions to the database on startup."""
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self.engine = engine
+
+    async def sync_permissions(self, registered_models: list[Any]) -> None:
+        """Create missing permissions for all registered models.
+
+        Args:
+            registered_models: List of ``(model_name, admin_class)`` tuples.
+        """
+        async with AsyncSession(self.engine) as session:
+            existing = (await session.execute(select(Permission.codename))).scalars().all()
+            existing_set = set(existing)
+
+            to_create: list[Permission] = []
+            for model_name, admin_class in registered_models:
+                # Default CRUD permissions
+                for codename, name in generate_default_permissions(model_name):
+                    if codename not in existing_set:
+                        to_create.append(
+                            Permission(codename=codename, name=name, content_type=model_name)
+                        )
+                        existing_set.add(codename)
+
+                # Custom permissions from ModelAdmin.permissions
+                custom = getattr(admin_class, "permissions", None) or []
+                for codename, name in custom:
+                    if codename not in existing_set:
+                        to_create.append(
+                            Permission(codename=codename, name=name, content_type=model_name)
+                        )
+                        existing_set.add(codename)
+
+            if to_create:
+                session.add_all(to_create)
+                await session.commit()
+
+
+class ModelPermissionChecker:
+    """Checks user permissions via direct grants and group inheritance."""
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self.engine = engine
+
+    async def has_permission(self, user: User, codename: str) -> bool:
+        """Return ``True`` if the user holds the given permission."""
+        if user.is_superuser:
+            return True
+        perms = await self.get_user_permissions(user)
+        return codename in perms
+
+    async def get_user_permissions(self, user: User) -> set[str]:
+        """Return the union of direct + group-inherited permission codenames."""
+        async with AsyncSession(self.engine) as session:
+            # Direct permissions
+            stmt = (
+                select(Permission.codename)
+                .join(
+                    UserPermission,
+                    UserPermission.permission_id == Permission.id,  # type: ignore[arg-type]
+                )
+                .where(UserPermission.user_id == user.id)
+            )
+            direct = set((await session.execute(stmt)).scalars().all())
+
+            # Group-inherited permissions
+            stmt = (
+                select(Permission.codename)
+                .join(
+                    GroupPermission,
+                    GroupPermission.permission_id == Permission.id,  # type: ignore[arg-type]
+                )
+                .join(Group, Group.id == GroupPermission.group_id)  # type: ignore[arg-type]
+                .join(UserGroup, UserGroup.group_id == Group.id)  # type: ignore[arg-type]
+                .where(UserGroup.user_id == user.id)
+            )
+            inherited = set((await session.execute(stmt)).scalars().all())
+
+            return direct | inherited

--- a/src/hyperadmin/auth/session.py
+++ b/src/hyperadmin/auth/session.py
@@ -1,0 +1,52 @@
+"""Session-based authentication service.
+
+Implements ``AuthBackend`` and ``CurrentUserProvider`` protocols using
+Starlette's ``SessionMiddleware``-backed cookie sessions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlmodel import select
+
+from hyperadmin.auth.backend import verify_password
+from hyperadmin.auth.models import User
+
+
+class SessionAuthBackend:
+    """Cookie-session authentication backed by an async SQLAlchemy engine."""
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self.engine = engine
+
+    async def authenticate(self, username: str, password: str) -> User | None:
+        """Return the user if credentials are valid, else ``None``."""
+        async with AsyncSession(self.engine) as session:
+            stmt = select(User).where(User.username == username)
+            user = (await session.execute(stmt)).scalar_one_or_none()
+            if user is None:
+                return None
+            if not user.is_active:
+                return None
+            if not verify_password(password, user.password_hash):
+                return None
+            return user
+
+    async def login(self, request: Any, user: User) -> None:
+        """Store the user ID in the session."""
+        request.session["user_id"] = user.id
+
+    async def logout(self, request: Any) -> None:
+        """Clear the session."""
+        request.session.pop("user_id", None)
+
+    async def get_current_user(self, request: Any) -> User | None:
+        """Resolve the current user from the session, or ``None``."""
+        user_id = request.session.get("user_id")
+        if user_id is None:
+            return None
+        async with AsyncSession(self.engine) as session:
+            stmt = select(User).where(User.id == user_id)
+            return (await session.execute(stmt)).scalar_one_or_none()

--- a/src/hyperadmin/auth/views.py
+++ b/src/hyperadmin/auth/views.py
@@ -1,0 +1,43 @@
+"""Login and logout view handlers for HyperAdmin."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.templating import Jinja2Templates
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
+
+
+async def login_view(
+    request: Request,
+    templates: Jinja2Templates,
+    auth_backend: Any,
+    admin_prefix: str,
+) -> Any:
+    """Handle GET (render form) and POST (authenticate) for login."""
+    error = None
+
+    if request.method == "POST":
+        form = await request.form()
+        username = form.get("username", "")
+        password = form.get("password", "")
+
+        user = await auth_backend.authenticate(str(username), str(password))
+        if user is not None:
+            await auth_backend.login(request, user)
+            return RedirectResponse(url=f"{admin_prefix}/", status_code=302)
+        error = "Invalid username or password."
+
+    context = {"request": request, "error": error, "admin_prefix": admin_prefix}
+    return templates.TemplateResponse(request, "login.html", context)
+
+
+async def logout_view(
+    request: Request,
+    auth_backend: Any,
+    admin_prefix: str,
+) -> RedirectResponse:
+    """Handle POST logout — clear session and redirect to login."""
+    await auth_backend.logout(request)
+    return RedirectResponse(url=f"{admin_prefix}/login", status_code=302)

--- a/src/hyperadmin/core/app.py
+++ b/src/hyperadmin/core/app.py
@@ -34,6 +34,10 @@ class Admin:
         create_tables: bool = True,
         engine: Any = None,
         template_dirs: list[str] | None = None,
+        auth_backend: Any = None,
+        permission_checker: Any = None,
+        permission_registry: Any = None,
+        session_secret: str | None = None,
     ):
         """Initialise HyperAdmin and attach it to a FastAPI application.
 
@@ -47,10 +51,20 @@ class Admin:
                 ``hyperadmin.db.engine`` if not provided.
             template_dirs: Additional Jinja2 template directories searched
                 before the built-in HyperAdmin templates.
+            auth_backend: An optional authentication backend implementing the
+                ``AuthBackend`` protocol. When ``None``, auth is disabled.
+            permission_checker: An optional ``PermissionChecker`` implementation.
+            permission_registry: An optional ``PermissionRegistry`` implementation.
+            session_secret: Secret key for ``SessionMiddleware``. Required when
+                ``auth_backend`` is set.
         """
         self.app = app
         self.router = APIRouter()
         self.engine = engine or default_engine
+        self.auth_backend = auth_backend
+        self.permission_checker = permission_checker
+        self.permission_registry = permission_registry
+        self.session_secret = session_secret
         self.template_dirs = template_dirs or []
         template_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
         self.templates = Jinja2Templates(directory=[template_dir, *self.template_dirs])
@@ -78,16 +92,82 @@ class Admin:
         """Registers the views from the site registry."""
         from hyperadmin.routing import HyperAdminRouter
 
-        admin_router = HyperAdminRouter(engine=self.engine, templates=self.templates)
+        admin_router = HyperAdminRouter(
+            engine=self.engine,
+            templates=self.templates,
+            permission_checker=self.permission_checker if self.auth_backend else None,
+        )
         admin_router.generate_routes()
         routers = admin_router.get_routers()
         for router in routers:
             self.router.include_router(router)
 
+    def _register_auth_routes(self, path: str) -> None:
+        """Register login/logout routes when auth is enabled."""
+        from starlette.requests import Request
+
+        from hyperadmin.auth.views import login_view, logout_view
+
+        admin_prefix = path.rstrip("/")
+        templates = self.templates
+        auth_backend = self.auth_backend
+
+        async def login_get(request: Request):
+            return await login_view(request, templates, auth_backend, admin_prefix)
+
+        async def login_post(request: Request):
+            return await login_view(request, templates, auth_backend, admin_prefix)
+
+        async def logout_post(request: Request):
+            return await logout_view(request, auth_backend, admin_prefix)
+
+        self.router.add_api_route("/login", login_get, methods=["GET"], name="admin-login")
+        self.router.add_api_route("/login", login_post, methods=["POST"], name="admin-login-post")
+        self.router.add_api_route("/logout", logout_post, methods=["POST"], name="admin-logout")
+
+    def _add_auth_middleware(self, path: str) -> None:
+        """Add session and authentication middleware."""
+        from starlette.middleware.sessions import SessionMiddleware
+
+        from hyperadmin.auth.middleware import AuthenticationMiddleware
+
+        admin_prefix = path.rstrip("/")
+        self.app.add_middleware(
+            AuthenticationMiddleware,
+            auth_backend=self.auth_backend,
+            admin_prefix=admin_prefix,
+        )
+        self.app.add_middleware(
+            SessionMiddleware,
+            secret_key=self.session_secret or "hyperadmin-default-secret",
+        )
+
+    async def _sync_permissions(self) -> None:
+        """Sync permissions for all registered models to the database."""
+        if not self.permission_registry:
+            return
+
+        from hyperadmin.core.registry import site
+
+        models = []
+        for model, admin_class in site._registry.items():
+            model_name = model.__name__.lower()
+            models.append((model_name, admin_class))
+        await self.permission_registry.sync_permissions(models)
+
     def mount(self, path: str):
-        """
-        Mounts the admin interface on the FastAPI application.
-        """
+        """Mounts the admin interface on the FastAPI application."""
+        if self.auth_backend:
+            self._register_auth_routes(path)
+
         self._register_views()
         self.templates.env.globals["admin_prefix"] = path.rstrip("/")
+        self.templates.env.globals["auth_enabled"] = self.auth_backend is not None
+
+        if self.auth_backend:
+            self.router.on_startup.append(self._sync_permissions)
+
         self.app.include_router(self.router, prefix=path, tags=["HyperAdmin"])
+
+        if self.auth_backend:
+            self._add_auth_middleware(path)

--- a/src/hyperadmin/core/auth.py
+++ b/src/hyperadmin/core/auth.py
@@ -1,0 +1,46 @@
+"""Authentication and authorization protocol definitions.
+
+These protocols define the injection seams for auth services. Concrete
+implementations live in ``hyperadmin.auth``, keeping ``core/`` free of
+ORM and HTTP dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from starlette.requests import Request
+
+
+@runtime_checkable
+class AuthBackend(Protocol):
+    """Authenticates users and manages login/logout sessions."""
+
+    async def authenticate(self, username: str, password: str) -> Any | None: ...
+
+    async def login(self, request: Request, user: Any) -> None: ...
+
+    async def logout(self, request: Request) -> None: ...
+
+
+@runtime_checkable
+class CurrentUserProvider(Protocol):
+    """Resolves the current user from an incoming request."""
+
+    async def get_current_user(self, request: Request) -> Any | None: ...
+
+
+@runtime_checkable
+class PermissionChecker(Protocol):
+    """Checks whether a user holds a specific permission."""
+
+    async def has_permission(self, user: Any, codename: str) -> bool: ...
+
+    async def get_user_permissions(self, user: Any) -> set[str]: ...
+
+
+@runtime_checkable
+class PermissionRegistry(Protocol):
+    """Syncs auto-generated and custom permissions to the database."""
+
+    async def sync_permissions(self, registered_models: list[Any]) -> None: ...

--- a/src/hyperadmin/routing.py
+++ b/src/hyperadmin/routing.py
@@ -48,6 +48,7 @@ def create_admin_router(  # noqa: PLR0913
     form_include: list[str] | None = None,
     form_create_exclude: list[str] | None = None,
     column_list: list[str] | None = None,
+    permission_checker: Any = None,
 ) -> APIRouter:
     """Creates an APIRouter for a given model with the specified admin options."""
     router = APIRouter()
@@ -59,6 +60,7 @@ def create_admin_router(  # noqa: PLR0913
         form_include=form_include,
         form_create_exclude=form_create_exclude,
         column_list=column_list,
+        permission_checker=permission_checker,
     )
     model_name = model.__name__.lower()
 
@@ -130,8 +132,9 @@ class HyperAdminRouter:
         templates: The shared ``Jinja2Templates`` instance used across all views.
     """
 
-    def __init__(self, engine: Any, templates: Jinja2Templates):
+    def __init__(self, engine: Any, templates: Jinja2Templates, permission_checker: Any = None):
         self.engine = engine
+        self.permission_checker = permission_checker
         # Enable global whitespace trimming
         templates.env.trim_blocks = True
         templates.env.lstrip_blocks = True
@@ -182,6 +185,7 @@ class HyperAdminRouter:
                 form_include=form_include,
                 form_create_exclude=form_create_exclude,
                 column_list=column_list,
+                permission_checker=self.permission_checker,
             )
             self.routers.append(router)
 

--- a/src/hyperadmin/templates/_base.html
+++ b/src/hyperadmin/templates/_base.html
@@ -51,10 +51,10 @@
 </head>
 <body class="ha-page">
     <div class="ha-container">
-        {% include "_messages.html" %}
-        {% include "_navbar.html" %}
+        {% block messages %}{% include "_messages.html" %}{% endblock %}
+        {% block navbar %}{% include "_navbar.html" %}{% endblock %}
         <div class="ha-layout">
-            {% include "_sidebar.html" %}
+            {% block sidebar %}{% include "_sidebar.html" %}{% endblock %}
             <main class="ha-content">
                 {% block content %}{% endblock %}
             </main>

--- a/src/hyperadmin/templates/_navbar.html
+++ b/src/hyperadmin/templates/_navbar.html
@@ -1,7 +1,23 @@
 <nav class="ha-navbar">
     <div class="ha-navbar-inner">
-        <a href="/" class="ha-navbar-brand">HyperAdmin</a>
+        <a href="{{ admin_prefix }}/" class="ha-navbar-brand">HyperAdmin</a>
         <div x-data="{ open: false }" class="ha-navbar-user">
+            {% if auth_enabled and request.state.user %}
+            <button @click="open = !open" class="ha-navbar-user-btn">
+                <svg class="ha-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                </svg>
+                <span data-testid="current-user">{{ request.state.user.username }}</span>
+                <svg class="ha-icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+            </button>
+            <div x-show="open" @click.away="open = false" class="ha-dropdown">
+                <form method="post" action="{{ admin_prefix }}/logout">
+                    <button type="submit" class="ha-dropdown-item" data-testid="logout-btn">Logout</button>
+                </form>
+            </div>
+            {% else %}
             <button @click="open = !open" class="ha-navbar-user-btn">
                 <svg class="ha-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0z"></path>
@@ -14,8 +30,8 @@
             <div x-show="open" @click.away="open = false" class="ha-dropdown">
                 <a href="#" class="ha-dropdown-item">Profile</a>
                 <a href="#" class="ha-dropdown-item">Settings</a>
-                <a href="#" class="ha-dropdown-item">Logout</a>
             </div>
+            {% endif %}
         </div>
     </div>
 </nav>

--- a/src/hyperadmin/templates/_sidebar.html
+++ b/src/hyperadmin/templates/_sidebar.html
@@ -3,6 +3,7 @@
         <h2 class="ha-sidebar-title">Menu</h2>
         <ul class="ha-sidebar-nav">
             {%- for item in nav_items -%}
+            {%- if not auth_enabled or not request.state.user or item.get('visible', true) -%}
             <li>
                 <a href="{{ admin_prefix }}{{ item.url }}" class="ha-sidebar-link">
                     {%- if item.icon -%}
@@ -11,6 +12,7 @@
                     {{ item.name }}
                 </a>
             </li>
+            {%- endif -%}
             {%- endfor -%}
         </ul>
     </div>

--- a/src/hyperadmin/templates/login.html
+++ b/src/hyperadmin/templates/login.html
@@ -1,55 +1,51 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login — HyperAdmin</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="{{ url_for('static', path='/css/hyperadmin.css') }}">
-</head>
-<body class="ha-page">
-    <div class="ha-login-container">
-        <div class="ha-login-card">
-            <h1 class="ha-login-title">HyperAdmin</h1>
-            <p class="ha-text-muted">Sign in to your account</p>
+{%- extends "_base.html" -%}
 
-            {% if error %}
-            <div class="ha-alert ha-alert-error" data-testid="login-error">
-                {{ error }}
-            </div>
-            {% endif %}
+{%- block title -%}Login — HyperAdmin{%- endblock -%}
 
-            <form method="post" action="{{ admin_prefix }}/login" data-testid="login-form">
-                <div class="ha-form-group">
-                    <label for="username" class="ha-label">Username</label>
-                    <input
-                        type="text"
-                        id="username"
-                        name="username"
-                        class="ha-input"
-                        data-testid="login-username"
-                        required
-                        autofocus
-                    >
-                </div>
-                <div class="ha-form-group">
-                    <label for="password" class="ha-label">Password</label>
-                    <input
-                        type="password"
-                        id="password"
-                        name="password"
-                        class="ha-input"
-                        data-testid="login-password"
-                        required
-                    >
-                </div>
-                <button type="submit" class="ha-btn ha-btn-primary ha-btn-block" data-testid="login-submit">
-                    Sign in
-                </button>
-            </form>
+{%- block messages -%}{%- endblock -%}
+{%- block navbar -%}{%- endblock -%}
+{%- block sidebar -%}{%- endblock -%}
+
+{%- block content -%}
+<div class="ha-login-container">
+    <div class="ha-login-card">
+        <h1 class="ha-login-title">HyperAdmin</h1>
+        <p class="ha-text-muted">Sign in to your account</p>
+
+        {%- if error -%}
+        <div class="ha-alert ha-alert-error" data-testid="login-error">
+            {{ error }}
         </div>
+        {%- endif -%}
+
+        <form method="post" action="{{ admin_prefix }}/login" data-testid="login-form">
+            <div class="ha-form-group">
+                <label for="username" class="ha-label">Username</label>
+                <input
+                    type="text"
+                    id="username"
+                    name="username"
+                    class="ha-input"
+                    data-testid="login-username"
+                    required
+                    autofocus
+                >
+            </div>
+            <div class="ha-form-group">
+                <label for="password" class="ha-label">Password</label>
+                <input
+                    type="password"
+                    id="password"
+                    name="password"
+                    class="ha-input"
+                    data-testid="login-password"
+                    required
+                >
+            </div>
+            <button type="submit" class="ha-btn ha-btn-primary ha-btn-block" data-testid="login-submit">
+                Sign in
+            </button>
+        </form>
     </div>
-</body>
-</html>
+</div>
+{%- endblock -%}

--- a/src/hyperadmin/templates/login.html
+++ b/src/hyperadmin/templates/login.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login — HyperAdmin</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="{{ url_for('static', path='/css/hyperadmin.css') }}">
+</head>
+<body class="ha-page">
+    <div class="ha-login-container">
+        <div class="ha-login-card">
+            <h1 class="ha-login-title">HyperAdmin</h1>
+            <p class="ha-text-muted">Sign in to your account</p>
+
+            {% if error %}
+            <div class="ha-alert ha-alert-error" data-testid="login-error">
+                {{ error }}
+            </div>
+            {% endif %}
+
+            <form method="post" action="{{ admin_prefix }}/login" data-testid="login-form">
+                <div class="ha-form-group">
+                    <label for="username" class="ha-label">Username</label>
+                    <input
+                        type="text"
+                        id="username"
+                        name="username"
+                        class="ha-input"
+                        data-testid="login-username"
+                        required
+                        autofocus
+                    >
+                </div>
+                <div class="ha-form-group">
+                    <label for="password" class="ha-label">Password</label>
+                    <input
+                        type="password"
+                        id="password"
+                        name="password"
+                        class="ha-input"
+                        data-testid="login-password"
+                        required
+                    >
+                </div>
+                <button type="submit" class="ha-btn ha-btn-primary ha-btn-block" data-testid="login-submit">
+                    Sign in
+                </button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -73,6 +73,7 @@ class DynamicModelView:
         form_include: list[str] | None = None,
         form_create_exclude: list[str] | None = None,
         column_list: list[str] | None = None,
+        permission_checker: Any = None,
     ):
         self.adapter = adapter
         self.model = adapter.model
@@ -82,6 +83,22 @@ class DynamicModelView:
         self.form_include = form_include
         self.form_create_exclude = form_create_exclude or []
         self.column_list = column_list or ["id", "__str__"]
+        self.permission_checker = permission_checker
+        self._model_name_lower = self.model.__name__.lower()
+
+    async def _check_permission(self, request: Request, action: str) -> None:
+        """Raise 403 if the user lacks the required permission.
+
+        Does nothing when ``permission_checker`` is ``None`` (auth disabled).
+        """
+        if self.permission_checker is None:
+            return
+        user = getattr(request.state, "user", None)
+        if user is None:
+            raise HTTPException(status_code=403, detail="Authentication required")
+        codename = f"{action}_{self._model_name_lower}"
+        if not await self.permission_checker.has_permission(user, codename):
+            raise HTTPException(status_code=403, detail="Permission denied")
 
     def _get_template_name(self, view_name: str) -> str:
         model_name = self.model.__name__.lower()
@@ -128,6 +145,7 @@ class DynamicModelView:
         sort_direction: str = Query("asc", pattern="^(asc|desc)$"),
     ):
         """Renders the list view for the model with pagination, sorting, and filtering."""
+        await self._check_permission(request, "view")
 
         # Parse filters from query params
         active_filters: dict[str, str] = {}
@@ -234,6 +252,7 @@ class DynamicModelView:
         Renders the detail view for a single item.
         Assumes the model has an 'id' field.
         """
+        await self._check_permission(request, "view")
         item = await self.adapter.get(pk=item_id)
 
         if not item:
@@ -259,6 +278,7 @@ class DynamicModelView:
         For HTMX requests, only the inner form body is returned to prevent nesting the full page
         into the target container.
         """
+        await self._check_permission(request, "add")
         # Build a Pydantic-backed form abstraction for templates
         # Create forms exclude form_create_exclude fields (e.g. updated_at)
         create_include = self.form_include
@@ -295,6 +315,7 @@ class DynamicModelView:
 
     async def create_view(self, request: Request):
         """Handles form submission for creating a new item."""
+        await self._check_permission(request, "add")
         form_data = await request.form()
         data = dict(form_data)
 
@@ -352,6 +373,7 @@ class DynamicModelView:
         status_code: int = 200,
     ):
         """Renders the update form, optionally pre-filled with submitted values and errors."""
+        await self._check_permission(request, "change")
         item = await self.adapter.get(pk=item_id)
         if not item:
             raise HTTPException(status_code=404, detail="Item not found")
@@ -396,6 +418,7 @@ class DynamicModelView:
 
     async def update_view(self, request: Request, item_id: int):
         """Handles form submission for updating an item."""
+        await self._check_permission(request, "change")
         form_data = await request.form()
         data: dict[str, Any] = dict(form_data)
 
@@ -439,6 +462,7 @@ class DynamicModelView:
 
     async def delete_action(self, request: Request, item_id: int):
         """Deletes an item."""
+        await self._check_permission(request, "delete")
         item = await self.adapter.get(pk=item_id)
         if not item:
             raise HTTPException(status_code=404, detail="Item not found")

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -1,0 +1,205 @@
+"""Tests for auth middleware, login/logout views, and permission sync (A5).
+
+TDD: Verify redirect behavior, login/logout flows, request.state.user,
+permission sync on mount, and backward compatibility.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import SQLModel
+
+from hyperadmin.auth.backend import hash_password
+from hyperadmin.auth.models import Permission, User
+
+
+@pytest.fixture
+async def async_engine(tmp_path):
+    db_file = tmp_path / "test_mw.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_file}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def seed_user(async_engine):
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    async with AsyncSession(async_engine) as session:
+        user = User(
+            username="admin",
+            email="admin@example.com",
+            password_hash=hash_password("password123"),
+            is_superuser=True,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+def _build_auth_app(async_engine, register_models: bool = True):
+    """Build a FastAPI app with HyperAdmin auth wired up."""
+    from fastapi import FastAPI
+    from sqlmodel import Field
+    from sqlmodel import SQLModel as SM
+
+    from hyperadmin.auth.permissions import ModelPermissionChecker, PermissionSyncService
+    from hyperadmin.auth.session import SessionAuthBackend
+    from hyperadmin.core.app import Admin
+
+    app = FastAPI()
+    backend = SessionAuthBackend(engine=async_engine)
+    admin = Admin(
+        app,
+        engine=async_engine,
+        create_tables=False,
+        auth_backend=backend,
+        permission_checker=ModelPermissionChecker(engine=async_engine),
+        permission_registry=PermissionSyncService(engine=async_engine),
+        session_secret="test-secret-key",
+    )
+
+    if register_models:
+        # Register a dummy model for testing
+        class Item(SM, table=True):
+            __tablename__ = "hyperadmin_test_items"  # type: ignore[reportIncompatibleVariableOverride]
+            id: int | None = Field(default=None, primary_key=True)
+            name: str = Field(max_length=100)
+
+        # Create the table
+        import asyncio
+
+        async def create_table():
+            async with async_engine.begin() as conn:
+                await conn.run_sync(SM.metadata.create_all)
+
+        asyncio.get_event_loop().run_until_complete(create_table())
+
+    admin.mount("/admin")
+    return app
+
+
+def _build_no_auth_app(async_engine):
+    """Build a FastAPI app WITHOUT auth (backward compat)."""
+    from fastapi import FastAPI
+
+    from hyperadmin.core.app import Admin
+
+    app = FastAPI()
+    admin = Admin(app, engine=async_engine, create_tables=False)
+    admin.mount("/admin")
+    return app
+
+
+class TestAuthMiddleware:
+    @pytest.mark.anyio
+    async def test_unauthenticated_redirects_to_login(self, async_engine):
+        app = _build_auth_app(async_engine, register_models=False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/admin/", follow_redirects=False)
+            assert resp.status_code == 302
+            assert "/admin/login" in resp.headers["location"]
+
+    @pytest.mark.anyio
+    async def test_login_page_accessible_without_auth(self, async_engine):
+        app = _build_auth_app(async_engine, register_models=False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/admin/login")
+            assert resp.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_login_success_redirects_to_admin(self, async_engine, seed_user):
+        app = _build_auth_app(async_engine, register_models=False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/admin/login",
+                data={"username": "admin", "password": "password123"},
+                follow_redirects=False,
+            )
+            assert resp.status_code == 302
+            assert "/admin/" in resp.headers["location"]
+
+    @pytest.mark.anyio
+    async def test_login_failure_shows_error(self, async_engine, seed_user):
+        app = _build_auth_app(async_engine, register_models=False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/admin/login",
+                data={"username": "admin", "password": "wrong"},
+            )
+            assert resp.status_code == 200
+            assert "Invalid" in resp.text or "invalid" in resp.text
+
+    @pytest.mark.anyio
+    async def test_logout_clears_session(self, async_engine, seed_user):
+        app = _build_auth_app(async_engine, register_models=False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Login first
+            await client.post(
+                "/admin/login",
+                data={"username": "admin", "password": "password123"},
+            )
+            # Logout
+            resp = await client.post("/admin/logout", follow_redirects=False)
+            assert resp.status_code == 302
+            assert "/admin/login" in resp.headers["location"]
+
+            # Verify can't access admin anymore
+            resp = await client.get("/admin/", follow_redirects=False)
+            assert resp.status_code == 302
+
+    @pytest.mark.anyio
+    async def test_authenticated_user_on_request_state(self, async_engine, seed_user):
+        """After login, request.state.user should be populated."""
+        app = _build_auth_app(async_engine, register_models=False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Login
+            await client.post(
+                "/admin/login",
+                data={"username": "admin", "password": "password123"},
+            )
+            # Access dashboard — should be 200 (authenticated)
+            resp = await client.get("/admin/", follow_redirects=False)
+            assert resp.status_code == 200
+
+
+class TestBackwardCompatibility:
+    @pytest.mark.anyio
+    async def test_no_auth_backend_routes_accessible(self, async_engine):
+        """auth_backend=None → all routes publicly accessible."""
+        app = _build_no_auth_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/admin/")
+            assert resp.status_code == 200
+
+
+class TestPermissionSyncOnStartup:
+    @pytest.mark.anyio
+    async def test_permissions_synced_on_mount(self, async_engine):
+        """Permission sync creates DB rows for all registered models on startup."""
+        from sqlalchemy.ext.asyncio import AsyncSession
+
+        app = _build_auth_app(async_engine, register_models=False)
+
+        # Trigger startup
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.get("/admin/login")
+
+        async with AsyncSession(async_engine) as session:
+            from sqlmodel import select
+
+            perms = (await session.execute(select(Permission))).scalars().all()
+            # If no models are registered, sync should still run without error
+            # The exact count depends on registered models
+            assert isinstance(perms, list)

--- a/tests/unit/test_auth_models.py
+++ b/tests/unit/test_auth_models.py
@@ -1,0 +1,326 @@
+"""Tests for auth domain models (A1).
+
+TDD: These tests define the expected behavior for User, Group, Permission,
+and junction table models before implementation.
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlmodel import Session, SQLModel, select
+
+
+@pytest.fixture
+def engine(tmp_path):
+    db_file = tmp_path / "test_auth.db"
+    eng = create_engine(f"sqlite:///{db_file}")
+    SQLModel.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as s:
+        yield s
+
+
+class TestUserModel:
+    def test_user_creation_with_new_fields(self, session: Session):
+        from hyperadmin.auth.models import User
+
+        user = User(
+            username="testuser",
+            email="test@example.com",
+            password_hash="fakehash",
+            first_name="John",
+            last_name="Doe",
+            is_active=True,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        assert user.id is not None
+        assert user.username == "testuser"
+        assert user.first_name == "John"
+        assert user.last_name == "Doe"
+        assert user.is_active is True
+        assert user.is_superuser is False
+        assert user.created_at is not None
+        assert user.updated_at is None
+
+    def test_user_defaults(self, session: Session):
+        from hyperadmin.auth.models import User
+
+        user = User(
+            username="defaults",
+            email="defaults@example.com",
+            password_hash="fakehash",
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        assert user.is_active is True
+        assert user.is_superuser is False
+        assert user.first_name == ""
+        assert user.last_name == ""
+
+    def test_user_table_name(self):
+        from hyperadmin.auth.models import User
+
+        assert User.__tablename__ == "hyperadmin_users"
+
+    def test_user_username_unique(self, session: Session):
+        from sqlalchemy.exc import IntegrityError
+
+        from hyperadmin.auth.models import User
+
+        session.add(User(username="dup", email="a@a.com", password_hash="h"))
+        session.commit()
+        session.add(User(username="dup", email="b@b.com", password_hash="h"))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+class TestGroupModel:
+    def test_group_crud(self, session: Session):
+        from hyperadmin.auth.models import Group
+
+        group = Group(name="Editors", description="Can edit content")
+        session.add(group)
+        session.commit()
+        session.refresh(group)
+
+        assert group.id is not None
+        assert group.name == "Editors"
+        assert group.description == "Can edit content"
+        assert group.is_active is True
+        assert group.created_at is not None
+
+    def test_group_table_name(self):
+        from hyperadmin.auth.models import Group
+
+        assert Group.__tablename__ == "hyperadmin_groups"
+
+    def test_group_name_unique(self, session: Session):
+        from sqlalchemy.exc import IntegrityError
+
+        from hyperadmin.auth.models import Group
+
+        session.add(Group(name="dup"))
+        session.commit()
+        session.add(Group(name="dup"))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+class TestPermissionModel:
+    def test_permission_creation(self, session: Session):
+        from hyperadmin.auth.models import Permission
+
+        perm = Permission(
+            codename="view_user",
+            name="Can view user",
+            content_type="user",
+        )
+        session.add(perm)
+        session.commit()
+        session.refresh(perm)
+
+        assert perm.id is not None
+        assert perm.codename == "view_user"
+        assert perm.name == "Can view user"
+        assert perm.content_type == "user"
+
+    def test_permission_table_name(self):
+        from hyperadmin.auth.models import Permission
+
+        assert Permission.__tablename__ == "hyperadmin_permissions"
+
+    def test_permission_codename_unique(self, session: Session):
+        from sqlalchemy.exc import IntegrityError
+
+        from hyperadmin.auth.models import Permission
+
+        session.add(Permission(codename="view_user", name="Can view user"))
+        session.commit()
+        session.add(Permission(codename="view_user", name="Can view user 2"))
+        with pytest.raises(IntegrityError):
+            session.commit()
+
+
+class TestJunctionTables:
+    def test_user_group_junction(self, session: Session):
+        from hyperadmin.auth.models import Group, User, UserGroup
+
+        user = User(username="jtest", email="j@t.com", password_hash="h")
+        group = Group(name="TestGroup")
+        session.add_all([user, group])
+        session.commit()
+
+        ug = UserGroup(user_id=user.id, group_id=group.id)
+        session.add(ug)
+        session.commit()
+        session.refresh(ug)
+
+        assert ug.id is not None
+        assert ug.user_id == user.id
+        assert ug.group_id == group.id
+
+    def test_user_group_table_name(self):
+        from hyperadmin.auth.models import UserGroup
+
+        assert UserGroup.__tablename__ == "hyperadmin_user_groups"
+
+    def test_user_permission_junction(self, session: Session):
+        from hyperadmin.auth.models import Permission, User, UserPermission
+
+        user = User(username="ptest", email="p@t.com", password_hash="h")
+        perm = Permission(codename="view_user", name="Can view user")
+        session.add_all([user, perm])
+        session.commit()
+
+        up = UserPermission(user_id=user.id, permission_id=perm.id)
+        session.add(up)
+        session.commit()
+        session.refresh(up)
+
+        assert up.id is not None
+        assert up.user_id == user.id
+        assert up.permission_id == perm.id
+
+    def test_user_permission_table_name(self):
+        from hyperadmin.auth.models import UserPermission
+
+        assert UserPermission.__tablename__ == "hyperadmin_user_permissions"
+
+    def test_group_permission_junction(self, session: Session):
+        from hyperadmin.auth.models import Group, GroupPermission, Permission
+
+        group = Group(name="GPTest")
+        perm = Permission(codename="add_user", name="Can add user")
+        session.add_all([group, perm])
+        session.commit()
+
+        gp = GroupPermission(group_id=group.id, permission_id=perm.id)
+        session.add(gp)
+        session.commit()
+        session.refresh(gp)
+
+        assert gp.id is not None
+        assert gp.group_id == group.id
+        assert gp.permission_id == perm.id
+
+    def test_group_permission_table_name(self):
+        from hyperadmin.auth.models import GroupPermission
+
+        assert GroupPermission.__tablename__ == "hyperadmin_group_permissions"
+
+
+class TestRelationshipTraversal:
+    def test_group_to_permissions(self, session: Session):
+        from hyperadmin.auth.models import Group, GroupPermission, Permission
+
+        group = Group(name="Admins")
+        p1 = Permission(codename="view_user", name="Can view user")
+        p2 = Permission(codename="add_user", name="Can add user")
+        session.add_all([group, p1, p2])
+        session.commit()
+
+        session.add_all(
+            [
+                GroupPermission(group_id=group.id, permission_id=p1.id),
+                GroupPermission(group_id=group.id, permission_id=p2.id),
+            ]
+        )
+        session.commit()
+
+        # Refresh to load relationships
+        session.expire_all()
+        group = session.exec(select(Group).where(Group.name == "Admins")).one()
+        perm_codenames = {gp.permission.codename for gp in group.group_permissions}
+        assert perm_codenames == {"view_user", "add_user"}
+
+    def test_user_to_direct_permissions(self, session: Session):
+        from hyperadmin.auth.models import Permission, User, UserPermission
+
+        user = User(username="directperm", email="dp@t.com", password_hash="h")
+        perm = Permission(codename="delete_user", name="Can delete user")
+        session.add_all([user, perm])
+        session.commit()
+
+        session.add(UserPermission(user_id=user.id, permission_id=perm.id))
+        session.commit()
+
+        session.expire_all()
+        user = session.exec(select(User).where(User.username == "directperm")).one()
+        perm_codenames = {up.permission.codename for up in user.user_permissions}
+        assert perm_codenames == {"delete_user"}
+
+    def test_user_to_group_to_permission_chain(self, session: Session):
+        from hyperadmin.auth.models import (
+            Group,
+            GroupPermission,
+            Permission,
+            User,
+            UserGroup,
+        )
+
+        user = User(username="chainuser", email="chain@t.com", password_hash="h")
+        group = Group(name="ChainGroup")
+        perm = Permission(codename="change_user", name="Can change user")
+        session.add_all([user, group, perm])
+        session.commit()
+
+        session.add(UserGroup(user_id=user.id, group_id=group.id))
+        session.add(GroupPermission(group_id=group.id, permission_id=perm.id))
+        session.commit()
+
+        session.expire_all()
+        user = session.exec(select(User).where(User.username == "chainuser")).one()
+
+        # Traverse: user -> user_groups -> group -> group_permissions -> permission
+        inherited_perms: set[str] = set()
+        for ug in user.user_groups:
+            for gp in ug.group.group_permissions:
+                inherited_perms.add(gp.permission.codename)
+
+        assert inherited_perms == {"change_user"}
+
+
+class TestExports:
+    def test_imports_from_auth(self):
+        from hyperadmin.auth import (
+            Group,
+            GroupPermission,
+            Permission,
+            User,
+            UserGroup,
+            UserPermission,
+        )
+
+        assert User is not None
+        assert Group is not None
+        assert Permission is not None
+        assert UserGroup is not None
+        assert UserPermission is not None
+        assert GroupPermission is not None
+
+    def test_no_core_views_adapters_imports(self):
+        """auth/models.py must not import from core/, views/, or adapters/."""
+        import ast
+        from pathlib import Path
+
+        source = Path("src/hyperadmin/auth/models.py").read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert not node.module.startswith("hyperadmin.core"), (
+                    f"Forbidden import: {node.module}"
+                )
+                assert not node.module.startswith("hyperadmin.views"), (
+                    f"Forbidden import: {node.module}"
+                )
+                assert not node.module.startswith("hyperadmin.adapters"), (
+                    f"Forbidden import: {node.module}"
+                )

--- a/tests/unit/test_auth_permissions.py
+++ b/tests/unit/test_auth_permissions.py
@@ -1,0 +1,221 @@
+"""Tests for permission checking and auto-registration (A4).
+
+TDD: Verify permission generation, sync, checking (direct + group-inherited),
+superuser bypass, and custom permissions.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import SQLModel, select
+
+from hyperadmin.auth.backend import hash_password
+from hyperadmin.auth.models import (
+    Group,
+    GroupPermission,
+    Permission,
+    User,
+    UserGroup,
+    UserPermission,
+)
+
+
+@pytest.fixture
+async def async_engine(tmp_path):
+    db_file = tmp_path / "test_perms.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_file}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+def checker(async_engine):
+    from hyperadmin.auth.permissions import ModelPermissionChecker
+
+    return ModelPermissionChecker(engine=async_engine)
+
+
+@pytest.fixture
+def sync_service(async_engine):
+    from hyperadmin.auth.permissions import PermissionSyncService
+
+    return PermissionSyncService(engine=async_engine)
+
+
+@pytest.fixture
+async def superuser(async_engine):
+    async with AsyncSession(async_engine) as session:
+        user = User(
+            username="admin",
+            email="admin@example.com",
+            password_hash=hash_password("password"),
+            is_superuser=True,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+@pytest.fixture
+async def regular_user(async_engine):
+    async with AsyncSession(async_engine) as session:
+        user = User(
+            username="regular",
+            email="regular@example.com",
+            password_hash=hash_password("password"),
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+class TestGenerateDefaultPermissions:
+    def test_generate_default_permissions(self):
+        from hyperadmin.auth.permissions import generate_default_permissions
+
+        perms = generate_default_permissions("order")
+        assert perms == [
+            ("view_order", "Can view order"),
+            ("add_order", "Can add order"),
+            ("change_order", "Can change order"),
+            ("delete_order", "Can delete order"),
+        ]
+
+    def test_generate_default_permissions_lowercases(self):
+        from hyperadmin.auth.permissions import generate_default_permissions
+
+        perms = generate_default_permissions("Order")
+        codenames = [p[0] for p in perms]
+        assert all(c == c.lower() for c in codenames)
+
+
+class TestPermissionSyncService:
+    @pytest.mark.anyio
+    async def test_sync_creates_permissions(self, sync_service, async_engine):
+        """sync_permissions creates default permissions for registered models."""
+
+        class FakeModelAdmin:
+            permissions: list = []
+
+        models = [("user", FakeModelAdmin)]
+        await sync_service.sync_permissions(models)
+
+        async with AsyncSession(async_engine) as session:
+            perms = (await session.execute(select(Permission))).scalars().all()
+            codenames = {p.codename for p in perms}
+            assert codenames == {"view_user", "add_user", "change_user", "delete_user"}
+
+    @pytest.mark.anyio
+    async def test_sync_is_idempotent(self, sync_service, async_engine):
+        """Running sync twice doesn't duplicate rows."""
+
+        class FakeModelAdmin:
+            permissions: list = []
+
+        models = [("user", FakeModelAdmin)]
+        await sync_service.sync_permissions(models)
+        await sync_service.sync_permissions(models)
+
+        async with AsyncSession(async_engine) as session:
+            perms = (await session.execute(select(Permission))).scalars().all()
+            assert len(perms) == 4
+
+    @pytest.mark.anyio
+    async def test_sync_custom_permissions(self, sync_service, async_engine):
+        """Custom permissions from ModelAdmin.permissions are synced."""
+
+        class OrderAdmin:
+            permissions = [
+                ("export_order", "Can export orders"),
+                ("approve_order", "Can approve orders"),
+            ]
+
+        models = [("order", OrderAdmin)]
+        await sync_service.sync_permissions(models)
+
+        async with AsyncSession(async_engine) as session:
+            perms = (await session.execute(select(Permission))).scalars().all()
+            codenames = {p.codename for p in perms}
+            assert "export_order" in codenames
+            assert "approve_order" in codenames
+            # Also has 4 default + 2 custom = 6
+            assert len(perms) == 6
+
+
+class TestModelPermissionChecker:
+    @pytest.mark.anyio
+    async def test_superuser_bypasses_all(self, checker, superuser):
+        result = await checker.has_permission(superuser, "anything")
+        assert result is True
+
+    @pytest.mark.anyio
+    async def test_direct_user_permission_grant(self, checker, regular_user, async_engine):
+        async with AsyncSession(async_engine) as session:
+            perm = Permission(codename="view_user", name="Can view user")
+            session.add(perm)
+            await session.commit()
+            await session.refresh(perm)
+
+            up = UserPermission(user_id=regular_user.id, permission_id=perm.id)
+            session.add(up)
+            await session.commit()
+
+        assert await checker.has_permission(regular_user, "view_user") is True
+
+    @pytest.mark.anyio
+    async def test_permission_denied(self, checker, regular_user):
+        assert await checker.has_permission(regular_user, "view_user") is False
+
+    @pytest.mark.anyio
+    async def test_group_inherited_permission(self, checker, regular_user, async_engine):
+        async with AsyncSession(async_engine) as session:
+            group = Group(name="Editors")
+            perm = Permission(codename="change_article", name="Can change article")
+            session.add_all([group, perm])
+            await session.commit()
+            await session.refresh(group)
+            await session.refresh(perm)
+
+            session.add(UserGroup(user_id=regular_user.id, group_id=group.id))
+            session.add(GroupPermission(group_id=group.id, permission_id=perm.id))
+            await session.commit()
+
+        assert await checker.has_permission(regular_user, "change_article") is True
+
+    @pytest.mark.anyio
+    async def test_get_user_permissions_combined(self, checker, regular_user, async_engine):
+        """get_user_permissions returns union of direct + group-inherited."""
+        async with AsyncSession(async_engine) as session:
+            p1 = Permission(codename="view_user", name="Can view user")
+            p2 = Permission(codename="add_user", name="Can add user")
+            group = Group(name="Writers")
+            session.add_all([p1, p2, group])
+            await session.commit()
+            await session.refresh(p1)
+            await session.refresh(p2)
+            await session.refresh(group)
+
+            # Direct grant
+            session.add(UserPermission(user_id=regular_user.id, permission_id=p1.id))
+            # Group grant
+            session.add(UserGroup(user_id=regular_user.id, group_id=group.id))
+            session.add(GroupPermission(group_id=group.id, permission_id=p2.id))
+            await session.commit()
+
+        perms = await checker.get_user_permissions(regular_user)
+        assert perms == {"view_user", "add_user"}
+
+    @pytest.mark.anyio
+    async def test_satisfies_protocols(self, checker):
+        from hyperadmin.core.auth import PermissionChecker
+
+        assert isinstance(checker, PermissionChecker)
+
+    @pytest.mark.anyio
+    async def test_sync_service_satisfies_protocol(self, sync_service):
+        from hyperadmin.core.auth import PermissionRegistry
+
+        assert isinstance(sync_service, PermissionRegistry)

--- a/tests/unit/test_auth_protocols.py
+++ b/tests/unit/test_auth_protocols.py
@@ -1,0 +1,107 @@
+"""Tests for auth protocols and Admin integration (A2).
+
+TDD: Verify protocol definitions, runtime_checkable, and Admin auth_backend parameter.
+"""
+
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+
+
+class TestProtocolDefinitions:
+    def test_protocols_importable_from_core(self):
+        from hyperadmin.core.auth import (
+            AuthBackend,
+            CurrentUserProvider,
+            PermissionChecker,
+            PermissionRegistry,
+        )
+
+        assert AuthBackend is not None
+        assert CurrentUserProvider is not None
+        assert PermissionChecker is not None
+        assert PermissionRegistry is not None
+
+    def test_auth_backend_is_runtime_checkable(self):
+        from hyperadmin.core.auth import AuthBackend
+
+        class MockBackend:
+            async def authenticate(self, username: str, password: str):
+                return None
+
+            async def login(self, request, user):
+                pass
+
+            async def logout(self, request):
+                pass
+
+        assert isinstance(MockBackend(), AuthBackend)
+
+    def test_permission_checker_is_runtime_checkable(self):
+        from hyperadmin.core.auth import PermissionChecker
+
+        class MockChecker:
+            async def has_permission(self, user, codename: str) -> bool:
+                return True
+
+            async def get_user_permissions(self, user) -> set[str]:
+                return set()
+
+        assert isinstance(MockChecker(), PermissionChecker)
+
+    def test_current_user_provider_is_runtime_checkable(self):
+        from hyperadmin.core.auth import CurrentUserProvider
+
+        class MockProvider:
+            async def get_current_user(self, request):
+                return None
+
+        assert isinstance(MockProvider(), CurrentUserProvider)
+
+    def test_permission_registry_is_runtime_checkable(self):
+        from hyperadmin.core.auth import PermissionRegistry
+
+        class MockRegistry:
+            async def sync_permissions(self, registered_models: list) -> None:
+                pass
+
+        assert isinstance(MockRegistry(), PermissionRegistry)
+
+    def test_non_conforming_class_not_instance(self):
+        from hyperadmin.core.auth import AuthBackend
+
+        class NotABackend:
+            pass
+
+        assert not isinstance(NotABackend(), AuthBackend)
+
+
+class TestAdminAuthBackend:
+    def test_admin_without_auth_backend(self):
+        """Admin(app) still works without auth (backward compatible)."""
+        from hyperadmin.core.app import Admin
+
+        app = FastAPI()
+        admin = Admin(app, create_tables=False)
+        assert admin.auth_backend is None
+
+    def test_admin_with_auth_backend(self):
+        """Admin(app, auth_backend=backend) stores the backend."""
+        from hyperadmin.core.app import Admin
+
+        app = FastAPI()
+        mock_backend = AsyncMock()
+        admin = Admin(app, create_tables=False, auth_backend=mock_backend)
+        assert admin.auth_backend is mock_backend
+
+    def test_no_circular_imports(self):
+        """python -c 'import hyperadmin' must succeed."""
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-c", "import hyperadmin"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"Import failed: {result.stderr}"

--- a/tests/unit/test_auth_session.py
+++ b/tests/unit/test_auth_session.py
@@ -1,0 +1,139 @@
+"""Tests for session-based auth service (A3).
+
+TDD: Verify authenticate, login, logout, get_current_user.
+"""
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import SQLModel
+
+from hyperadmin.auth.backend import hash_password
+from hyperadmin.auth.models import User
+
+
+@pytest.fixture
+async def async_engine(tmp_path):
+    db_file = tmp_path / "test_session.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_file}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def seed_user(async_engine):
+    """Create a test user in the database."""
+    async with AsyncSession(async_engine) as session:
+        user = User(
+            username="testuser",
+            email="test@example.com",
+            password_hash=hash_password("correctpassword"),
+            is_active=True,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+@pytest.fixture
+def backend(async_engine):
+    from hyperadmin.auth.session import SessionAuthBackend
+
+    return SessionAuthBackend(engine=async_engine)
+
+
+class FakeRequest:
+    """Minimal request mock with session dict."""
+
+    def __init__(self, session_data: dict | None = None):
+        self.session: dict = session_data or {}
+
+
+class TestSessionAuthBackend:
+    @pytest.mark.anyio
+    async def test_authenticate_success(self, backend, seed_user):
+        user = await backend.authenticate("testuser", "correctpassword")
+        assert user is not None
+        assert user.username == "testuser"
+
+    @pytest.mark.anyio
+    async def test_authenticate_wrong_password(self, backend, seed_user):
+        user = await backend.authenticate("testuser", "wrongpassword")
+        assert user is None
+
+    @pytest.mark.anyio
+    async def test_authenticate_nonexistent_user(self, backend, seed_user):
+        user = await backend.authenticate("nouser", "anything")
+        assert user is None
+
+    @pytest.mark.anyio
+    async def test_authenticate_inactive_user(self, async_engine):
+        from hyperadmin.auth.session import SessionAuthBackend
+
+        async with AsyncSession(async_engine) as session:
+            user = User(
+                username="inactive",
+                email="inactive@example.com",
+                password_hash=hash_password("password123"),
+                is_active=False,
+            )
+            session.add(user)
+            await session.commit()
+
+        backend = SessionAuthBackend(engine=async_engine)
+        result = await backend.authenticate("inactive", "password123")
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_login_sets_session(self, backend, seed_user):
+        request = FakeRequest()
+        await backend.login(request, seed_user)
+        assert request.session["user_id"] == seed_user.id
+
+    @pytest.mark.anyio
+    async def test_logout_clears_session(self, backend, seed_user):
+        request = FakeRequest({"user_id": seed_user.id})
+        await backend.logout(request)
+        assert "user_id" not in request.session
+
+    @pytest.mark.anyio
+    async def test_get_current_user_valid(self, backend, seed_user):
+        request = FakeRequest({"user_id": seed_user.id})
+        user = await backend.get_current_user(request)
+        assert user is not None
+        assert user.username == "testuser"
+
+    @pytest.mark.anyio
+    async def test_get_current_user_no_session(self, backend):
+        request = FakeRequest()
+        user = await backend.get_current_user(request)
+        assert user is None
+
+    @pytest.mark.anyio
+    async def test_get_current_user_invalid_id(self, backend, seed_user):
+        request = FakeRequest({"user_id": 99999})
+        user = await backend.get_current_user(request)
+        assert user is None
+
+    @pytest.mark.anyio
+    async def test_satisfies_auth_backend_protocol(self, backend):
+        from hyperadmin.core.auth import AuthBackend, CurrentUserProvider
+
+        assert isinstance(backend, AuthBackend)
+        assert isinstance(backend, CurrentUserProvider)
+
+    @pytest.mark.anyio
+    async def test_no_views_import(self):
+        """session.py must not import from views/."""
+        import ast
+        from pathlib import Path
+
+        source = Path("src/hyperadmin/auth/session.py").read_text()
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                assert not node.module.startswith("hyperadmin.views"), (
+                    f"Forbidden import: {node.module}"
+                )

--- a/tests/unit/test_auth_views.py
+++ b/tests/unit/test_auth_views.py
@@ -1,0 +1,190 @@
+"""Tests for authorization checks in CRUD views (A7).
+
+TDD: Verify permission gates on list/create/update/delete views,
+superuser bypass, and backward compat with auth_backend=None.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.auth.backend import hash_password
+from hyperadmin.auth.models import Permission, User, UserPermission
+
+
+@pytest.fixture
+async def async_engine(tmp_path):
+    db_file = tmp_path / "test_authz.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_file}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+class Article(SQLModel, table=True):
+    __tablename__ = "hyperadmin_test_articles"  # type: ignore[reportIncompatibleVariableOverride]
+    id: int | None = Field(default=None, primary_key=True)
+    title: str = Field(max_length=200)
+
+
+@pytest.fixture
+async def superuser(async_engine):
+    async with AsyncSession(async_engine) as session:
+        user = User(
+            username="superadmin",
+            email="super@example.com",
+            password_hash=hash_password("password123"),
+            is_superuser=True,
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+@pytest.fixture
+async def regular_user(async_engine):
+    async with AsyncSession(async_engine) as session:
+        user = User(
+            username="regular",
+            email="regular@example.com",
+            password_hash=hash_password("password123"),
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+@pytest.fixture
+async def user_with_view_perm(async_engine):
+    async with AsyncSession(async_engine) as session:
+        user = User(
+            username="viewer",
+            email="viewer@example.com",
+            password_hash=hash_password("password123"),
+        )
+        perm = Permission(codename="view_article", name="Can view article")
+        session.add_all([user, perm])
+        await session.commit()
+        await session.refresh(user)
+        await session.refresh(perm)
+
+        session.add(UserPermission(user_id=user.id, permission_id=perm.id))
+        await session.commit()
+        return user
+
+
+def _build_app(async_engine, with_auth: bool = True):
+    """Build a FastAPI app with Article registered, optionally with auth."""
+    from fastapi import FastAPI
+
+    from hyperadmin.auth.permissions import ModelPermissionChecker, PermissionSyncService
+    from hyperadmin.auth.session import SessionAuthBackend
+    from hyperadmin.core.app import Admin
+    from hyperadmin.core.registry import site
+
+    # Clear registry to avoid conflicts
+    site._registry.clear()
+
+    app = FastAPI()
+
+    if with_auth:
+        backend = SessionAuthBackend(engine=async_engine)
+        admin = Admin(
+            app,
+            engine=async_engine,
+            create_tables=False,
+            auth_backend=backend,
+            permission_checker=ModelPermissionChecker(engine=async_engine),
+            permission_registry=PermissionSyncService(engine=async_engine),
+            session_secret="test-secret",
+        )
+    else:
+        admin = Admin(app, engine=async_engine, create_tables=False)
+
+    from hyperadmin.core.model import ModelAdmin
+
+    site.register(Article, admin_class=ModelAdmin)
+    admin.mount("/admin")
+    return app
+
+
+async def _login(client: AsyncClient, username: str, password: str = "password123"):
+    """Helper to login and get authenticated session."""
+    await client.post("/admin/login", data={"username": username, "password": password})
+
+
+class TestSuperuserAccess:
+    @pytest.mark.anyio
+    async def test_superuser_can_list(self, async_engine, superuser):
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await _login(client, "superadmin")
+            resp = await client.get("/admin/article", follow_redirects=False)
+            assert resp.status_code == 200
+
+    @pytest.mark.anyio
+    async def test_superuser_can_access_create_form(self, async_engine, superuser):
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await _login(client, "superadmin")
+            resp = await client.get("/admin/article/create", follow_redirects=False)
+            assert resp.status_code == 200
+
+
+class TestPermissionDenied:
+    @pytest.mark.anyio
+    async def test_user_without_view_perm_gets_403(self, async_engine, regular_user):
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await _login(client, "regular")
+            resp = await client.get("/admin/article", follow_redirects=False)
+            assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_user_with_view_but_not_change_gets_403_on_edit(
+        self, async_engine, user_with_view_perm
+    ):
+        app = _build_app(async_engine)
+
+        # Create an article first
+        async with AsyncSession(async_engine) as session:
+            article = Article(title="Test Article")
+            session.add(article)
+            await session.commit()
+            await session.refresh(article)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await _login(client, "viewer")
+            resp = await client.get(f"/admin/article/{article.id}/edit", follow_redirects=False)
+            assert resp.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_user_with_view_can_list(self, async_engine, user_with_view_perm):
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await _login(client, "viewer")
+            resp = await client.get("/admin/article", follow_redirects=False)
+            assert resp.status_code == 200
+
+
+class TestBackwardCompat:
+    @pytest.mark.anyio
+    async def test_no_auth_all_views_accessible(self, async_engine):
+        """auth_backend=None → all views accessible without permissions."""
+        app = _build_app(async_engine, with_auth=False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/admin/article")
+            assert resp.status_code == 200
+
+            resp = await client.get("/admin/article/create")
+            assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Implements the full authorization and user management stack (Epic 1.5) following strict bottom-up TDD ordering. Replaces issues #115, #116, #117, #119 with 7 properly layered issues implemented in one PR.

### What's included

- **A1 — Domain models**: Extended `User` with `is_active`, `first_name`, `last_name`, `created_at`, `updated_at`; added `Group`, `Permission`, `UserGroup`, `UserPermission`, `GroupPermission` with `hyperadmin_` table prefix
- **A2 — Auth protocols**: `AuthBackend`, `PermissionChecker`, `CurrentUserProvider`, `PermissionRegistry` in `core/auth.py`; optional `auth_backend` param on `Admin`
- **A3 — Session auth service**: `SessionAuthBackend` — authenticate, login, logout, get_current_user; inactive-user block
- **A4 — Permission service**: `ModelPermissionChecker` (superuser bypass, direct + group-inherited grants); `PermissionSyncService` auto-generates `view/add/change/delete_{model}` + custom permissions, idempotent
- **A5 — Middleware & endpoints**: `AuthenticationMiddleware`, login/logout views, `SessionMiddleware`; permission sync on startup via `router.on_startup`
- **A6 — Templates**: standalone `login.html`; auth-aware `_navbar.html` (username + logout); `_sidebar.html` conditional rendering
- **A7 — CRUD authorization**: `_check_permission()` in `DynamicModelView` gates all CRUD actions; threaded through routing

### Backward compatibility

`Admin(app)` without `auth_backend` — zero middleware added, all routes public, full regression-free.

## Test plan

- [x] 222 unit tests pass, 0 failures
- [x] 0 warnings from all new auth test files
- [x] All pre-commit hooks pass (ruff, mypy, basedpyright, commitizen)
- [x] `python -c "import hyperadmin"` — no circular imports
- [x] `Admin(app)` without auth_backend — full backward compatibility verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)