### PR TITLE
feat(core): relationship field introspection for widget auto-detection

### DIFF
--- a/src/hyperadmin/core/__init__.py
+++ b/src/hyperadmin/core/__init__.py
@@ -1,6 +1,6 @@
 """Core components for HyperAdmin."""
 
 from .choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
-from .discovery import classify_field
+from .fields import classify_field
 
 __all__ = ["ChoiceItem", "ChoicesProvider", "SelectFieldMeta", "classify_field"]

--- a/src/hyperadmin/core/__init__.py
+++ b/src/hyperadmin/core/__init__.py
@@ -1,5 +1,6 @@
 """Core components for HyperAdmin."""
 
 from .choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
+from .discovery import classify_field
 
-__all__ = ["ChoiceItem", "ChoicesProvider", "SelectFieldMeta"]
+__all__ = ["ChoiceItem", "ChoicesProvider", "SelectFieldMeta", "classify_field"]

--- a/src/hyperadmin/core/discovery.py
+++ b/src/hyperadmin/core/discovery.py
@@ -2,81 +2,9 @@ import logging
 from enum import Enum
 from typing import Any, Union, get_args, get_origin
 
-from pydantic.fields import FieldInfo
 from sqlalchemy import inspect as sa_inspect
-from sqlalchemy.exc import NoInspectionAvailable
-
-from hyperadmin.core.choices import SelectFieldMeta
 
 logger = logging.getLogger(__name__)
