### PR TITLE
Define ChoicesProvider protocol and SelectFieldMeta

### DIFF
--- a/src/hyperadmin/core/__init__.py
+++ b/src/hyperadmin/core/__init__.py
@@ -1,1 +1,5 @@
 """Core components for HyperAdmin."""
+
+from .choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
+
+__all__ = ["ChoiceItem", "ChoicesProvider", "SelectFieldMeta"]

--- a/src/hyperadmin/core/choices.py
+++ b/src/hyperadmin/core/choices.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Protocol, TypedDict
+
+
+class ChoiceItem(TypedDict):
+    """A single choice for a select field."""
+
+    value: str
+    label: str
+    selected: bool
+
+
+class ChoicesProvider(Protocol):
+    """Protocol for providing choices to a field."""
+
+    async def get_choices(
+        self,
+        field: str,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+        **filters: Any,
+    ) -> list[ChoiceItem]:
+        """Retrieves a list of choices based on the provided parameters."""
+        ...
+
+
+@dataclass
+class SelectFieldMeta:
+    """Metadata for a select field to hint the widget layer."""
+
+    choices_source: Literal["enum", "static", "relation"]
+    preload: bool = True
+    multiple: bool = False
+    searchable: bool = False
+    dependent_on: str | None = None

--- a/tests/unit/test_core_choices.py
+++ b/tests/unit/test_core_choices.py
@@ -1,0 +1,56 @@
+from typing import Any
+
+import pytest
+
+from hyperadmin.core.choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
+
+
+def test_choice_item_shape():
+    item: ChoiceItem = {"value": "1", "label": "One", "selected": False}
+    assert item["value"] == "1"
+    assert item["label"] == "One"
+    assert item["selected"] is False
+
+
+def test_select_field_meta_defaults():
+    meta = SelectFieldMeta(choices_source="enum")
+    assert meta.choices_source == "enum"
+    assert meta.preload is True
+    assert meta.multiple is False
+    assert meta.searchable is False
+    assert meta.dependent_on is None
+
+
+def test_select_field_meta_custom():
+    meta = SelectFieldMeta(
+        choices_source="relation",
+        preload=False,
+        multiple=True,
+        searchable=True,
+        dependent_on="other_field",
+    )
+    assert meta.choices_source == "relation"
+    assert meta.preload is False
+    assert meta.multiple is True
+    assert meta.searchable is True
+    assert meta.dependent_on == "other_field"
+
+
+class MockChoicesProvider:
+    async def get_choices(
+        self,
+        field: str,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+        **filters: Any,
+    ) -> list[ChoiceItem]:
+        return [{"value": "mock", "label": "Mock", "selected": False}]
+
+
+@pytest.mark.anyio
+async def test_choices_provider_protocol():
+    provider: ChoicesProvider = MockChoicesProvider()
+    choices = await provider.get_choices("test_field")
+    assert len(choices) == 1
+    assert choices[0]["value"] == "mock"


### PR DESCRIPTION
This PR introduces the core types for handling field choices in HyperAdmin. It defines the `ChoicesProvider` protocol, which describes how choices are retrieved (e.g., from enums, static lists, or related models), and the `SelectFieldMeta` dataclass, which provides hints to the UI layer (e.g., whether to preload choices or use HTMX for lazy loading). These types are essential for upcoming work on related fields and select widgets.

Fixes #160

---
*PR created automatically by Jules for task [9464521778754892539](https://jules.google.com/task/9464521778754892539) started by @yevheniidehtiar*