### PR TITLE
feat(core): ActionDef dataclass and @action decorator

### DIFF
--- a/src/hyperadmin/core/__init__.py
+++ b/src/hyperadmin/core/__init__.py
@@ -1,5 +1,6 @@
 """Core components for HyperAdmin."""
 
-from .choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
+from hyperadmin.core.actions import ActionDef, action
+from hyperadmin.core.choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
 
-__all__ = ["ChoiceItem", "ChoicesProvider", "SelectFieldMeta"]
+__all__ = ["ActionDef", "ChoiceItem", "ChoicesProvider", "SelectFieldMeta", "action"]

--- a/src/hyperadmin/core/actions.py
+++ b/src/hyperadmin/core/actions.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+class ActionCallable(Protocol):
+    _action_def: "ActionDef"
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+@dataclass(frozen=True)
+class ActionDef:
+    """Definition of an administrative action.
+
+    Attributes:
+        name: The internal name of the action (usually the function name).
+        label: The human-readable label for the action.
+        handler: The callable that implements the action logic.
+        requires_selection: Whether the action requires items to be selected.
+    """
+
+    name: str
+    label: str
+    handler: Callable[..., Any]
+    requires_selection: bool = False
+
+
+def action(
+    label: str | None = None,
+    requires_selection: bool = False,
+) -> Callable[[F], F]:
+    """Decorator to mark a method as an admin action.
+
+    Example:
+        class UserView(ModelView):
+            @action(label="Activate Users", requires_selection=True)
+            async def activate(self, request, items):
+                ...
+    """
+
+    def decorator(func: F) -> F:
+        name = func.__name__
+        action_label = label or name.replace("_", " ").strip().title()
+
+        # We attach the ActionDef to the function so it can be discovered
+        # when the ModelView class is inspected.
+        adef = ActionDef(
+            name=name,
+            label=action_label,
+            handler=func,
+            requires_selection=requires_selection,
+        )
+        setattr(func, "_action_def", adef)
+        return func
+
+    return decorator

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -1,0 +1,59 @@
+from hyperadmin.core import ActionDef, action
+
+
+def test_action_decorator_basic():
+    class MyView:
+        @action(label="My Custom Label")
+        def my_action(self):
+            return "ok"
+
+    # Check if the metadata is attached to the method
+    assert hasattr(MyView.my_action, "_action_def")
+    action_def = MyView.my_action._action_def
+
+    assert isinstance(action_def, ActionDef)
+    assert action_def.name == "my_action"
+    assert action_def.label == "My Custom Label"
+    assert action_def.requires_selection is False
+    assert action_def.handler == MyView.my_action
+
+
+def test_action_decorator_defaults():
+    class MyView:
+        @action()
+        def some_other_action(self):
+            pass
+
+    action_def = MyView.some_other_action._action_def
+    assert action_def.name == "some_other_action"
+    assert action_def.label == "Some Other Action"
+    assert action_def.requires_selection is False
+
+
+def test_action_decorator_requires_selection():
+    class MyView:
+        @action(requires_selection=True)
+        def bulk_delete(self):
+            pass
+
+    action_def = MyView.bulk_delete._action_def
+    assert action_def.name == "bulk_delete"
+    assert action_def.label == "Bulk Delete"
+    assert action_def.requires_selection is True
+
+
+def test_action_def_instantiation():
+    def my_handler():
+        pass
+
+    adef = ActionDef(
+        name="test_action",
+        label="Test Action",
+        handler=my_handler,
+        requires_selection=True,
+    )
+
+    assert adef.name == "test_action"
+    assert adef.label == "Test Action"
+    assert adef.handler == my_handler
+    assert adef.requires_selection is True


### PR DESCRIPTION
Implementation of `ActionDef` dataclass and `@action` decorator in the core module. This allows defining administrative actions on `ModelView` classes with metadata (label, selection requirement) attached for discovery. Includes unit tests and linting fixes (absolute imports, mypy protocol for decorated methods).

Fixes #184

---
*PR created automatically by Jules for task [10477908137930338620](https://jules.google.com/task/10477908137930338620) started by @yevheniidehtiar*