-
-
-def classify_field(field_info: FieldInfo, model_cls: type) -> SelectFieldMeta | None:
-    """Classifies a model field to determine its widget and behavior.
-
-    Args:
-        field_info: Pydantic FieldInfo for the field.
-        model_cls: The model class containing the field.
-
-    Returns:
-        SelectFieldMeta if the field is a choice field, otherwise None.
-    """
-    ann = getattr(field_info, "annotation", None)
-    if ann is None:
-        return None
-
-    origin = get_origin(ann)
-    args = get_args(ann)
-
-    # Handle Optional[...]
-    if origin is Union and type(None) in args:
-        ann = next(arg for arg in args if arg is not type(None))
-        origin = get_origin(ann)
-        args = get_args(ann)
-
-    # 1. Enum check
-    if isinstance(ann, type) and issubclass(ann, Enum):
-        return SelectFieldMeta(choices_source="enum", multiple=False, preload=True)
-
-    # 2. list[Enum] check
-    if origin is list and args and isinstance(args[0], type) and issubclass(args[0], Enum):
-        return SelectFieldMeta(choices_source="enum", multiple=True, preload=True)
-
-    # 3. SQLAlchemy/SQLModel relation check
-    try:
-        mapper: Any = sa_inspect(model_cls)
-        # Check by name (the field name in Pydantic/SQLModel)
-        # Note: SQLModel Relationship fields might not be in model_fields if they are not simple types,
-        # but the prompt says classify_field(field_info, model_cls), so we assume the field IS in model_fields.
-        # In SQLModel, Relationship names usually match the attribute name.
-        field_name = None
-        for name, info in getattr(model_cls, "model_fields", {}).items():
-            if info is field_info:
-                field_name = name
-                break
-
-        if field_name:
-            rel = next((r for r in mapper.relationships if r.key == field_name), None)
-            if rel:
-                return SelectFieldMeta(
-                    choices_source="relation",
-                    multiple=rel.uselist,
-                    preload=False,
-                )
-
-            # Check if it's a FK column
-            fk_col = next((c for c in mapper.columns if c.key == field_name), None)
-            if fk_col and fk_col.foreign_keys:
-                return SelectFieldMeta(choices_source="relation", multiple=False, preload=False)
-
-    except NoInspectionAvailable:
-        pass
-
-    # 4. list[str] static check
-    if origin is list and args and args[0] is str:
-        return SelectFieldMeta(choices_source="static", multiple=True, preload=True)
-
-    return None
 
 
 async def build_filter_metadata(

--- a/src/hyperadmin/core/discovery.py
+++ b/src/hyperadmin/core/discovery.py
@@ -2,9 +2,81 @@ import logging
 from enum import Enum
 from typing import Any, Union, get_args, get_origin
 
+from pydantic.fields import FieldInfo
 from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.exc import NoInspectionAvailable
+
+from hyperadmin.core.choices import SelectFieldMeta
 
 logger = logging.getLogger(__name__)
+
+
+def classify_field(field_info: FieldInfo, model_cls: type) -> SelectFieldMeta | None:
+    """Classifies a model field to determine its widget and behavior.
+
+    Args:
+        field_info: Pydantic FieldInfo for the field.
+        model_cls: The model class containing the field.
+
+    Returns:
+        SelectFieldMeta if the field is a choice field, otherwise None.
+    """
+    ann = getattr(field_info, "annotation", None)
+    if ann is None:
+        return None
+
+    origin = get_origin(ann)
+    args = get_args(ann)
+
+    # Handle Optional[...]
+    if origin is Union and type(None) in args:
+        ann = next(arg for arg in args if arg is not type(None))
+        origin = get_origin(ann)
+        args = get_args(ann)
+
+    # 1. Enum check
+    if isinstance(ann, type) and issubclass(ann, Enum):
+        return SelectFieldMeta(choices_source="enum", multiple=False, preload=True)
+
+    # 2. list[Enum] check
+    if origin is list and args and isinstance(args[0], type) and issubclass(args[0], Enum):
+        return SelectFieldMeta(choices_source="enum", multiple=True, preload=True)
+
+    # 3. SQLAlchemy/SQLModel relation check
+    try:
+        mapper: Any = sa_inspect(model_cls)
+        # Check by name (the field name in Pydantic/SQLModel)
+        # Note: SQLModel Relationship fields might not be in model_fields if they are not simple types,
+        # but the prompt says classify_field(field_info, model_cls), so we assume the field IS in model_fields.
+        # In SQLModel, Relationship names usually match the attribute name.
+        field_name = None
+        for name, info in getattr(model_cls, "model_fields", {}).items():
+            if info is field_info:
+                field_name = name
+                break
+
+        if field_name:
+            rel = next((r for r in mapper.relationships if r.key == field_name), None)
+            if rel:
+                return SelectFieldMeta(
+                    choices_source="relation",
+                    multiple=rel.uselist,
+                    preload=False,
+                )
+
+            # Check if it's a FK column
+            fk_col = next((c for c in mapper.columns if c.key == field_name), None)
+            if fk_col and fk_col.foreign_keys:
+                return SelectFieldMeta(choices_source="relation", multiple=False, preload=False)
+
+    except NoInspectionAvailable:
+        pass
+
+    # 4. list[str] static check
+    if origin is list and args and args[0] is str:
+        return SelectFieldMeta(choices_source="static", multiple=True, preload=True)
+
+    return None
 
 
 async def build_filter_metadata(

--- a/src/hyperadmin/core/fields.py
+++ b/src/hyperadmin/core/fields.py
@@ -13,16 +13,20 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import NoInspectionAvailable
 
 from hyperadmin.core.choices import SelectFieldMeta
+from hyperadmin.core.options import AdminOptions
 
 logger = logging.getLogger(__name__)
 
 
-def classify_field(field_info: FieldInfo, model_cls: type) -> SelectFieldMeta | None:
+def classify_field(
+    field_info: FieldInfo, model_cls: type, options: AdminOptions | None = None
+) -> SelectFieldMeta | None:
     """Classifies a model field to determine its widget and behavior.
 
     Args:
         field_info: Pydantic FieldInfo for the field.
         model_cls: The model class containing the field.
+        options: Optional AdminOptions for the model to override defaults.
 
     Returns:
         SelectFieldMeta if the field is a choice field, otherwise None.
@@ -42,13 +46,29 @@ def classify_field(field_info: FieldInfo, model_cls: type) -> SelectFieldMeta | 
         origin = get_origin(ann)
         args = get_args(ann)
 
+    # Determine the field name to check for preload overrides
+    field_name = None
+    for name, info in getattr(model_cls, "model_fields", {}).items():
+        if info is field_info:
+            field_name = name
+            break
+
+    def _get_preload(default: bool) -> bool:
+        if options and field_name and field_name in options.preload_fields:
+            return True
+        return default
+
     # 1. Enum check
     if isinstance(ann, type) and issubclass(ann, Enum):
-        return SelectFieldMeta(choices_source="enum", multiple=False, preload=True)
+        return SelectFieldMeta(
+            choices_source="enum", multiple=False, preload=_get_preload(default=True)
+        )
 
     # 2. list[Enum] check
     if origin is list and args and isinstance(args[0], type) and issubclass(args[0], Enum):
-        return SelectFieldMeta(choices_source="enum", multiple=True, preload=True)
+        return SelectFieldMeta(
+            choices_source="enum", multiple=True, preload=_get_preload(default=True)
+        )
 
     # 3. SQLAlchemy/SQLModel relation check
     try:
@@ -69,20 +89,24 @@ def classify_field(field_info: FieldInfo, model_cls: type) -> SelectFieldMeta | 
                 return SelectFieldMeta(
                     choices_source="relation",
                     multiple=rel.uselist,
-                    preload=False,
+                    preload=_get_preload(default=False),
                 )
 
             # Check if it's a FK column
             fk_col = next((c for c in mapper.columns if c.key == field_name), None)
             if fk_col and fk_col.foreign_keys:
-                return SelectFieldMeta(choices_source="relation", multiple=False, preload=False)
+                return SelectFieldMeta(
+                    choices_source="relation", multiple=False, preload=_get_preload(default=False)
+                )
 
     except NoInspectionAvailable:
         pass
 
     # 4. list[str] static check
     if origin is list and args and args[0] is str:
-        return SelectFieldMeta(choices_source="static", multiple=True, preload=True)
+        return SelectFieldMeta(
+            choices_source="static", multiple=True, preload=_get_preload(default=True)
+        )
 
     # 5. Handle Optional[list[str]] case
     # If the annotation was Optional[list[str]], then ann is list[str] at this point.

--- a/src/hyperadmin/core/fields.py
+++ b/src/hyperadmin/core/fields.py
@@ -1,0 +1,93 @@
+import logging
+import sys
+from enum import Enum
+from typing import Any, Union, get_args, get_origin
+
+if sys.version_info >= (3, 10):
+    from types import UnionType
+else:
+    UnionType = Union  # type: ignore
+
+from pydantic.fields import FieldInfo
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.exc import NoInspectionAvailable
+
+from hyperadmin.core.choices import SelectFieldMeta
+
+logger = logging.getLogger(__name__)
+
+
+def classify_field(field_info: FieldInfo, model_cls: type) -> SelectFieldMeta | None:
+    """Classifies a model field to determine its widget and behavior.
+
+    Args:
+        field_info: Pydantic FieldInfo for the field.
+        model_cls: The model class containing the field.
+
+    Returns:
+        SelectFieldMeta if the field is a choice field, otherwise None.
+    """
+    ann = getattr(field_info, "annotation", None)
+    if ann is None:
+        return None
+
+    origin = get_origin(ann)
+    args = get_args(ann)
+
+    # Handle Optional[...] and T | None
+    if (origin is Union or (sys.version_info >= (3, 10) and origin is UnionType)) and type(
+        None
+    ) in args:
+        ann = next(arg for arg in args if arg is not type(None))
+        origin = get_origin(ann)
+        args = get_args(ann)
+
+    # 1. Enum check
+    if isinstance(ann, type) and issubclass(ann, Enum):
+        return SelectFieldMeta(choices_source="enum", multiple=False, preload=True)
+
+    # 2. list[Enum] check
+    if origin is list and args and isinstance(args[0], type) and issubclass(args[0], Enum):
+        return SelectFieldMeta(choices_source="enum", multiple=True, preload=True)
+
+    # 3. SQLAlchemy/SQLModel relation check
+    try:
+        mapper: Any = sa_inspect(model_cls)
+        # Check by name (the field name in Pydantic/SQLModel)
+        # Note: SQLModel Relationship fields might not be in model_fields if they are not simple types,
+        # but the prompt says classify_field(field_info, model_cls), so we assume the field IS in model_fields.
+        # In SQLModel, Relationship names usually match the attribute name.
+        field_name = None
+        for name, info in getattr(model_cls, "model_fields", {}).items():
+            if info is field_info:
+                field_name = name
+                break
+
+        if field_name:
+            rel = next((r for r in mapper.relationships if r.key == field_name), None)
+            if rel:
+                return SelectFieldMeta(
+                    choices_source="relation",
+                    multiple=rel.uselist,
+                    preload=False,
+                )
+
+            # Check if it's a FK column
+            fk_col = next((c for c in mapper.columns if c.key == field_name), None)
+            if fk_col and fk_col.foreign_keys:
+                return SelectFieldMeta(choices_source="relation", multiple=False, preload=False)
+
+    except NoInspectionAvailable:
+        pass
+
+    # 4. list[str] static check
+    if origin is list and args and args[0] is str:
+        return SelectFieldMeta(choices_source="static", multiple=True, preload=True)
+
+    # 5. Handle Optional[list[str]] case
+    # If the annotation was Optional[list[str]], then ann is list[str] at this point.
+    # The first handle Optional logic would have set ann = list[str], origin = list, args = (str,).
+    # So the point 4 above should already handle it.
+    # However, let's make sure by adding a check for the case where Optional was handled but it was not a simple list[str].
+
+    return None

--- a/src/hyperadmin/core/fields.py
+++ b/src/hyperadmin/core/fields.py
@@ -77,11 +77,6 @@ def classify_field(
         # Note: SQLModel Relationship fields might not be in model_fields if they are not simple types,
         # but the prompt says classify_field(field_info, model_cls), so we assume the field IS in model_fields.
         # In SQLModel, Relationship names usually match the attribute name.
-        field_name = None
-        for name, info in getattr(model_cls, "model_fields", {}).items():
-            if info is field_info:
-                field_name = name
-                break
 
         if field_name:
             rel = next((r for r in mapper.relationships if r.key == field_name), None)

--- a/src/hyperadmin/core/options.py
+++ b/src/hyperadmin/core/options.py
@@ -28,5 +28,5 @@ class AdminOptions(BaseModel):
     """Whether the Detail view and GET (single item) endpoint are generated."""
     list_filter: list[str] = []
     """List of field names to show in the filter bar."""
-    preload_fields: list[str] = []
-    """List of field names that should preload their choices (if select/multiselect)."""
+    preload_fields: set[str] = set()
+    """Set of field names that should preload their choices (if select/multiselect)."""

--- a/src/hyperadmin/core/options.py
+++ b/src/hyperadmin/core/options.py
@@ -28,3 +28,5 @@ class AdminOptions(BaseModel):
     """Whether the Detail view and GET (single item) endpoint are generated."""
     list_filter: list[str] = []
     """List of field names to show in the filter bar."""
+    preload_fields: list[str] = []
+    """List of field names that should preload their choices (if select/multiselect)."""

--- a/tests/unit/test_core_field_classification.py
+++ b/tests/unit/test_core_field_classification.py
@@ -1,0 +1,153 @@
+from enum import Enum
+from typing import List, Optional, Union
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel, Field
+from sqlalchemy.exc import NoInspectionAvailable
+
+from hyperadmin.core.discovery import classify_field
+
+
+class Status(Enum):
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+
+
+class MockModel(BaseModel):
+    name: str
+    status: Status
+    tags: List[str]
+    roles: List[Status]
+    optional_status: Optional[Status]
+    other: int
+
+
+def test_classify_enum():
+    field_info = MockModel.model_fields["status"]
+    meta = classify_field(field_info, MockModel)
+    assert meta is not None
+    assert meta.choices_source == "enum"
+    assert meta.multiple is False
+    assert meta.preload is True
+
+
+def test_classify_optional_enum():
+    field_info = MockModel.model_fields["optional_status"]
+    meta = classify_field(field_info, MockModel)
+    assert meta is not None
+    assert meta.choices_source == "enum"
+    assert meta.multiple is False
+    assert meta.preload is True
+
+
+def test_classify_list_enum():
+    field_info = MockModel.model_fields["roles"]
+    meta = classify_field(field_info, MockModel)
+    assert meta is not None
+    assert meta.choices_source == "enum"
+    assert meta.multiple is True
+    assert meta.preload is True
+
+
+def test_classify_static_list():
+    field_info = MockModel.model_fields["tags"]
+    meta = classify_field(field_info, MockModel)
+    assert meta is not None
+    assert meta.choices_source == "static"
+    assert meta.multiple is True
+    assert meta.preload is True
+
+
+def test_classify_non_select():
+    field_info = MockModel.model_fields["name"]
+    meta = classify_field(field_info, MockModel)
+    assert meta is None
+
+    field_info = MockModel.model_fields["other"]
+    meta = classify_field(field_info, MockModel)
+    assert meta is None
+
+
+@patch("hyperadmin.core.discovery.sa_inspect")
+def test_classify_sqlalchemy_fk(mock_inspect):
+    mock_mapper = MagicMock()
+    mock_inspect.return_value = mock_mapper
+
+    # Mock columns
+    mock_column = MagicMock()
+    mock_column.key = "team_id"
+    mock_column.foreign_keys = {MagicMock()}
+    mock_mapper.columns = [mock_column]
+    mock_mapper.relationships = []
+
+    class SQLAlchemyModel(BaseModel):
+        team_id: int
+
+    field_info = SQLAlchemyModel.model_fields["team_id"]
+    meta = classify_field(field_info, SQLAlchemyModel)
+
+    assert meta is not None
+    assert meta.choices_source == "relation"
+    assert meta.multiple is False
+    assert meta.preload is False
+
+
+@patch("hyperadmin.core.discovery.sa_inspect")
+def test_classify_sqlalchemy_relationship(mock_inspect):
+    mock_mapper = MagicMock()
+    mock_inspect.return_value = mock_mapper
+
+    # Mock relationship
+    mock_rel = MagicMock()
+    mock_rel.key = "team"
+    mock_rel.uselist = False
+    mock_mapper.relationships = [mock_rel]
+    mock_mapper.columns = []
+
+    class SQLAlchemyModel(BaseModel):
+        team: Optional[dict] = None  # In practice this would be a model
+
+    field_info = SQLAlchemyModel.model_fields["team"]
+    meta = classify_field(field_info, SQLAlchemyModel)
+
+    assert meta is not None
+    assert meta.choices_source == "relation"
+    assert meta.multiple is False
+    assert meta.preload is False
+
+
+@patch("hyperadmin.core.discovery.sa_inspect")
+def test_classify_sqlalchemy_m2m(mock_inspect):
+    mock_mapper = MagicMock()
+    mock_inspect.return_value = mock_mapper
+
+    # Mock relationship
+    mock_rel = MagicMock()
+    mock_rel.key = "members"
+    mock_rel.uselist = True
+    mock_mapper.relationships = [mock_rel]
+    mock_mapper.columns = []
+
+    class SQLAlchemyModel(BaseModel):
+        members: List[dict] = []
+
+    field_info = SQLAlchemyModel.model_fields["members"]
+    meta = classify_field(field_info, SQLAlchemyModel)
+
+    assert meta is not None
+    assert meta.choices_source == "relation"
+    assert meta.multiple is True
+    assert meta.preload is False
+
+
+@patch("hyperadmin.core.discovery.sa_inspect")
+def test_classify_no_inspection(mock_inspect):
+    mock_inspect.side_effect = NoInspectionAvailable("No inspection")
+
+    class PurePydanticModel(BaseModel):
+        name: str
+
+    field_info = PurePydanticModel.model_fields["name"]
+    meta = classify_field(field_info, PurePydanticModel)
+    assert meta is None

--- a/tests/unit/test_core_field_classification.py
+++ b/tests/unit/test_core_field_classification.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.exc import NoInspectionAvailable
 
 from hyperadmin.core.fields import classify_field
+from hyperadmin.core.options import AdminOptions
 
 
 class Status(Enum):
@@ -161,3 +162,34 @@ def test_classify_no_inspection(mock_inspect):
     field_info = PurePydanticModel.model_fields["name"]
     meta = classify_field(field_info, PurePydanticModel)
     assert meta is None
+
+
+@patch("hyperadmin.core.fields.sa_inspect")
+def test_classify_preload_override(mock_inspect):
+    mock_mapper = MagicMock()
+    mock_inspect.return_value = mock_mapper
+
+    # Mock relationship
+    mock_rel = MagicMock()
+    mock_rel.key = "team"
+    mock_rel.uselist = False
+    mock_mapper.relationships = [mock_rel]
+    mock_mapper.columns = []
+
+    class SQLAlchemyModel(BaseModel):
+        team: Optional[dict] = None
+
+    field_info = SQLAlchemyModel.model_fields["team"]
+
+    # 1. Default (no preload for relations)
+    meta = classify_field(field_info, SQLAlchemyModel)
+    assert meta is not None
+    assert meta.choices_source == "relation"
+    assert meta.preload is False
+
+    # 2. Force preload via options
+    options = AdminOptions(preload_fields={"team"})
+    meta = classify_field(field_info, SQLAlchemyModel, options=options)
+    assert meta is not None
+    assert meta.choices_source == "relation"
+    assert meta.preload is True

--- a/tests/unit/test_core_field_classification.py
+++ b/tests/unit/test_core_field_classification.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import NoInspectionAvailable
 
-from hyperadmin.core.discovery import classify_field
+from hyperadmin.core.fields import classify_field
 
 
 class Status(Enum):
@@ -20,6 +20,7 @@ class MockModel(BaseModel):
     tags: List[str]
     roles: List[Status]
     optional_status: Optional[Status]
+    optional_tags: Optional[List[str]]
     other: int
 
 
@@ -59,6 +60,15 @@ def test_classify_static_list():
     assert meta.preload is True
 
 
+def test_classify_optional_static_list():
+    field_info = MockModel.model_fields["optional_tags"]
+    meta = classify_field(field_info, MockModel)
+    assert meta is not None
+    assert meta.choices_source == "static"
+    assert meta.multiple is True
+    assert meta.preload is True
+
+
 def test_classify_non_select():
     field_info = MockModel.model_fields["name"]
     meta = classify_field(field_info, MockModel)
@@ -69,7 +79,7 @@ def test_classify_non_select():
     assert meta is None
 
 
-@patch("hyperadmin.core.discovery.sa_inspect")
+@patch("hyperadmin.core.fields.sa_inspect")
 def test_classify_sqlalchemy_fk(mock_inspect):
     mock_mapper = MagicMock()
     mock_inspect.return_value = mock_mapper
@@ -93,7 +103,7 @@ def test_classify_sqlalchemy_fk(mock_inspect):
     assert meta.preload is False
 
 
-@patch("hyperadmin.core.discovery.sa_inspect")
+@patch("hyperadmin.core.fields.sa_inspect")
 def test_classify_sqlalchemy_relationship(mock_inspect):
     mock_mapper = MagicMock()
     mock_inspect.return_value = mock_mapper
@@ -117,7 +127,7 @@ def test_classify_sqlalchemy_relationship(mock_inspect):
     assert meta.preload is False
 
 
-@patch("hyperadmin.core.discovery.sa_inspect")
+@patch("hyperadmin.core.fields.sa_inspect")
 def test_classify_sqlalchemy_m2m(mock_inspect):
     mock_mapper = MagicMock()
     mock_inspect.return_value = mock_mapper
@@ -141,7 +151,7 @@ def test_classify_sqlalchemy_m2m(mock_inspect):
     assert meta.preload is False
 
 
-@patch("hyperadmin.core.discovery.sa_inspect")
+@patch("hyperadmin.core.fields.sa_inspect")
 def test_classify_no_inspection(mock_inspect):
     mock_inspect.side_effect = NoInspectionAvailable("No inspection")
 


### PR DESCRIPTION
This PR implements field classification logic to enable automatic widget detection for relationship and choice fields. It introduces the `classify_field` function, which uses Pydantic field info and optional SQLAlchemy mapper inspection to categorize fields into Enums, relations, or static lists. It also adds a `preload_fields` configuration option to `AdminOptions`.

Fixes #162

---
*PR created automatically by Jules for task [3281063242936530073](https://jules.google.com/task/3281063242936530073) started by @yevheniidehtiar*