### PR TITLE
feat(epic-a): core field introspection — classify_field, get_choices, widgets, HTMX endpoint

### DIFF
--- a/src/hyperadmin/adapters/sqlalchemy.py
+++ b/src/hyperadmin/adapters/sqlalchemy.py
@@ -9,6 +9,7 @@ from sqlalchemy.sql.sqltypes import String
 from sqlmodel import AutoString, SQLModel
 
 from hyperadmin.core.adapters import BaseAdapter
+from hyperadmin.core.choices import ChoiceItem
 
 
 class SQLAlchemyAdapter(BaseAdapter):
@@ -122,3 +123,58 @@ class SQLAlchemyAdapter(BaseAdapter):
 
     async def get_schema(self) -> dict[str, Any]:
         return self.model.model_json_schema()
+
+    async def get_choices(
+        self,
+        field: str,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+        **filters: Any,
+    ) -> builtins.list[ChoiceItem]:
+        """Return paginated, searchable choices for a relation field.
+
+        Performs a single SELECT on the related model — no N+1.
+        """
+        if limit > 200:
+            raise ValueError(f"limit {limit} exceeds maximum of 200")
+
+        if not self.inspector:
+            return []
+
+        target_model = None
+        for rel in self.inspector.relationships:
+            if rel.key == field:
+                target_model = rel.mapper.class_
+                break
+
+        if target_model is None:
+            return []
+
+        target_inspector = inspect(target_model)
+        async with AsyncSession(self.engine) as session:
+            query = select(target_model)
+
+            if q:
+                str_cols = [
+                    c for c in target_inspector.c if isinstance(c.type, AutoString | String)
+                ]
+                if str_cols:
+                    query = query.where(or_(*[c.ilike(f"%{q}%") for c in str_cols[:3]]))
+
+            for key, value in filters.items():
+                if hasattr(target_model, key):
+                    query = query.where(getattr(target_model, key) == value)
+
+            query = query.offset(offset).limit(limit)
+            result = await session.execute(query)
+            items = result.scalars().all()
+
+        return [
+            ChoiceItem(
+                value=str(getattr(item, "id", "")),
+                label=str(item),
+                selected=False,
+            )
+            for item in items
+        ]

--- a/src/hyperadmin/adapters/sqlmodel.py
+++ b/src/hyperadmin/adapters/sqlmodel.py
@@ -4,9 +4,11 @@ from typing import Any
 from sqlalchemy import func, inspect, or_
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 from sqlalchemy.orm import selectinload
-from sqlmodel import SQLModel, select
+from sqlalchemy.sql.sqltypes import String
+from sqlmodel import AutoString, SQLModel, select
 
 from hyperadmin.core.adapters import BaseAdapter
+from hyperadmin.core.choices import ChoiceItem
 
 
 class SQLModelAdapter(BaseAdapter):
@@ -171,3 +173,56 @@ class SQLModelAdapter(BaseAdapter):
             A dictionary representing the JSON schema.
         """
         return self.model.model_json_schema()
+
+    async def get_choices(
+        self,
+        field: str,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+        **filters: Any,
+    ) -> builtins.list[ChoiceItem]:
+        """Return paginated, searchable choices for a relation field.
+
+        Performs a single SELECT on the related model — no N+1.
+        """
+        if limit > 200:
+            raise ValueError(f"limit {limit} exceeds maximum of 200")
+
+        mapper = inspect(self.model)
+        target_model = None
+        for rel in mapper.relationships:
+            if rel.key == field:
+                target_model = rel.mapper.class_
+                break
+
+        if target_model is None:
+            return []
+
+        target_inspector = inspect(target_model)
+        async with AsyncSession(self.engine) as session:
+            query = select(target_model)
+
+            if q:
+                str_cols = [
+                    c for c in target_inspector.c if isinstance(c.type, AutoString | String)
+                ]
+                if str_cols:
+                    query = query.where(or_(*[c.ilike(f"%{q}%") for c in str_cols[:3]]))
+
+            for key, value in filters.items():
+                if hasattr(target_model, key):
+                    query = query.where(getattr(target_model, key) == value)
+
+            query = query.offset(offset).limit(limit)
+            result = await session.execute(query)
+            items = result.scalars().all()
+
+        return [
+            ChoiceItem(
+                value=str(getattr(item, "id", "")),
+                label=str(item),
+                selected=False,
+            )
+            for item in items
+        ]

--- a/src/hyperadmin/core/__init__.py
+++ b/src/hyperadmin/core/__init__.py
@@ -1,5 +1,6 @@
 """Core components for HyperAdmin."""
 
 from .choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
+from .fields import classify_field
 
-__all__ = ["ChoiceItem", "ChoicesProvider", "SelectFieldMeta"]
+__all__ = ["ChoiceItem", "ChoicesProvider", "SelectFieldMeta", "classify_field"]

--- a/src/hyperadmin/core/adapters.py
+++ b/src/hyperadmin/core/adapters.py
@@ -2,6 +2,8 @@ import builtins
 from abc import ABC, abstractmethod
 from typing import Any
 
+from hyperadmin.core.choices import ChoiceItem
+
 
 class BaseAdapter(ABC):
     """Abstract base class for data adapters.
@@ -117,5 +119,31 @@ class BaseAdapter(ABC):
 
         Returns:
             A dictionary representing the model's schema.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_choices(
+        self,
+        field: str,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+        **filters: Any,
+    ) -> builtins.list[ChoiceItem]:
+        """Return paginated, searchable choices for a relation field.
+
+        Args:
+            field: The relation field name on this adapter's model.
+            q: Optional search string (ILIKE match on string columns).
+            limit: Max results to return. Must not exceed 200.
+            offset: Number of rows to skip for pagination.
+            **filters: Extra equality filters forwarded to the query (cascading support).
+
+        Returns:
+            A list of ``ChoiceItem`` dicts with ``value``, ``label``, ``selected=False``.
+
+        Raises:
+            ValueError: When ``limit`` exceeds 200.
         """
         raise NotImplementedError

--- a/src/hyperadmin/core/fields.py
+++ b/src/hyperadmin/core/fields.py
@@ -7,14 +7,17 @@ from typing import Any, Union, get_args, get_origin
 
 from pydantic.fields import FieldInfo
 
+from hyperadmin.core.choices import SelectFieldMeta
+
 try:
-    import sqlalchemy  # noqa: F401
+    from sqlalchemy import inspect as sa_inspect
+    from sqlalchemy.exc import NoInspectionAvailable
 
     _HAS_SQLALCHEMY = True
 except ImportError:  # pragma: no cover
     _HAS_SQLALCHEMY = False
-
-from hyperadmin.core.choices import SelectFieldMeta
+    sa_inspect = None  # type: ignore[assignment]
+    NoInspectionAvailable = Exception  # type: ignore[assignment,misc]
 
 
 def classify_field(field_info: FieldInfo, model_cls: type) -> SelectFieldMeta | None:
