### PR TITLE
Add FieldsetSpec and fieldsets to AdminOptions

### DIFF
--- a/src/hyperadmin/core/__init__.py
+++ b/src/hyperadmin/core/__init__.py
@@ -1,5 +1,6 @@
 """Core components for HyperAdmin."""
 
 from .choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
+from .options import AdminOptions, FieldsetSpec
 
-__all__ = ["ChoiceItem", "ChoicesProvider", "SelectFieldMeta"]
+__all__ = ["AdminOptions", "ChoiceItem", "ChoicesProvider", "FieldsetSpec", "SelectFieldMeta"]

--- a/src/hyperadmin/core/options.py
+++ b/src/hyperadmin/core/options.py
@@ -1,4 +1,18 @@
+from dataclasses import dataclass
+
 from pydantic import BaseModel
+
+
+@dataclass
+class FieldsetSpec:
+    """Configuration for a group of fields in the form view."""
+
+    title: str
+    """The title of the fieldset."""
+    fields: list[str]
+    """List of field names to include in this fieldset."""
+    collapsible: bool = False
+    """Whether the fieldset can be collapsed in the UI."""
 
 
 class AdminOptions(BaseModel):
@@ -28,3 +42,5 @@ class AdminOptions(BaseModel):
     """Whether the Detail view and GET (single item) endpoint are generated."""
     list_filter: list[str] = []
     """List of field names to show in the filter bar."""
+    fieldsets: list[FieldsetSpec] | None = None
+    """Optional list of fieldsets to organize fields in Create/Edit/Detail views."""


### PR DESCRIPTION
This change introduces the `FieldsetSpec` dataclass and updates `AdminOptions` to support organizing fields into fieldsets. This is a core part of enhancing form layouts in HyperAdmin.

Changes:
1. `src/hyperadmin/core/options.py`:
   - Added `FieldsetSpec` dataclass with `title`, `fields`, and `collapsible` attributes.
   - Added `fieldsets` field to `AdminOptions` Pydantic model.
2. `src/hyperadmin/core/__init__.py`:
   - Exported `FieldsetSpec` and `AdminOptions`.
3. Verified compliance with architectural boundaries (no imports from `views/` or `adapters/` in `core/`).
4. Ensured `mypy` (via `basedpyright`) and unit tests pass.

Fixes #188

---
*PR created automatically by Jules for task [16157275773743599620](https://jules.google.com/task/16157275773743599620) started by @yevheniidehtiar*