@@ -82,10 +85,8 @@ def _inspect_orm_field(model_cls: type, field_name: str) -> SelectFieldMeta | No
 
     Returns ``None`` when *model_cls* has no SQLAlchemy mapper.
     """
-    if not _HAS_SQLALCHEMY:  # pragma: no cover
+    if not _HAS_SQLALCHEMY or sa_inspect is None:  # pragma: no cover
         return None
-    from sqlalchemy import inspect as sa_inspect
-    from sqlalchemy.exc import NoInspectionAvailable
 
     try:
         mapper: Any = sa_inspect(model_cls)

--- a/src/hyperadmin/core/fields.py
+++ b/src/hyperadmin/core/fields.py
@@ -1,0 +1,115 @@
+"""Field classification utilities for select widget auto-detection."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Union, get_args, get_origin
+
+from pydantic.fields import FieldInfo
+
+try:
+    import sqlalchemy  # noqa: F401
+
+    _HAS_SQLALCHEMY = True
+except ImportError:  # pragma: no cover
+    _HAS_SQLALCHEMY = False
+
+from hyperadmin.core.choices import SelectFieldMeta
+
+
+def classify_field(field_info: FieldInfo, model_cls: type) -> SelectFieldMeta | None:
+    """Classify a Pydantic FieldInfo for select widget auto-detection.
+
+    Returns a ``SelectFieldMeta`` when the field should render as a select or
+    multiselect widget. Returns ``None`` to fall through to existing widget logic.
+
+    SQLAlchemy mapper inspection is isolated in a try/except so the function
+    degrades gracefully when *model_cls* is a plain Pydantic model (no ORM).
+    """
+    ann = getattr(field_info, "annotation", None)
+    if ann is None:
+        return None
+
+    # Unwrap Optional[X] → X
+    origin = get_origin(ann)
+    args = get_args(ann)
+    if origin is Union and type(None) in args:
+        ann = next(a for a in args if a is not type(None))
+        origin = get_origin(ann)
+        args = get_args(ann)
+
+    # Detect list[X] wrapper
+    is_list = origin is list
+    inner = args[0] if (is_list and args) else ann
+
+    # Enum or list[Enum]
+    if isinstance(inner, type) and issubclass(inner, Enum):
+        return SelectFieldMeta(
+            choices_source="enum",
+            preload=True,
+            multiple=is_list,
+        )
+
+    # SQLAlchemy FK / M2M via mapper inspection
+    field_name = _find_field_name(field_info, model_cls)
+    if field_name is not None:
+        meta = _inspect_orm_field(model_cls, field_name)
+        if meta is not None:
+            return meta
+
+    # list[str] hybrid — no relation found
+    if is_list and inner is str:
+        return SelectFieldMeta(
+            choices_source="static",
+            preload=True,
+            multiple=True,
+        )
+
+    return None
+
+
+def _find_field_name(field_info: FieldInfo, model_cls: type) -> str | None:
+    """Return the field name by identity-matching *field_info* in *model_cls.model_fields*."""
+    model_fields = getattr(model_cls, "model_fields", {})
+    for name, fi in model_fields.items():
+        if fi is field_info:
+            return name
+    return None
+
+
+def _inspect_orm_field(model_cls: type, field_name: str) -> SelectFieldMeta | None:
+    """Inspect the SQLAlchemy mapper for FK / M2M relations.
+
+    Returns ``None`` when *model_cls* has no SQLAlchemy mapper.
+    """
+    if not _HAS_SQLALCHEMY:  # pragma: no cover
+        return None
+    from sqlalchemy import inspect as sa_inspect
+    from sqlalchemy.exc import NoInspectionAvailable
+
+    try:
+        mapper: Any = sa_inspect(model_cls)
+    except NoInspectionAvailable:
+        return None
+    except Exception:
+        return None
+
+    relationships = getattr(mapper, "relationships", [])
+    for rel in relationships:
+        if getattr(rel, "key", None) == field_name:
+            return SelectFieldMeta(
+                choices_source="relation",
+                preload=False,
+                multiple=bool(getattr(rel, "uselist", False)),
+            )
+
+    columns = getattr(mapper, "columns", [])
+    for col in columns:
+        if getattr(col, "key", None) == field_name and getattr(col, "foreign_keys", None):
+            return SelectFieldMeta(
+                choices_source="relation",
+                preload=False,
+                multiple=False,
+            )
+
+    return None

--- a/src/hyperadmin/core/fields.py
+++ b/src/hyperadmin/core/fields.py
@@ -2,8 +2,22 @@
 
 from __future__ import annotations
 
+import sys
 from enum import Enum
 from typing import Any, Union, get_args, get_origin
+
+# Python 3.10+ introduces X | Y union syntax (types.UnionType).  We must
+# detect both typing.Union and types.UnionType when unwrapping Optional[X].
+if sys.version_info >= (3, 10):
+    import types as _types
+
+    def _is_optional_union(origin: Any, args: tuple) -> bool:
+        return (origin is Union or origin is _types.UnionType) and type(None) in args
+else:
+
+    def _is_optional_union(origin: Any, args: tuple) -> bool:
+        return origin is Union and type(None) in args
+
 
 from pydantic.fields import FieldInfo
 
@@ -33,10 +47,10 @@ def classify_field(field_info: FieldInfo, model_cls: type) -> SelectFieldMeta | 
     if ann is None:
         return None
 
-    # Unwrap Optional[X] → X
+    # Unwrap Optional[X] → X  (handles both typing.Union and types.UnionType)
     origin = get_origin(ann)
     args = get_args(ann)
-    if origin is Union and type(None) in args:
+    if _is_optional_union(origin, args):
         ann = next(a for a in args if a is not type(None))
         origin = get_origin(ann)
         args = get_args(ann)

--- a/src/hyperadmin/core/options.py
+++ b/src/hyperadmin/core/options.py
@@ -28,3 +28,8 @@ class AdminOptions(BaseModel):
     """Whether the Detail view and GET (single item) endpoint are generated."""
     list_filter: list[str] = []
     """List of field names to show in the filter bar."""
+    dependent_fields: dict[str, str] = {}
+    """Cascading select configuration: maps child field name → parent field name.
+
+    Example: ``{"city": "country_id"}`` makes the city select reload when country_id changes.
+    """

--- a/src/hyperadmin/routing.py
+++ b/src/hyperadmin/routing.py
@@ -118,6 +118,13 @@ def create_admin_router(  # noqa: PLR0913
             name=f"{model_name}-delete",
         )
 
+    router.add_api_route(
+        f"{prefix}/choices/{{field_name}}",
+        view.choices_view,
+        methods=["GET"],
+        name=f"{model_name}-choices",
+    )
+
     return router
 
 

--- a/src/hyperadmin/templates/widgets/choices_options.html
+++ b/src/hyperadmin/templates/widgets/choices_options.html
@@ -1,0 +1,3 @@
+{%- for choice in choices -%}
+<option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
+{%- endfor -%}

--- a/src/hyperadmin/templates/widgets/multiselect_input.html
+++ b/src/hyperadmin/templates/widgets/multiselect_input.html
@@ -4,16 +4,11 @@
     </label>
     <select id="{{- field.name -}}" {# -#}
             name="{{- field.name -}}" {# -#}
-            class="ha-select">
-        {%- if widget.choices is defined and widget.choices -%}
-            {%- for choice in widget.choices -%}
-                <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
-            {%- endfor -%}
-        {%- else -%}
-            {%- for choice in field.model_field.annotation -%}
-                <option value="{{- choice.value -}}" {%- if choice == field.value -%} selected{%- endif -%}>{{- choice.name -}}</option>
-            {%- endfor -%}
-        {%- endif -%}
+            multiple {# -#}
+            class="ha-select ha-select--multi">
+        {%- for choice in widget.choices -%}
+            <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
+        {%- endfor -%}
     </select>
     {%- if field.help_text -%}<p class="ha-help-text">{{- field.help_text -}}</p>{%- endif -%}
     {%- if field.errors -%}

--- a/src/hyperadmin/templates/widgets/relation_multiselect_input.html
+++ b/src/hyperadmin/templates/widgets/relation_multiselect_input.html
@@ -17,7 +17,12 @@
             multiple {# -#}
             class="ha-select ha-select--multi ha-select--relation ha-select--lazy" {# -#}
             hx-get="{{- widget.choices_url -}}?q=" {# -#}
+            {%- if widget.dependent_on -%}
+            hx-trigger="focus delay:200ms, input changed delay:300ms, change from:[name={{- widget.dependent_on -}}]" {# -#}
+            hx-include="[name={{- widget.dependent_on -}}]" {# -#}
+            {%- else -%}
             hx-trigger="focus delay:200ms, input changed delay:300ms" {# -#}
+            {%- endif -%}
             hx-target="#{{- field.name -}}-options">
         {%- for choice in widget.choices -%}
             <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>

--- a/src/hyperadmin/templates/widgets/relation_multiselect_input.html
+++ b/src/hyperadmin/templates/widgets/relation_multiselect_input.html
@@ -1,0 +1,34 @@
+<div class="ha-form-group">
+    <label for="{{- field.name -}}" class="ha-label">
+        {{- field.label -}}{%- if field.required -%}<span class="ha-required">*</span>{%- endif -%}
+    </label>
+    {%- if widget.preload -%}
+    <select id="{{- field.name -}}" {# -#}
+            name="{{- field.name -}}" {# -#}
+            multiple {# -#}
+            class="ha-select ha-select--multi ha-select--relation">
+        {%- for choice in widget.choices -%}
+            <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
+        {%- endfor -%}
+    </select>
+    {%- else -%}
+    <select id="{{- field.name -}}" {# -#}
+            name="{{- field.name -}}" {# -#}
+            multiple {# -#}
+            class="ha-select ha-select--multi ha-select--relation ha-select--lazy" {# -#}
+            hx-get="{{- widget.choices_url -}}?q=" {# -#}
+            hx-trigger="focus delay:200ms, input changed delay:300ms" {# -#}
+            hx-target="#{{- field.name -}}-options">
+        {%- for choice in widget.choices -%}
+            <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
+        {%- endfor -%}
+        <span id="{{- field.name -}}-options"></span>
+    </select>
+    {%- endif -%}
+    {%- if field.help_text -%}<p class="ha-help-text">{{- field.help_text -}}</p>{%- endif -%}
+    {%- if field.errors -%}
+        <ul class="ha-field-errors" aria-live="polite" data-testid="{{ field.name }}-errors">
+            {%- for e in field.errors -%}<li>{{- e -}}</li>{%- endfor -%}
+        </ul>
+    {%- endif -%}
+</div>

--- a/src/hyperadmin/templates/widgets/relation_select_input.html
+++ b/src/hyperadmin/templates/widgets/relation_select_input.html
@@ -1,0 +1,34 @@
+<div class="ha-form-group">
+    <label for="{{- field.name -}}" class="ha-label">
+        {{- field.label -}}{%- if field.required -%}<span class="ha-required">*</span>{%- endif -%}
+    </label>
+    {%- if widget.preload -%}
+    <select id="{{- field.name -}}" {# -#}
+            name="{{- field.name -}}" {# -#}
+            class="ha-select ha-select--relation">
+        <option value="">---------</option>
+        {%- for choice in widget.choices -%}
+            <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
+        {%- endfor -%}
+    </select>
+    {%- else -%}
+    <select id="{{- field.name -}}" {# -#}
+            name="{{- field.name -}}" {# -#}
+            class="ha-select ha-select--relation ha-select--lazy" {# -#}
+            hx-get="{{- widget.choices_url -}}?q=" {# -#}
+            hx-trigger="focus delay:200ms, input changed delay:300ms" {# -#}
+            hx-target="#{{- field.name -}}-options">
+        <option value="">---------</option>
+        {%- for choice in widget.choices -%}
+            <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
+        {%- endfor -%}
+        <span id="{{- field.name -}}-options"></span>
+    </select>
+    {%- endif -%}
+    {%- if field.help_text -%}<p class="ha-help-text">{{- field.help_text -}}</p>{%- endif -%}
+    {%- if field.errors -%}
+        <ul class="ha-field-errors" aria-live="polite" data-testid="{{ field.name }}-errors">
+            {%- for e in field.errors -%}<li>{{- e -}}</li>{%- endfor -%}
+        </ul>
+    {%- endif -%}
+</div>

--- a/src/hyperadmin/templates/widgets/relation_select_input.html
+++ b/src/hyperadmin/templates/widgets/relation_select_input.html
@@ -16,7 +16,12 @@
             name="{{- field.name -}}" {# -#}
             class="ha-select ha-select--relation ha-select--lazy" {# -#}
             hx-get="{{- widget.choices_url -}}?q=" {# -#}
+            {%- if widget.dependent_on -%}
+            hx-trigger="focus delay:200ms, input changed delay:300ms, change from:[name={{- widget.dependent_on -}}]" {# -#}
+            hx-include="[name={{- widget.dependent_on -}}]" {# -#}
+            {%- else -%}
             hx-trigger="focus delay:200ms, input changed delay:300ms" {# -#}
+            {%- endif -%}
             hx-target="#{{- field.name -}}-options">
         <option value="">---------</option>
         {%- for choice in widget.choices -%}

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -517,6 +517,34 @@ class DynamicModelView:
 
         return RedirectResponse(url=redirect_url, status_code=303)
 
+    async def choices_view(
+        self,
+        request: Request,
+        field_name: str,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+    ) -> Response:
+        """HTMX endpoint: returns an HTML `<option>` fragment for a relation field.
+
+        GET /{model_name}/choices/{field_name}?q=&limit=50&offset=0
+        """
+        await self._check_permission(request, "view")
+        if limit > 200:
+            raise HTTPException(status_code=400, detail=f"limit {limit} exceeds maximum of 200")
+
+        # Validate that field_name is a known relation on this model
+        inspector = getattr(self.adapter, "inspector", None)
+        known_fields = {rel.key for rel in inspector.relationships} if inspector else set()
+        if field_name not in known_fields:
+            raise HTTPException(status_code=404, detail=f"Unknown relation field: {field_name!r}")
+
+        choices = await self.adapter.get_choices(field_name, q=q, limit=limit, offset=offset)
+        context = {"request": request, "choices": choices}
+        template = self.templates.get_template("widgets/choices_options.html")
+        html = template.render(context)
+        return Response(content=html, media_type="text/html")
+
     async def delete_action(self, request: Request, item_id: int):
         """Deletes an item."""
         await self._check_permission(request, "delete")

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -13,12 +13,20 @@ if TYPE_CHECKING:
     from jinja2 import FileSystemLoader
 
 from hyperadmin.adapters import SQLAlchemyAdapter, SQLModelAdapter
+from hyperadmin.core.choices import ChoiceItem, SelectFieldMeta
 from hyperadmin.core.discovery import build_filter_metadata
 from hyperadmin.core.display import get_display_name
+from hyperadmin.core.fields import classify_field
 from hyperadmin.core.options import AdminOptions
 from hyperadmin.core.registry import site
 from hyperadmin.discover import app_label_var
-from hyperadmin.views.forms import CheckboxInput, PydanticForm
+from hyperadmin.views.forms import (
+    CheckboxInput,
+    HtmxWidget,
+    PydanticForm,
+    RelationMultiSelectWidget,
+    RelationSelectWidget,
+)
 from hyperadmin.views.htmx import HtmxTemplateResponse
 
 logger = logging.getLogger(__name__)
@@ -266,6 +274,46 @@ class DynamicModelView:
         template_name = self._get_template_name("detail")
         return self.templates.TemplateResponse(request, template_name, context)
 
+    async def _build_relation_widgets(
+        self,
+        field_names: list[str],
+        selected_values: dict[str, Any] | None = None,
+    ) -> dict[str, HtmxWidget]:
+        """Return a widget override dict for relation fields detected by classify_field().
+
+        For each field in *field_names* that resolves to a relation, this method
+        either pre-fetches choices (preload=True) or creates a lazy HTMX widget
+        (preload=False) pointing at the choices endpoint for that field.
+        """
+        widgets: dict[str, HtmxWidget] = {}
+        sv = selected_values or {}
+        for name, field_info in self.model.model_fields.items():
+            if field_names and name not in field_names:
+                continue
+            meta: SelectFieldMeta | None = classify_field(field_info, self.model)
+            if meta is None or meta.choices_source != "relation":
+                continue
+            choices_url = f"/{self._model_name_lower}/choices/{name}"
+            choices: list[ChoiceItem]
+            if meta.preload:
+                raw_choices = await self.adapter.get_choices(name)
+                current = str(sv.get(name, ""))
+                choices = [
+                    ChoiceItem(value=c["value"], label=c["label"], selected=c["value"] == current)
+                    for c in raw_choices
+                ]
+            else:
+                choices = []
+            if meta.multiple:
+                widgets[name] = RelationMultiSelectWidget(
+                    choices_url=choices_url, choices=choices, preload=meta.preload
+                )
+            else:
+                widgets[name] = RelationSelectWidget(
+                    choices_url=choices_url, choices=choices, preload=meta.preload
+                )
+        return widgets
+
     async def create_form_view(
         self,
         request: Request,
@@ -284,8 +332,12 @@ class DynamicModelView:
         create_include = self.form_include
         if create_include and self.form_create_exclude:
             create_include = [f for f in create_include if f not in self.form_create_exclude]
+        relation_widgets = await self._build_relation_widgets(
+            field_names=create_include or [], selected_values=values
+        )
         form = PydanticForm(
             self.model,
+            widgets=relation_widgets,
             include=create_include,
             exclude=self.form_create_exclude,
             initial=values or {},
@@ -388,7 +440,12 @@ class DynamicModelView:
         if values:
             initial_values.update(values)
 
-        form = PydanticForm(self.model, include=self.form_include, initial=initial_values)
+        relation_widgets = await self._build_relation_widgets(
+            field_names=self.form_include or [], selected_values=initial_values
+        )
+        form = PydanticForm(
+            self.model, widgets=relation_widgets, include=self.form_include, initial=initial_values
+        )
 
         if errors:
             form.bind(values or {})

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -287,6 +287,7 @@ class DynamicModelView:
         """
         widgets: dict[str, HtmxWidget] = {}
         sv = selected_values or {}
+        dependent_fields: dict[str, str] = getattr(self.options, "dependent_fields", {})
         for name, field_info in self.model.model_fields.items():
             if field_names and name not in field_names:
                 continue
@@ -294,6 +295,7 @@ class DynamicModelView:
             if meta is None or meta.choices_source != "relation":
                 continue
             choices_url = f"/{self._model_name_lower}/choices/{name}"
+            dependent_on = meta.dependent_on or dependent_fields.get(name)
             choices: list[ChoiceItem]
             if meta.preload:
                 raw_choices = await self.adapter.get_choices(name)
@@ -306,11 +308,17 @@ class DynamicModelView:
                 choices = []
             if meta.multiple:
                 widgets[name] = RelationMultiSelectWidget(
-                    choices_url=choices_url, choices=choices, preload=meta.preload
+                    choices_url=choices_url,
+                    choices=choices,
+                    preload=meta.preload,
+                    dependent_on=dependent_on,
                 )
             else:
                 widgets[name] = RelationSelectWidget(
-                    choices_url=choices_url, choices=choices, preload=meta.preload
+                    choices_url=choices_url,
+                    choices=choices,
+                    preload=meta.preload,
+                    dependent_on=dependent_on,
                 )
         return widgets
 
@@ -527,7 +535,10 @@ class DynamicModelView:
     ) -> Response:
         """HTMX endpoint: returns an HTML `<option>` fragment for a relation field.
 
-        GET /{model_name}/choices/{field_name}?q=&limit=50&offset=0
+        GET /{model_name}/choices/{field_name}?q=&limit=50&offset=0[&{parent_field}={value}]
+
+        Extra query parameters (beyond q/limit/offset) are forwarded as equality filters
+        to ``adapter.get_choices()`` to support cascading selects.
         """
         await self._check_permission(request, "view")
         if limit > 200:
@@ -539,7 +550,13 @@ class DynamicModelView:
         if field_name not in known_fields:
             raise HTTPException(status_code=404, detail=f"Unknown relation field: {field_name!r}")
 
-        choices = await self.adapter.get_choices(field_name, q=q, limit=limit, offset=offset)
+        # Forward any extra query params as cascading filters (e.g. country_id=1)
+        reserved = {"q", "limit", "offset"}
+        extra_filters = {k: v for k, v in request.query_params.items() if k not in reserved}
+
+        choices = await self.adapter.get_choices(
+            field_name, q=q, limit=limit, offset=offset, **extra_filters
+        )
         context = {"request": request, "choices": choices}
         template = self.templates.get_template("widgets/choices_options.html")
         html = template.render(context)

--- a/src/hyperadmin/views/forms.py
+++ b/src/hyperadmin/views/forms.py
@@ -107,12 +107,14 @@ class RelationSelectWidget(HtmxWidget):
     choices: list[ChoiceItem]
     choices_url: str
     preload: bool
+    dependent_on: str | None
 
     def __init__(
         self,
         choices_url: str,
         choices: list[ChoiceItem] | None = None,
         preload: bool = True,
+        dependent_on: str | None = None,
     ) -> None:
         object.__setattr__(self, "template_path", "widgets/relation_select_input.html")
         object.__setattr__(self, "static_list", ())
@@ -120,6 +122,7 @@ class RelationSelectWidget(HtmxWidget):
         self.choices = choices or []
         self.choices_url = choices_url
         self.preload = preload
+        self.dependent_on = dependent_on
 
 
 class RelationMultiSelectWidget(HtmxWidget):
@@ -128,12 +131,14 @@ class RelationMultiSelectWidget(HtmxWidget):
     choices: list[ChoiceItem]
     choices_url: str
     preload: bool
+    dependent_on: str | None
 
     def __init__(
         self,
         choices_url: str,
         choices: list[ChoiceItem] | None = None,
         preload: bool = True,
+        dependent_on: str | None = None,
     ) -> None:
         object.__setattr__(self, "template_path", "widgets/relation_multiselect_input.html")
         object.__setattr__(self, "static_list", ())
@@ -141,6 +146,7 @@ class RelationMultiSelectWidget(HtmxWidget):
         self.choices = choices or []
         self.choices_url = choices_url
         self.preload = preload
+        self.dependent_on = dependent_on
 
 
 def hybrid_to_python(raw: str | list[str], storage: Literal["json", "csv"]) -> list[str]:

--- a/src/hyperadmin/views/forms.py
+++ b/src/hyperadmin/views/forms.py
@@ -101,6 +101,48 @@ class DateTimeInput(HtmxWidget):
         super().__init__(template_path="widgets/datetime_input.html")
 
 
+class RelationSelectWidget(HtmxWidget):
+    """Widget for a single FK relation field — supports preload and lazy (HTMX) strategies."""
+
+    choices: list[ChoiceItem]
+    choices_url: str
+    preload: bool
+
+    def __init__(
+        self,
+        choices_url: str,
+        choices: list[ChoiceItem] | None = None,
+        preload: bool = True,
+    ) -> None:
+        object.__setattr__(self, "template_path", "widgets/relation_select_input.html")
+        object.__setattr__(self, "static_list", ())
+        object.__setattr__(self, "htmx_attrs", None)
+        self.choices = choices or []
+        self.choices_url = choices_url
+        self.preload = preload
+
+
+class RelationMultiSelectWidget(HtmxWidget):
+    """Widget for a M2M relation field — supports preload and lazy (HTMX) strategies."""
+
+    choices: list[ChoiceItem]
+    choices_url: str
+    preload: bool
+
+    def __init__(
+        self,
+        choices_url: str,
+        choices: list[ChoiceItem] | None = None,
+        preload: bool = True,
+    ) -> None:
+        object.__setattr__(self, "template_path", "widgets/relation_multiselect_input.html")
+        object.__setattr__(self, "static_list", ())
+        object.__setattr__(self, "htmx_attrs", None)
+        self.choices = choices or []
+        self.choices_url = choices_url
+        self.preload = preload
+
+
 def hybrid_to_python(raw: str | list[str], storage: Literal["json", "csv"]) -> list[str]:
     """Deserialise a stored hybrid list field back to a Python list of strings."""
     if isinstance(raw, list):

--- a/src/hyperadmin/views/forms.py
+++ b/src/hyperadmin/views/forms.py
@@ -12,6 +12,14 @@ from pydantic.fields import FieldInfo
 
 from hyperadmin.core.choices import ChoiceItem
 
+try:
+    from hyperadmin.core.fields import classify_field as _classify_field
+
+    _HAS_CLASSIFY = True
+except ImportError:
+    _classify_field = None  # type: ignore[assignment]
+    _HAS_CLASSIFY = False
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -208,19 +216,73 @@ class PydanticForm:
         include: list[str] | None = None,
         exclude: list[str] | None = None,
         initial: dict[str, Any] | None = None,
+        choices_base_url: str = "",
     ) -> None:
         self.model = model
         self.widgets = widgets or {}
         self.include = set(include or [])
         self.exclude = set(exclude or [])
         self.initial = initial or {}
+        self.choices_base_url = choices_base_url
         self.errors: dict[str, list[str]] = {}
         self._fields: list[FormField] = []
+
+    @staticmethod
+    def _enum_choices(enum_cls: type[Enum]) -> list[ChoiceItem]:
+        return [
+            ChoiceItem(
+                value=member.value if not isinstance(member.value, str) else member.value,
+                label=member.name,
+                selected=False,
+            )
+            for member in enum_cls
+        ]
 
     def _pick_widget(self, name: str, field: FieldInfo) -> HtmxWidget:
         if name in self.widgets:
             return self.widgets[name]
-        # Heuristics for common fields
+
+        # --- classify_field auto-detection (requires SQLAlchemy) ---
+        if _HAS_CLASSIFY and _classify_field is not None:
+            from hyperadmin.core.choices import SelectFieldMeta  # noqa: PLC0415
+
+            meta: SelectFieldMeta | None = _classify_field(field, self.model)
+            if meta is not None:
+                choices_url = f"{self.choices_base_url}/{name}" if self.choices_base_url else ""
+                if meta.choices_source == "enum":
+                    # Extract enum type for choices
+                    ann = getattr(field, "annotation", None)
+                    origin = get_origin(ann)
+                    args = get_args(ann)
+                    if origin is not None and args and origin is Union and type(None) in args:
+                        ann = next(a for a in args if a is not type(None))
+                    # Unwrap list[Enum]
+                    if get_origin(ann) is list and get_args(ann):
+                        ann = get_args(ann)[0]
+                    enum_choices = (
+                        self._enum_choices(ann)
+                        if isinstance(ann, type) and issubclass(ann, Enum)
+                        else []
+                    )
+                    if meta.multiple:
+                        return MultiSelectWidget(choices=enum_choices)
+                    return SelectWidget(choices=enum_choices)
+                if meta.choices_source == "static" and meta.multiple:
+                    return MultiSelectWidget()
+                if meta.choices_source == "relation":
+                    if meta.multiple:
+                        return RelationMultiSelectWidget(
+                            choices_url=choices_url,
+                            preload=meta.preload,
+                            dependent_on=meta.dependent_on,
+                        )
+                    return RelationSelectWidget(
+                        choices_url=choices_url,
+                        preload=meta.preload,
+                        dependent_on=meta.dependent_on,
+                    )
+
+        # --- Legacy heuristics ---
         lower = name.lower()
         if lower in {"description", "text", "body", "content"}:
             return Textarea()

--- a/src/hyperadmin/views/forms.py
+++ b/src/hyperadmin/views/forms.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Literal, Union, get_args, get_origin
 
 from markupsafe import Markup
 from pydantic import BaseModel, ValidationError
 from pydantic.fields import FieldInfo
+
+from hyperadmin.core.choices import ChoiceItem
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -67,9 +70,55 @@ class SelectInput(HtmxWidget):
         super().__init__(template_path="widgets/select_input.html")
 
 
+class SelectWidget(HtmxWidget):
+    """Widget for a single-select with a pre-built choices list."""
+
+    choices: list[ChoiceItem]
+
+    def __init__(self, choices: list[ChoiceItem] | None = None) -> None:
+        # HtmxWidget is slots=True; bypass super().__init__ to avoid the
+        # zero-arg super() cell-variable issue introduced by @dataclass(slots=True).
+        object.__setattr__(self, "template_path", "widgets/select_input.html")
+        object.__setattr__(self, "static_list", ())
+        object.__setattr__(self, "htmx_attrs", None)
+        self.choices = choices or []
+
+
+class MultiSelectWidget(HtmxWidget):
+    """Widget for a multi-select with a pre-built choices list."""
+
+    choices: list[ChoiceItem]
+
+    def __init__(self, choices: list[ChoiceItem] | None = None) -> None:
+        object.__setattr__(self, "template_path", "widgets/multiselect_input.html")
+        object.__setattr__(self, "static_list", ())
+        object.__setattr__(self, "htmx_attrs", None)
+        self.choices = choices or []
+
+
 class DateTimeInput(HtmxWidget):
     def __init__(self):
         super().__init__(template_path="widgets/datetime_input.html")
+
+
+def hybrid_to_python(raw: str | list[str], storage: Literal["json", "csv"]) -> list[str]:
+    """Deserialise a stored hybrid list field back to a Python list of strings."""
+    if isinstance(raw, list):
+        return [str(v) for v in raw]
+    if not raw:
+        return []
+    if storage == "json":
+        parsed = json.loads(raw)
+        return [str(v) for v in parsed]
+    # csv
+    return [v.strip() for v in raw.split(",") if v.strip()]
+
+
+def hybrid_to_storage(value: list[str], storage: Literal["json", "csv"]) -> str:
+    """Serialise a Python list of strings to the chosen storage format."""
+    if storage == "json":
+        return json.dumps(value)
+    return ",".join(value)
 
 
 @dataclass(slots=True)

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -47,6 +47,16 @@ def test_concrete_adapter_must_implement_all_methods():
         async def get_schema(self) -> dict[str, Any]:
             pass
 
+        async def get_choices(
+            self,
+            field: str,
+            q: str = "",
+            limit: int = 50,
+            offset: int = 0,
+            **filters: Any,
+        ) -> builtins.list:
+            pass
+
     # This should not raise an error
     ConcreteAdapter(model=None, engine=None)
 

--- a/tests/unit/test_adapter_choices.py
+++ b/tests/unit/test_adapter_choices.py
@@ -1,0 +1,163 @@
+"""Unit tests for SQLModelAdapter.get_choices() — N+1 safety verified."""
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
+from sqlalchemy.orm import Mapped
+from sqlmodel import Field, Relationship, SQLModel, select
+
+# ---------------------------------------------------------------------------
+# Schema fixtures
+# ---------------------------------------------------------------------------
+
+
+class Country(SQLModel, table=True):
+    __tablename__: str = "countries_choices"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+
+    cities: Mapped[list["City"]] = Relationship(back_populates="country")
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class City(SQLModel, table=True):
+    __tablename__: str = "cities_choices"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    country_id: int | None = Field(default=None, foreign_key="countries_choices.id")
+
+    country: Mapped[Country | None] = Relationship(back_populates="cities")
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@pytest.fixture
+async def engine() -> AsyncEngine:
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with eng.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield eng
+    async with eng.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+    await eng.dispose()
+
+
+@pytest.fixture
+async def populated_db(engine: AsyncEngine) -> None:
+    async with AsyncSession(engine) as session:
+        uk = Country(name="United Kingdom")
+        fr = Country(name="France")
+        session.add_all([uk, fr])
+        await session.commit()
+        await session.refresh(uk)
+        await session.refresh(fr)
+        session.add_all(
+            [
+                City(name="London", country_id=uk.id),
+                City(name="Manchester", country_id=uk.id),
+                City(name="Paris", country_id=fr.id),
+            ]
+        )
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def query_counter(engine: AsyncEngine) -> list[str]:
+    """Accumulate SQL statements issued against *engine* during a test."""
+    log: list[str] = []
+
+    @event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _record(conn, cursor, statement, parameters, context, executemany):
+        log.append(statement)
+
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_choices_fk_single_query(engine: AsyncEngine, populated_db: None) -> None:
+    from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+
+    adapter = SQLModelAdapter(City, engine)
+    log = query_counter(engine)
+
+    choices = await adapter.get_choices("country")
+
+    select_stmts = [s for s in log if s.strip().upper().startswith("SELECT")]
+    assert len(select_stmts) == 1, f"Expected 1 SELECT, got {len(select_stmts)}"
+    assert len(choices) == 2
+    labels = {c["label"] for c in choices}
+    assert "United Kingdom" in labels
+    assert "France" in labels
+    assert all(c["selected"] is False for c in choices)
+
+
+@pytest.mark.anyio
+async def test_get_choices_search_filters_results(engine: AsyncEngine, populated_db: None) -> None:
+    from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+
+    adapter = SQLModelAdapter(City, engine)
+    choices = await adapter.get_choices("country", q="uni")
+
+    assert len(choices) == 1
+    assert choices[0]["label"] == "United Kingdom"
+
+
+@pytest.mark.anyio
+async def test_get_choices_pagination(engine: AsyncEngine, populated_db: None) -> None:
+    from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+
+    adapter = SQLModelAdapter(City, engine)
+    page1 = await adapter.get_choices("country", limit=1, offset=0)
+    page2 = await adapter.get_choices("country", limit=1, offset=1)
+
+    assert len(page1) == 1
+    assert len(page2) == 1
+    assert page1[0]["value"] != page2[0]["value"]
+
+
+@pytest.mark.anyio
+async def test_get_choices_cascading_filter(engine: AsyncEngine, populated_db: None) -> None:
+    from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+
+    async with AsyncSession(engine) as session:
+        result = await session.execute(select(Country).where(Country.name == "United Kingdom"))
+        uk = result.scalar_one()
+        uk_id = uk.id
+
+    adapter = SQLModelAdapter(Country, engine)
+    choices = await adapter.get_choices("cities", country_id=uk_id)
+
+    assert len(choices) == 2
+    labels = {c["label"] for c in choices}
+    assert "London" in labels
+    assert "Manchester" in labels
+
+
+@pytest.mark.anyio
+async def test_get_choices_limit_exceeds_max_raises(engine: AsyncEngine) -> None:
+    from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+
+    adapter = SQLModelAdapter(City, engine)
+    with pytest.raises(ValueError, match="exceeds maximum"):
+        await adapter.get_choices("country", limit=201)
+
+
+@pytest.mark.anyio
+async def test_get_choices_unknown_field_returns_empty(engine: AsyncEngine) -> None:
+    from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+
+    adapter = SQLModelAdapter(City, engine)
+    choices = await adapter.get_choices("nonexistent_field")
+    assert choices == []

--- a/tests/unit/test_core_field_classification.py
+++ b/tests/unit/test_core_field_classification.py
@@ -1,0 +1,168 @@
+"""Unit tests for classify_field() — no real DB required."""
+
+from __future__ import annotations
+
+from enum import Enum
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from hyperadmin.core.choices import SelectFieldMeta
+from hyperadmin.core.fields import classify_field
+
+
+class Color(Enum):
+    RED = "red"
+    BLUE = "blue"
+    GREEN = "green"
+
+
+class PureModel(BaseModel):
+    color: Color
+    colors: list[Color]
+    tags: list[str]
+    name: str
+    opt_color: Color | None = None
+    opt_name: str | None = None
+
+
+def test_enum_field_returns_single_select() -> None:
+    fi = PureModel.model_fields["color"]
+    result = classify_field(fi, PureModel)
+    assert isinstance(result, SelectFieldMeta)
+    assert result.choices_source == "enum"
+    assert result.multiple is False
+    assert result.preload is True
+
+
+def test_list_enum_field_returns_multi_select() -> None:
+    fi = PureModel.model_fields["colors"]
+    result = classify_field(fi, PureModel)
+    assert isinstance(result, SelectFieldMeta)
+    assert result.choices_source == "enum"
+    assert result.multiple is True
+
+
+def test_optional_enum_field_returns_single_select() -> None:
+    fi = PureModel.model_fields["opt_color"]
+    result = classify_field(fi, PureModel)
+    assert isinstance(result, SelectFieldMeta)
+    assert result.choices_source == "enum"
+    assert result.multiple is False
+
+
+def test_list_str_hybrid_returns_static_multi() -> None:
+    fi = PureModel.model_fields["tags"]
+    result = classify_field(fi, PureModel)
+    assert isinstance(result, SelectFieldMeta)
+    assert result.choices_source == "static"
+    assert result.multiple is True
+    assert result.preload is True
+
+
+def test_plain_str_returns_none() -> None:
+    fi = PureModel.model_fields["name"]
+    result = classify_field(fi, PureModel)
+    assert result is None
+
+
+def test_optional_str_returns_none() -> None:
+    fi = PureModel.model_fields["opt_name"]
+    result = classify_field(fi, PureModel)
+    assert result is None
+
+
+def test_fk_field_via_relationship_returns_relation_single() -> None:
+    mock_rel = MagicMock()
+    mock_rel.key = "category_id"
+    mock_rel.uselist = False
+
+    mock_mapper = MagicMock()
+    mock_mapper.relationships = [mock_rel]
+    mock_mapper.columns = []
+
+    class OrmLikeModel(BaseModel):
+        category_id: int
+
+    with (
+        patch("hyperadmin.core.fields._HAS_SQLALCHEMY", True),
+        patch("hyperadmin.core.fields.sa_inspect", return_value=mock_mapper, create=True),
+    ):
+        fi = OrmLikeModel.model_fields["category_id"]
+        result = classify_field(fi, OrmLikeModel)
+
+    assert isinstance(result, SelectFieldMeta)
+    assert result.choices_source == "relation"
+    assert result.multiple is False
+    assert result.preload is False
+
+
+def test_m2m_field_via_relationship_returns_relation_multi() -> None:
+    mock_rel = MagicMock()
+    mock_rel.key = "tags"
+    mock_rel.uselist = True
+
+    mock_mapper = MagicMock()
+    mock_mapper.relationships = [mock_rel]
+    mock_mapper.columns = []
+
+    class OrmLikeModel(BaseModel):
+        tags: list[int]
+
+    with (
+        patch("hyperadmin.core.fields._HAS_SQLALCHEMY", True),
+        patch("hyperadmin.core.fields.sa_inspect", return_value=mock_mapper, create=True),
+    ):
+        fi = OrmLikeModel.model_fields["tags"]
+        result = classify_field(fi, OrmLikeModel)
+
+    assert isinstance(result, SelectFieldMeta)
+    assert result.choices_source == "relation"
+    assert result.multiple is True
+
+
+def test_bare_fk_column_returns_relation_single() -> None:
+    mock_col = MagicMock()
+    mock_col.key = "country_id"
+    mock_col.foreign_keys = {"fk"}
+
+    mock_mapper = MagicMock()
+    mock_mapper.relationships = []
+    mock_mapper.columns = [mock_col]
+
+    class OrmLikeModel(BaseModel):
+        country_id: int
+
+    with (
+        patch("hyperadmin.core.fields._HAS_SQLALCHEMY", True),
+        patch("hyperadmin.core.fields.sa_inspect", return_value=mock_mapper, create=True),
+    ):
+        fi = OrmLikeModel.model_fields["country_id"]
+        result = classify_field(fi, OrmLikeModel)
+
+    assert isinstance(result, SelectFieldMeta)
+    assert result.choices_source == "relation"
+    assert result.multiple is False
+
+
+def test_no_inspection_available_falls_through() -> None:
+    from sqlalchemy.exc import NoInspectionAvailable
+
+    class PurePydanticModel(BaseModel):
+        fk_id: int
+
+    with (
+        patch("hyperadmin.core.fields._HAS_SQLALCHEMY", True),
+        patch("hyperadmin.core.fields.sa_inspect", side_effect=NoInspectionAvailable, create=True),
+    ):
+        fi = PurePydanticModel.model_fields["fk_id"]
+        result = classify_field(fi, PurePydanticModel)
+
+    assert result is None
+
+
+@pytest.mark.parametrize("field_name", ["name", "opt_name"])
+def test_non_select_fields_return_none(field_name: str) -> None:
+    fi = PureModel.model_fields[field_name]
+    assert classify_field(fi, PureModel) is None

--- a/tests/unit/test_dependent_select.py
+++ b/tests/unit/test_dependent_select.py
@@ -1,0 +1,162 @@
+"""Unit tests for cascading/dependent select support (#166)."""
+
+from __future__ import annotations
+
+import builtins
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import BaseModel
+from starlette.requests import Request
+
+from hyperadmin.core.adapters import BaseAdapter
+from hyperadmin.core.choices import ChoiceItem
+from hyperadmin.core.options import AdminOptions
+from hyperadmin.views import dynamic as dynamic_module
+from hyperadmin.views.forms import RelationSelectWidget
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class City(BaseModel):
+    name: str
+    country_id: int | None = None
+
+
+class StubAdapter(BaseAdapter):
+    def __init__(self, model):
+        self.model = model
+        rel = SimpleNamespace(key="country")
+        self.inspector = SimpleNamespace(relationships=[rel], c=[])
+
+    async def get(self, pk: Any) -> Any:
+        return None
+
+    async def list(self, **kwargs: Any) -> tuple[list[Any], int]:
+        return [], 0
+
+    async def create(self, data: dict[str, Any]) -> Any:
+        return None
+
+    async def update(self, pk: Any, data: dict[str, Any]) -> Any:
+        return None
+
+    async def delete(self, pk: Any) -> None:
+        pass
+
+    async def get_related(self, pk: Any, field: str) -> builtins.list[Any]:
+        return []
+
+    async def get_schema(self) -> dict[str, Any]:
+        return {}
+
+    async def get_choices(
+        self,
+        field: str,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+        **filters: Any,
+    ) -> builtins.list[ChoiceItem]:
+        return [ChoiceItem(value="1", label="UK", selected=False)]
+
+
+def _make_request(query_string: str = "") -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "query_string": query_string.encode(),
+        "headers": [],
+        "app": SimpleNamespace(
+            url_path_for=lambda name, **kw: SimpleNamespace(
+                make_absolute_url=lambda base_url=None, **kwargs: f"/{name}"
+            )
+        ),
+    }
+    return Request(scope)
+
+
+@pytest.fixture
+def view():
+    from fastapi.templating import Jinja2Templates
+
+    templates = Jinja2Templates(directory="src/hyperadmin/templates")
+    adapter = StubAdapter(City)
+    options = AdminOptions(dependent_fields={"country_id": "region_id"})
+    return dynamic_module.DynamicModelView(
+        adapter=adapter,
+        options=options,
+        templates=templates,
+        app_label=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_choices_view_forwards_extra_filters(view):
+    """Extra query params (parent field values) are forwarded as kwargs to get_choices."""
+    view.adapter.get_choices = AsyncMock(return_value=[])
+    request = _make_request("country_id=3&q=&limit=50&offset=0")
+    await view.choices_view(request, field_name="country", q="", limit=50, offset=0)
+    view.adapter.get_choices.assert_awaited_once_with(
+        "country", q="", limit=50, offset=0, country_id="3"
+    )
+
+
+@pytest.mark.anyio
+async def test_choices_view_no_extra_filters(view):
+    """When no extra params, get_choices is called without filters."""
+    view.adapter.get_choices = AsyncMock(return_value=[])
+    request = _make_request("q=&limit=50&offset=0")
+    await view.choices_view(request, field_name="country", q="", limit=50, offset=0)
+    view.adapter.get_choices.assert_awaited_once_with("country", q="", limit=50, offset=0)
+
+
+def test_admin_options_dependent_fields_default():
+    opts = AdminOptions()
+    assert opts.dependent_fields == {}
+
+
+def test_admin_options_dependent_fields_custom():
+    opts = AdminOptions(dependent_fields={"city": "country_id"})
+    assert opts.dependent_fields == {"city": "country_id"}
+
+
+def test_relation_select_widget_dependent_on():
+    widget = RelationSelectWidget(
+        choices_url="/city/choices/country", preload=False, dependent_on="region_id"
+    )
+    assert widget.dependent_on == "region_id"
+
+
+def test_relation_select_widget_dependent_on_none_default():
+    widget = RelationSelectWidget(choices_url="/city/choices/country")
+    assert widget.dependent_on is None
+
+
+@pytest.mark.anyio
+async def test_build_relation_widgets_wires_dependent_on(view):
+    """_build_relation_widgets picks up dependent_fields from AdminOptions."""
+    with patch("hyperadmin.views.dynamic.classify_field") as mock_classify:
+        from hyperadmin.core.choices import SelectFieldMeta
+
+        mock_classify.return_value = SelectFieldMeta(
+            choices_source="relation", preload=False, multiple=False
+        )
+        view.adapter.get_choices = AsyncMock(return_value=[])
+        widgets = await view._build_relation_widgets(field_names=[], selected_values={})
+
+    # "country_id" field should get dependent_on="region_id" from options.dependent_fields
+    assert "country_id" in widgets
+    w = widgets["country_id"]
+    assert isinstance(w, RelationSelectWidget)
+    assert w.dependent_on == "region_id"

--- a/tests/unit/test_dynamic_choices_endpoint.py
+++ b/tests/unit/test_dynamic_choices_endpoint.py
@@ -1,0 +1,152 @@
+"""Unit tests for DynamicModelView.choices_view() — HTMX autocomplete endpoint."""
+
+from __future__ import annotations
+
+import builtins
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from pydantic import BaseModel
+from starlette.requests import Request
+
+from hyperadmin.core.adapters import BaseAdapter
+from hyperadmin.core.choices import ChoiceItem
+from hyperadmin.views import dynamic as dynamic_module
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+class User(BaseModel):
+    name: str
+    country_id: int | None = None
+
+
+class StubAdapter(BaseAdapter):
+    def __init__(self, model):
+        self.model = model
+        # Simulate inspector with a "country" relationship
+        rel = SimpleNamespace(key="country")
+        self.inspector = SimpleNamespace(
+            relationships=[rel],
+            c=[],
+        )
+
+    async def get(self, pk: Any) -> Any:
+        return None
+
+    async def list(self, **kwargs: Any) -> tuple[list[Any], int]:
+        return [], 0
+
+    async def create(self, data: dict[str, Any]) -> Any:
+        return None
+
+    async def update(self, pk: Any, data: dict[str, Any]) -> Any:
+        return None
+
+    async def delete(self, pk: Any) -> None:
+        pass
+
+    async def get_related(self, pk: Any, field: str) -> builtins.list[Any]:
+        return []
+
+    async def get_schema(self) -> dict[str, Any]:
+        return {}
+
+    async def get_choices(
+        self,
+        field: str,
+        q: str = "",
+        limit: int = 50,
+        offset: int = 0,
+        **filters: Any,
+    ) -> builtins.list[ChoiceItem]:
+        return [
+            ChoiceItem(value="1", label="UK", selected=False),
+            ChoiceItem(value="2", label="France", selected=False),
+        ]
+
+
+def _make_request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [],
+        "app": SimpleNamespace(
+            url_path_for=lambda name, **kw: SimpleNamespace(
+                make_absolute_url=lambda base_url=None, **kwargs: f"/{name}"
+            )
+        ),
+    }
+    return Request(scope)
+
+
+@pytest.fixture
+def view(tmp_path):
+    from fastapi.templating import Jinja2Templates
+
+    templates = Jinja2Templates(directory="src/hyperadmin/templates")
+    adapter = StubAdapter(User)
+    return dynamic_module.DynamicModelView(
+        adapter=adapter,
+        options=SimpleNamespace(),
+        templates=templates,
+        app_label=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_choices_view_returns_html_options(view):
+    request = _make_request()
+    response = await view.choices_view(request, field_name="country")
+    assert response.media_type == "text/html"
+    content = response.body.decode()
+    assert "UK" in content
+    assert "France" in content
+
+
+@pytest.mark.anyio
+async def test_choices_view_limit_exceeds_max_returns_400(view):
+    request = _make_request()
+    with pytest.raises(HTTPException) as exc_info:
+        await view.choices_view(request, field_name="country", limit=201)
+    assert exc_info.value.status_code == 400
+    assert "exceeds maximum" in exc_info.value.detail
+
+
+@pytest.mark.anyio
+async def test_choices_view_unknown_field_returns_404(view):
+    request = _make_request()
+    with pytest.raises(HTTPException) as exc_info:
+        await view.choices_view(request, field_name="nonexistent")
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_choices_view_passes_q_to_adapter(view):
+    """Assert that the search query is forwarded to the adapter."""
+    request = _make_request()
+    view.adapter.get_choices = AsyncMock(
+        return_value=[ChoiceItem(value="1", label="UK", selected=False)]
+    )
+    await view.choices_view(request, field_name="country", q="uk")
+    view.adapter.get_choices.assert_awaited_once_with("country", q="uk", limit=50, offset=0)
+
+
+@pytest.mark.anyio
+async def test_choices_view_pagination(view):
+    """Assert that limit/offset are forwarded to the adapter."""
+    request = _make_request()
+    view.adapter.get_choices = AsyncMock(return_value=[])
+    await view.choices_view(request, field_name="country", limit=10, offset=20)
+    view.adapter.get_choices.assert_awaited_once_with("country", q="", limit=10, offset=20)

--- a/tests/unit/test_dynamic_choices_endpoint.py
+++ b/tests/unit/test_dynamic_choices_endpoint.py
@@ -71,11 +71,12 @@ class StubAdapter(BaseAdapter):
         ]
 
 
-def _make_request() -> Request:
+def _make_request(query_string: str = "") -> Request:
     scope = {
         "type": "http",
         "method": "GET",
         "path": "/",
+        "query_string": query_string.encode(),
         "headers": [],
         "app": SimpleNamespace(
             url_path_for=lambda name, **kw: SimpleNamespace(

--- a/tests/unit/test_dynamic_view_htmx.py
+++ b/tests/unit/test_dynamic_view_htmx.py
@@ -44,6 +44,9 @@ class DummyAdapter(BaseAdapter):
     async def get_schema(self):
         return {}
 
+    async def get_choices(self, field, q="", limit=50, offset=0, **filters):
+        return []
+
 
 class User(BaseModel):
     name: str

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -6,6 +6,7 @@ from typing import Any
 from markupsafe import Markup
 from pydantic import BaseModel, Field
 
+from hyperadmin.views import forms as forms_module
 from hyperadmin.views.forms import (
     FormField,
     HtmxWidget,
@@ -240,6 +241,125 @@ def test_relation_multiselect_widget_lazy():
     widget = RelationMultiSelectWidget(choices_url="/country/choices/cities", preload=False)
     assert widget.preload is False
     assert widget.choices == []
+
+
+def test_pick_widget_enum_auto_detects_select_widget():
+    """classify_field → enum → SelectWidget with choices."""
+    from enum import Enum
+    from unittest.mock import patch
+
+    class Color(Enum):
+        RED = "red"
+        BLUE = "blue"
+
+    class ColorModel(BaseModel):
+        color: Color
+
+    with (
+        patch.object(forms_module, "_HAS_CLASSIFY", True),
+        patch.object(forms_module, "_classify_field") as mock_classify,
+    ):
+        from hyperadmin.core.choices import SelectFieldMeta
+
+        mock_classify.return_value = SelectFieldMeta(
+            choices_source="enum", preload=True, multiple=False
+        )
+        form = PydanticForm(model=ColorModel)
+        widget = form._pick_widget("color", ColorModel.model_fields["color"])
+
+    assert isinstance(widget, SelectWidget)
+    assert len(widget.choices) == 2
+    labels = {c["label"] for c in widget.choices}
+    assert "RED" in labels
+    assert "BLUE" in labels
+
+
+def test_pick_widget_enum_multiple_detects_multiselect_widget():
+    """classify_field → enum + multiple → MultiSelectWidget."""
+    from enum import Enum
+    from unittest.mock import patch
+
+    class Tag(Enum):
+        A = "a"
+        B = "b"
+
+    class TagModel(BaseModel):
+        tags: list[Tag]
+
+    with (
+        patch.object(forms_module, "_HAS_CLASSIFY", True),
+        patch.object(forms_module, "_classify_field") as mock_classify,
+    ):
+        from hyperadmin.core.choices import SelectFieldMeta
+
+        mock_classify.return_value = SelectFieldMeta(
+            choices_source="enum", preload=True, multiple=True
+        )
+        form = PydanticForm(model=TagModel)
+        widget = form._pick_widget("tags", TagModel.model_fields["tags"])
+
+    assert isinstance(widget, MultiSelectWidget)
+
+
+def test_pick_widget_relation_detects_relation_select_widget():
+    """classify_field → relation → RelationSelectWidget."""
+    from unittest.mock import patch
+
+    class RelModel(BaseModel):
+        country_id: int | None = None
+
+    with (
+        patch.object(forms_module, "_HAS_CLASSIFY", True),
+        patch.object(forms_module, "_classify_field") as mock_classify,
+    ):
+        from hyperadmin.core.choices import SelectFieldMeta
+
+        mock_classify.return_value = SelectFieldMeta(
+            choices_source="relation", preload=False, multiple=False
+        )
+        form = PydanticForm(model=RelModel, choices_base_url="/relmodel/choices")
+        widget = form._pick_widget("country_id", RelModel.model_fields["country_id"])
+
+    assert isinstance(widget, RelationSelectWidget)
+    assert widget.choices_url == "/relmodel/choices/country_id"
+    assert widget.preload is False
+
+
+def test_pick_widget_relation_multiple_detects_relation_multiselect():
+    """classify_field → relation + multiple → RelationMultiSelectWidget."""
+    from unittest.mock import patch
+
+    class M2MModel(BaseModel):
+        tags_ids: list[int] = []
+
+    with (
+        patch.object(forms_module, "_HAS_CLASSIFY", True),
+        patch.object(forms_module, "_classify_field") as mock_classify,
+    ):
+        from hyperadmin.core.choices import SelectFieldMeta
+
+        mock_classify.return_value = SelectFieldMeta(
+            choices_source="relation", preload=False, multiple=True
+        )
+        form = PydanticForm(model=M2MModel, choices_base_url="/m2mmodel/choices")
+        widget = form._pick_widget("tags_ids", M2MModel.model_fields["tags_ids"])
+
+    assert isinstance(widget, RelationMultiSelectWidget)
+    assert widget.choices_url == "/m2mmodel/choices/tags_ids"
+
+
+def test_pick_widget_classify_none_falls_through_to_heuristics():
+    """When classify_field returns None, legacy heuristics still apply."""
+    from unittest.mock import patch
+
+    with (
+        patch.object(forms_module, "_HAS_CLASSIFY", True),
+        patch.object(forms_module, "_classify_field", return_value=None),
+    ):
+        form = PydanticForm(model=PydanticModel)
+        widget = form._pick_widget("age", PydanticModel.model_fields["age"])
+
+    assert isinstance(widget, NumberInput)
 
 
 def test_pydantic_form_media():

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -12,6 +12,8 @@ from hyperadmin.views.forms import (
     MultiSelectWidget,
     NumberInput,
     PydanticForm,
+    RelationMultiSelectWidget,
+    RelationSelectWidget,
     SelectWidget,
     Textarea,
     TextInput,
@@ -202,6 +204,42 @@ def test_hybrid_round_trip_csv():
 def test_hybrid_round_trip_json():
     original = ["one", "two", "three"]
     assert hybrid_to_python(hybrid_to_storage(original, "json"), "json") == original
+
+
+def test_relation_select_widget_preload():
+    choices = [
+        {"value": "1", "label": "UK", "selected": True},
+        {"value": "2", "label": "FR", "selected": False},
+    ]
+    widget = RelationSelectWidget(choices_url="/city/choices/country", choices=choices)
+    assert widget.template_path == "widgets/relation_select_input.html"
+    assert widget.preload is True
+    assert widget.choices_url == "/city/choices/country"
+    assert len(widget.choices) == 2
+    assert widget.choices[0]["selected"] is True
+
+
+def test_relation_select_widget_lazy():
+    widget = RelationSelectWidget(choices_url="/city/choices/country", preload=False)
+    assert widget.preload is False
+    assert widget.choices == []
+
+
+def test_relation_multiselect_widget_preload():
+    choices = [
+        {"value": "1", "label": "London", "selected": False},
+        {"value": "2", "label": "Paris", "selected": True},
+    ]
+    widget = RelationMultiSelectWidget(choices_url="/country/choices/cities", choices=choices)
+    assert widget.template_path == "widgets/relation_multiselect_input.html"
+    assert widget.preload is True
+    assert len(widget.choices) == 2
+
+
+def test_relation_multiselect_widget_lazy():
+    widget = RelationMultiSelectWidget(choices_url="/country/choices/cities", preload=False)
+    assert widget.preload is False
+    assert widget.choices == []
 
 
 def test_pydantic_form_media():

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -9,10 +9,14 @@ from pydantic import BaseModel, Field
 from hyperadmin.views.forms import (
     FormField,
     HtmxWidget,
+    MultiSelectWidget,
     NumberInput,
     PydanticForm,
+    SelectWidget,
     Textarea,
     TextInput,
+    hybrid_to_python,
+    hybrid_to_storage,
 )
 
 
@@ -131,6 +135,73 @@ def test_pydantic_form_validation_error():
     instance, errors = form.validate(data)
     assert instance is None
     assert "age" in errors
+
+
+def test_select_widget_holds_choices():
+    choices = [
+        {"value": "1", "label": "Option A", "selected": False},
+        {"value": "2", "label": "Option B", "selected": True},
+    ]
+    widget = SelectWidget(choices=choices)
+    assert widget.template_path == "widgets/select_input.html"
+    assert widget.choices == choices
+
+
+def test_select_widget_empty_by_default():
+    widget = SelectWidget()
+    assert widget.choices == []
+
+
+def test_multiselect_widget_holds_choices():
+    choices = [
+        {"value": "a", "label": "Apple", "selected": True},
+        {"value": "b", "label": "Banana", "selected": False},
+    ]
+    widget = MultiSelectWidget(choices=choices)
+    assert widget.template_path == "widgets/multiselect_input.html"
+    assert widget.choices == choices
+
+
+def test_multiselect_widget_empty_by_default():
+    widget = MultiSelectWidget()
+    assert widget.choices == []
+
+
+def test_hybrid_to_python_csv():
+    assert hybrid_to_python("a,b,c", "csv") == ["a", "b", "c"]
+
+
+def test_hybrid_to_python_json():
+    assert hybrid_to_python('["x", "y"]', "json") == ["x", "y"]
+
+
+def test_hybrid_to_python_list_passthrough():
+    assert hybrid_to_python(["p", "q"], "csv") == ["p", "q"]
+
+
+def test_hybrid_to_python_empty_string():
+    assert hybrid_to_python("", "csv") == []
+    assert hybrid_to_python("", "json") == []
+
+
+def test_hybrid_to_storage_csv():
+    assert hybrid_to_storage(["a", "b"], "csv") == "a,b"
+
+
+def test_hybrid_to_storage_json():
+    import json
+
+    assert json.loads(hybrid_to_storage(["x", "y"], "json")) == ["x", "y"]
+
+
+def test_hybrid_round_trip_csv():
+    original = ["red", "green", "blue"]
+    assert hybrid_to_python(hybrid_to_storage(original, "csv"), "csv") == original
+
+
+def test_hybrid_round_trip_json():
+    original = ["one", "two", "three"]
+    assert hybrid_to_python(hybrid_to_storage(original, "json"), "json") == original
 
 
 def test_pydantic_form_media():

--- a/tests/unit/test_list_view.py
+++ b/tests/unit/test_list_view.py
@@ -84,6 +84,9 @@ class MockAdapter(BaseAdapter):
     async def get_schema(self):
         return SampleModel.model_json_schema()
 
+    async def get_choices(self, field, q="", limit=50, offset=0, **filters):
+        return []
+
 
 @pytest.fixture
 def mock_request():


### PR DESCRIPTION
## Summary

Epic A — Core field introspection for auto-detection of select/relation widgets.

### Commits (one per issue)
- `feat(core): classify_field() for select widget auto-detection (#162)`
- `test(core): unit tests for classify_field() (#181)`
- `feat(adapters): get_choices() for FK/M2M with N+1-safe loading (#161)`
- `test(adapters): unit tests for get_choices() with N+1 assertion (#182)`
- `feat(views): SelectWidget, MultiSelectWidget, HybridFieldCoercer (#163)`
- `feat(views): RelationSelectWidget and RelationMultiSelectWidget with preload strategies (#164)`
- `feat(views): HTMX autocomplete endpoint for async relation choice search (#165)`
- `feat(views): dependent (cascading) select endpoint and widget support (#166)`
- `feat(views): update PydanticForm._pick_widget() for relations and hybrid fields (#167)`
- `fix(core): handle types.UnionType for Optional fields on Python 3.10+ (#181)`

### What was built
- `classify_field(field_info, model_cls)` — auto-detects enum/static/relation fields
- `get_choices()` on SQLAlchemy + SQLModel adapters — N+1-safe single SELECT, `limit ≤ 200`, cascading `**filters`
- `SelectWidget`, `MultiSelectWidget` — preloaded enum/static choices
- `RelationSelectWidget`, `RelationMultiSelectWidget` — preload + lazy HTMX strategies
- `HybridFieldCoercer` — CSV/JSON round-trip for `list[str]` fields
- `GET /{model}/choices/{field}` HTMX endpoint — `<option>` fragment, forwards cascading filters
- `AdminOptions.dependent_fields` — cascading select config
- `PydanticForm._pick_widget()` now calls `classify_field()` for auto-detection

## Test plan
- [ ] `poe test:unit` green (277 tests)
- [ ] `poe lint` green
- [ ] Review each commit diff for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)