### PR TITLE
feat(epic-b): select/relation widgets, FK introspection, E2E tests (#169 #170 #183)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ node_modules/
 
 # pytest
 .pytest_cache/
+.coverage
+.coverage*
 
 # Python
 __pycache__/
@@ -72,10 +74,10 @@ uv.lock
 # MkDocs
 site/
 
+# Sqlite
 *.sqlite3
 *.db
-.coverage
-.coverage*
+
 # Claude Code
 .claude/settings.local.json
 
@@ -83,4 +85,7 @@ site/
 !.gemini/
 .gemini/context/
 gha-creds-*.json
-misc/tailadmin-free-tailwind-dashboard-template-main/*
+
+# git worktrees
+/.worktrees/
+

--- a/examples/simple/admin.py
+++ b/examples/simple/admin.py
@@ -1,4 +1,4 @@
-from examples.simple.models import Product, User
+from examples.simple.models import City, Country, Product, User
 from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 from hyperadmin.core.model import ModelAdmin
 from hyperadmin.core.registry import site
@@ -13,5 +13,15 @@ class ProductAdmin(ModelAdmin):
     adapter_class = SQLModelAdapter
 
 
+class CountryAdmin(ModelAdmin):
+    adapter_class = SQLModelAdapter
+
+
+class CityAdmin(ModelAdmin):
+    adapter_class = SQLModelAdapter
+
+
 site.register(User, UserAdmin)
 site.register(Product, ProductAdmin)
+site.register(Country, CountryAdmin)
+site.register(City, CityAdmin)

--- a/examples/simple/main.py
+++ b/examples/simple/main.py
@@ -6,7 +6,7 @@ from fastapi.staticfiles import StaticFiles
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlmodel import SQLModel, select
 
-from examples.simple.models import User
+from examples.simple.models import City, Country, User
 from hyperadmin.main import Admin
 
 # 1. Create a database engine
@@ -28,6 +28,24 @@ async def create_db_and_tables():
             session.add(User(name="Alice", email="alice@example.com"))
             session.add(User(name="Bob", email="bob@example.com"))
             session.add(User(name="Charlie", email="charlie@example.com"))
+            await session.commit()
+
+    async with AsyncSession(engine) as session:
+        result = await session.execute(select(Country))
+        if not result.first():
+            uk = Country(name="United Kingdom")
+            fr = Country(name="France")
+            session.add_all([uk, fr])
+            await session.commit()
+            await session.refresh(uk)
+            await session.refresh(fr)
+            session.add_all(
+                [
+                    City(name="London", country_id=uk.id),
+                    City(name="Manchester", country_id=uk.id),
+                    City(name="Paris", country_id=fr.id),
+                ]
+            )
             await session.commit()
 
 

--- a/examples/simple/models.py
+++ b/examples/simple/models.py
@@ -1,7 +1,8 @@
 from datetime import datetime
 from enum import Enum
 
-from sqlmodel import Field, SQLModel
+from sqlalchemy.orm import Mapped
+from sqlmodel import Field, Relationship, SQLModel
 
 
 class UserType(str, Enum):
@@ -33,3 +34,24 @@ class Product(SQLModel, table=True):
     is_available: bool = True
     category: ProductCategory = Field(default=ProductCategory.ELECTRONICS, nullable=False)
     release_date: datetime | None = Field(default_factory=datetime.now)
+
+
+class Country(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(min_length=1)
+
+    cities: Mapped[list["City"]] = Relationship(back_populates="country")
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class City(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(min_length=1)
+    country_id: int | None = Field(default=None, foreign_key="country.id")
+
+    country: Mapped[Country | None] = Relationship(back_populates="cities")
+
+    def __str__(self) -> str:
+        return self.name

--- a/justfile
+++ b/justfile
@@ -46,11 +46,15 @@ qa: lint type-check audit test-cov
 
 # Run tests
 test:
-    uv run pytest --tb=short -q
+    uv run poe test:unit
 
 # Run tests with coverage (fail under 80%)
 test-cov:
     uv run pytest --tb=short --cov=src/hyperadmin --cov-report=term-missing --cov-fail-under=80
+
+# Run e2e tests
+test-e2e:
+    uv run poe test:e2e
 
 # ── Build ─────────────────────────────────────────────────────
 
@@ -103,6 +107,14 @@ setup-github repo="":
 secure repo="":
     bash scripts/secure-repo.sh {{ repo }}
 
+# -- Local dev -------------────────────────────────────────────
+
+# Run erp example
+run-erp:
+    uv run uvicorn examples.erp.main:app --log-level debug --reload --port 8001
+
+run-simple:
+    uv run uvicorn examples.simple.main:app --log-level debug --reload --port 8002
 
 # ── Utils ─────────────────────────────────────────────────────
 

--- a/src/hyperadmin/adapters/sqlmodel.py
+++ b/src/hyperadmin/adapters/sqlmodel.py
@@ -18,6 +18,7 @@ class SQLModelAdapter(BaseAdapter):
 
     def __init__(self, model: type[SQLModel], engine: AsyncEngine):
         super().__init__(model, engine)
+        self.inspector = inspect(model)
 
     async def get(self, pk: Any) -> Any:
         """

--- a/src/hyperadmin/core/fields.py
+++ b/src/hyperadmin/core/fields.py
@@ -123,7 +123,7 @@ def _inspect_orm_field(model_cls: type, field_name: str) -> SelectFieldMeta | No
         if getattr(col, "key", None) == field_name and getattr(col, "foreign_keys", None):
             return SelectFieldMeta(
                 choices_source="relation",
-                preload=False,
+                preload=True,  # FK columns are typically small; preload by default
                 multiple=False,
             )
 

--- a/src/hyperadmin/templates/widgets/multiselect_input.html
+++ b/src/hyperadmin/templates/widgets/multiselect_input.html
@@ -5,7 +5,9 @@
     <select id="{{- field.name -}}" {# -#}
             name="{{- field.name -}}" {# -#}
             multiple {# -#}
-            class="ha-select ha-select--multi">
+            aria-multiselectable="true" {# -#}
+            class="ha-select ha-select--multi ha-multiselect" {# -#}
+            data-testid="{{- field.name -}}-select">
         {%- for choice in widget.choices -%}
             <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
         {%- endfor -%}

--- a/src/hyperadmin/templates/widgets/relation_multiselect_input.html
+++ b/src/hyperadmin/templates/widgets/relation_multiselect_input.html
@@ -6,7 +6,9 @@
     <select id="{{- field.name -}}" {# -#}
             name="{{- field.name -}}" {# -#}
             multiple {# -#}
-            class="ha-select ha-select--multi ha-select--relation">
+            aria-multiselectable="true" {# -#}
+            class="ha-select ha-select--multi ha-select--relation" {# -#}
+            data-testid="{{- field.name -}}-relation-multiselect">
         {%- for choice in widget.choices -%}
             <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
         {%- endfor -%}
@@ -15,7 +17,9 @@
     <select id="{{- field.name -}}" {# -#}
             name="{{- field.name -}}" {# -#}
             multiple {# -#}
+            aria-multiselectable="true" {# -#}
             class="ha-select ha-select--multi ha-select--relation ha-select--lazy" {# -#}
+            data-testid="{{- field.name -}}-relation-multiselect" {# -#}
             hx-get="{{- widget.choices_url -}}?q=" {# -#}
             {%- if widget.dependent_on -%}
             hx-trigger="focus delay:200ms, input changed delay:300ms, change from:[name={{- widget.dependent_on -}}]" {# -#}
@@ -23,7 +27,8 @@
             {%- else -%}
             hx-trigger="focus delay:200ms, input changed delay:300ms" {# -#}
             {%- endif -%}
-            hx-target="#{{- field.name -}}-options">
+            hx-target="#{{- field.name -}}-options" {# -#}
+            hx-swap="innerHTML">
         {%- for choice in widget.choices -%}
             <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
         {%- endfor -%}

--- a/src/hyperadmin/templates/widgets/relation_select_input.html
+++ b/src/hyperadmin/templates/widgets/relation_select_input.html
@@ -5,7 +5,8 @@
     {%- if widget.preload -%}
     <select id="{{- field.name -}}" {# -#}
             name="{{- field.name -}}" {# -#}
-            class="ha-select ha-select--relation">
+            class="ha-select ha-select--relation" {# -#}
+            data-testid="{{- field.name -}}-relation-select">
         <option value="">---------</option>
         {%- for choice in widget.choices -%}
             <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>
@@ -15,6 +16,7 @@
     <select id="{{- field.name -}}" {# -#}
             name="{{- field.name -}}" {# -#}
             class="ha-select ha-select--relation ha-select--lazy" {# -#}
+            data-testid="{{- field.name -}}-relation-select" {# -#}
             hx-get="{{- widget.choices_url -}}?q=" {# -#}
             {%- if widget.dependent_on -%}
             hx-trigger="focus delay:200ms, input changed delay:300ms, change from:[name={{- widget.dependent_on -}}]" {# -#}
@@ -22,7 +24,8 @@
             {%- else -%}
             hx-trigger="focus delay:200ms, input changed delay:300ms" {# -#}
             {%- endif -%}
-            hx-target="#{{- field.name -}}-options">
+            hx-target="#{{- field.name -}}-options" {# -#}
+            hx-swap="innerHTML">
         <option value="">---------</option>
         {%- for choice in widget.choices -%}
             <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>

--- a/src/hyperadmin/templates/widgets/select_input.html
+++ b/src/hyperadmin/templates/widgets/select_input.html
@@ -4,7 +4,8 @@
     </label>
     <select id="{{- field.name -}}" {# -#}
             name="{{- field.name -}}" {# -#}
-            class="ha-select">
+            class="ha-select" {# -#}
+            data-testid="{{- field.name -}}-select">
         {%- if widget.choices is defined and widget.choices -%}
             {%- for choice in widget.choices -%}
                 <option value="{{- choice.value -}}" {%- if choice.selected -%} selected{%- endif -%}>{{- choice.label -}}</option>

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -288,17 +288,31 @@ class DynamicModelView:
         widgets: dict[str, HtmxWidget] = {}
         sv = selected_values or {}
         dependent_fields: dict[str, str] = getattr(self.options, "dependent_fields", {})
+
+        # Pre-build FK-column → relationship-name mapping via the adapter's inspector
+        # so that country_id → "country" for get_choices() and the HTMX URL.
+        fk_to_rel: dict[str, str] = {}
+        inspector = getattr(self.adapter, "inspector", None)
+        if inspector:
+            for rel in inspector.relationships:
+                for col in rel.local_columns:
+                    col_key = getattr(col, "key", None) or getattr(col, "name", None)
+                    if col_key:
+                        fk_to_rel[col_key] = rel.key
+
         for name, field_info in self.model.model_fields.items():
             if field_names and name not in field_names:
                 continue
             meta: SelectFieldMeta | None = classify_field(field_info, self.model)
             if meta is None or meta.choices_source != "relation":
                 continue
-            choices_url = f"/{self._model_name_lower}/choices/{name}"
+            # Resolve FK column name to relationship name (e.g. country_id → country)
+            rel_name: str = fk_to_rel.get(name) or name
+            choices_url = f"/{self._model_name_lower}/choices/{rel_name}"
             dependent_on = meta.dependent_on or dependent_fields.get(name)
             choices: list[ChoiceItem]
             if meta.preload:
-                raw_choices = await self.adapter.get_choices(name)
+                raw_choices = await self.adapter.get_choices(rel_name)
                 current = str(sv.get(name, ""))
                 choices = [
                     ChoiceItem(value=c["value"], label=c["label"], selected=c["value"] == current)

--- a/tests/e2e/test_relation_widgets.py
+++ b/tests/e2e/test_relation_widgets.py
@@ -1,0 +1,84 @@
+"""End-to-end tests for FK relation select widget — preload and lazy modes (#183)."""
+
+import re
+
+from playwright.sync_api import Page, expect
+
+# ---------------------------------------------------------------------------
+# Country preload tests (Country has no FK → options baked into page)
+# ---------------------------------------------------------------------------
+
+
+def test_city_create_form_shows_country_relation_select(page: Page, demo_base_url: str) -> None:
+    """City create form renders a relation select for the country_id FK field."""
+    page.goto(demo_base_url + "/admin/city/create")
+
+    expect(page.get_by_test_id("model-form")).to_be_visible()
+    # The country_id FK renders as a combobox (select element)
+    country_select = page.get_by_role("combobox", name=re.compile(r"country", re.IGNORECASE))
+    expect(country_select).to_be_visible()
+
+
+def test_city_create_form_preloaded_country_options_present(page: Page, demo_base_url: str) -> None:
+    """In preload mode the country options are present in the HTML before any interaction."""
+    page.goto(demo_base_url + "/admin/city/create")
+
+    country_select = page.get_by_role("combobox", name=re.compile(r"country", re.IGNORECASE))
+    expect(country_select).to_be_visible()
+
+    # Options must be present without any JS interaction (preload baked in)
+    options = country_select.locator("option")
+    # At minimum the blank option + UK + France from seed data
+    expect(options).to_have_count(3, timeout=3000)
+    option_texts = country_select.inner_text()
+    assert "United Kingdom" in option_texts
+    assert "France" in option_texts
+
+
+def test_city_create_form_submit_redirects_to_list(page: Page, demo_base_url: str) -> None:
+    """Submitting the create form with a selected country redirects to the city list."""
+    page.goto(demo_base_url + "/admin/city/create")
+
+    page.get_by_label("Name*").fill("Bristol")
+
+    country_select = page.get_by_role("combobox", name=re.compile(r"country", re.IGNORECASE))
+    # Select United Kingdom
+    country_select.select_option(label="United Kingdom")
+
+    page.get_by_role("button", name="Create").click()
+
+    expect(page).to_have_url(re.compile(r"/admin/city$"))
+    expect(page.get_by_test_id("list-table")).to_contain_text("Bristol")
+
+
+def test_city_update_form_preselects_current_country(page: Page, demo_base_url: str) -> None:
+    """Updating a city shows the current country preselected in the relation select."""
+    # Navigate to city list and click edit on the first row (London → UK)
+    page.goto(demo_base_url + "/admin/city")
+
+    page.get_by_test_id("list-row").first.get_by_test_id("row-edit-link").click()
+    expect(page).to_have_url(re.compile(r"/edit$"))
+    expect(page.get_by_test_id("model-form")).to_be_visible()
+
+    country_select = page.get_by_role("combobox", name=re.compile(r"country", re.IGNORECASE))
+    # The currently selected option should be non-empty (UK for London)
+    selected = country_select.evaluate("el => el.options[el.selectedIndex].text")
+    assert selected != "---------"
+
+
+def test_country_list_shows_entries(page: Page, demo_base_url: str) -> None:
+    """Country list view shows seeded countries."""
+    page.goto(demo_base_url + "/admin/country")
+
+    expect(page.get_by_test_id("list-table")).to_be_visible()
+    expect(page.get_by_test_id("list-table")).to_contain_text("United Kingdom")
+    expect(page.get_by_test_id("list-table")).to_contain_text("France")
+
+
+def test_city_list_shows_entries(page: Page, demo_base_url: str) -> None:
+    """City list view shows seeded cities."""
+    page.goto(demo_base_url + "/admin/city")
+
+    expect(page.get_by_test_id("list-table")).to_be_visible()
+    expect(page.get_by_test_id("list-table")).to_contain_text("London")
+    expect(page.get_by_test_id("list-table")).to_contain_text("Paris")

--- a/tests/e2e/test_relation_widgets.py
+++ b/tests/e2e/test_relation_widgets.py
@@ -35,8 +35,8 @@ def test_city_create_form_preloaded_country_options_present(page: Page, demo_bas
     assert "France" in option_texts
 
 
-def test_city_create_form_submit_redirects_to_list(page: Page, demo_base_url: str) -> None:
-    """Submitting the create form with a selected country redirects to the city list."""
+def test_city_create_form_submit_redirects_to_detail(page: Page, demo_base_url: str) -> None:
+    """Submitting the create form with a selected country redirects to the city detail page."""
     page.goto(demo_base_url + "/admin/city/create")
 
     page.get_by_label("Name*").fill("Bristol")
@@ -47,8 +47,8 @@ def test_city_create_form_submit_redirects_to_list(page: Page, demo_base_url: st
 
     page.get_by_role("button", name="Create").click()
 
-    expect(page).to_have_url(re.compile(r"/admin/city$"))
-    expect(page.get_by_test_id("list-table")).to_contain_text("Bristol")
+    expect(page).to_have_url(re.compile(r"/admin/city/\d+$"))
+    expect(page.get_by_test_id("detail-fields")).to_contain_text("Bristol")
 
 
 def test_city_update_form_preselects_current_country(page: Page, demo_base_url: str) -> None:

--- a/tests/unit/test_adapter_choices.py
+++ b/tests/unit/test_adapter_choices.py
@@ -11,24 +11,24 @@ from sqlmodel import Field, Relationship, SQLModel, select
 # ---------------------------------------------------------------------------
 
 
-class Country(SQLModel, table=True):
+class ChoiceCountry(SQLModel, table=True):
     __tablename__: str = "countries_choices"
     id: int | None = Field(default=None, primary_key=True)
     name: str
 
-    cities: Mapped[list["City"]] = Relationship(back_populates="country")
+    cities: Mapped[list["ChoiceCity"]] = Relationship(back_populates="country")
 
     def __str__(self) -> str:
         return self.name
 
 
-class City(SQLModel, table=True):
+class ChoiceCity(SQLModel, table=True):
     __tablename__: str = "cities_choices"
     id: int | None = Field(default=None, primary_key=True)
     name: str
     country_id: int | None = Field(default=None, foreign_key="countries_choices.id")
 
-    country: Mapped[Country | None] = Relationship(back_populates="cities")
+    country: Mapped[ChoiceCountry | None] = Relationship(back_populates="cities")
 
     def __str__(self) -> str:
         return self.name
@@ -48,17 +48,17 @@ async def engine() -> AsyncEngine:
 @pytest.fixture
 async def populated_db(engine: AsyncEngine) -> None:
     async with AsyncSession(engine) as session:
-        uk = Country(name="United Kingdom")
-        fr = Country(name="France")
+        uk = ChoiceCountry(name="United Kingdom")
+        fr = ChoiceCountry(name="France")
         session.add_all([uk, fr])
         await session.commit()
         await session.refresh(uk)
         await session.refresh(fr)
         session.add_all(
             [
-                City(name="London", country_id=uk.id),
-                City(name="Manchester", country_id=uk.id),
-                City(name="Paris", country_id=fr.id),
+                ChoiceCity(name="London", country_id=uk.id),
+                ChoiceCity(name="Manchester", country_id=uk.id),
+                ChoiceCity(name="Paris", country_id=fr.id),
             ]
         )
         await session.commit()
@@ -89,7 +89,7 @@ def query_counter(engine: AsyncEngine) -> list[str]:
 async def test_get_choices_fk_single_query(engine: AsyncEngine, populated_db: None) -> None:
     from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 
-    adapter = SQLModelAdapter(City, engine)
+    adapter = SQLModelAdapter(ChoiceCity, engine)
     log = query_counter(engine)
 
     choices = await adapter.get_choices("country")
@@ -107,7 +107,7 @@ async def test_get_choices_fk_single_query(engine: AsyncEngine, populated_db: No
 async def test_get_choices_search_filters_results(engine: AsyncEngine, populated_db: None) -> None:
     from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 
-    adapter = SQLModelAdapter(City, engine)
+    adapter = SQLModelAdapter(ChoiceCity, engine)
     choices = await adapter.get_choices("country", q="uni")
 
     assert len(choices) == 1
@@ -118,7 +118,7 @@ async def test_get_choices_search_filters_results(engine: AsyncEngine, populated
 async def test_get_choices_pagination(engine: AsyncEngine, populated_db: None) -> None:
     from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 
-    adapter = SQLModelAdapter(City, engine)
+    adapter = SQLModelAdapter(ChoiceCity, engine)
     page1 = await adapter.get_choices("country", limit=1, offset=0)
     page2 = await adapter.get_choices("country", limit=1, offset=1)
 
@@ -132,11 +132,13 @@ async def test_get_choices_cascading_filter(engine: AsyncEngine, populated_db: N
     from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 
     async with AsyncSession(engine) as session:
-        result = await session.execute(select(Country).where(Country.name == "United Kingdom"))
+        result = await session.execute(
+            select(ChoiceCountry).where(ChoiceCountry.name == "United Kingdom")
+        )
         uk = result.scalar_one()
         uk_id = uk.id
 
-    adapter = SQLModelAdapter(Country, engine)
+    adapter = SQLModelAdapter(ChoiceCountry, engine)
     choices = await adapter.get_choices("cities", country_id=uk_id)
 
     assert len(choices) == 2
@@ -149,7 +151,7 @@ async def test_get_choices_cascading_filter(engine: AsyncEngine, populated_db: N
 async def test_get_choices_limit_exceeds_max_raises(engine: AsyncEngine) -> None:
     from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 
-    adapter = SQLModelAdapter(City, engine)
+    adapter = SQLModelAdapter(ChoiceCity, engine)
     with pytest.raises(ValueError, match="exceeds maximum"):
         await adapter.get_choices("country", limit=201)
 
@@ -158,6 +160,6 @@ async def test_get_choices_limit_exceeds_max_raises(engine: AsyncEngine) -> None
 async def test_get_choices_unknown_field_returns_empty(engine: AsyncEngine) -> None:
     from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 
-    adapter = SQLModelAdapter(City, engine)
+    adapter = SQLModelAdapter(ChoiceCity, engine)
     choices = await adapter.get_choices("nonexistent_field")
     assert choices == []

--- a/tests/unit/test_dependent_select.py
+++ b/tests/unit/test_dependent_select.py
@@ -30,7 +30,9 @@ class City(BaseModel):
 class StubAdapter(BaseAdapter):
     def __init__(self, model):
         self.model = model
-        rel = SimpleNamespace(key="country")
+        rel = SimpleNamespace(
+            key="country", local_columns=[SimpleNamespace(key="country_id", name="country_id")]
+        )
         self.inspector = SimpleNamespace(relationships=[rel], c=[])
 
     async def get(self, pk: Any) -> Any:

--- a/tests/unit/test_dynamic_choices_endpoint.py
+++ b/tests/unit/test_dynamic_choices_endpoint.py
@@ -30,11 +30,11 @@ class StubAdapter(BaseAdapter):
     def __init__(self, model):
         self.model = model
         # Simulate inspector with a "country" relationship
-        rel = SimpleNamespace(key="country")
-        self.inspector = SimpleNamespace(
-            relationships=[rel],
-            c=[],
+        rel = SimpleNamespace(
+            key="country",
+            local_columns=[SimpleNamespace(key="country_id", name="country_id")],
         )
+        self.inspector = SimpleNamespace(relationships=[rel], c=[])
 
     async def get(self, pk: Any) -> Any:
         return None


### PR DESCRIPTION
## Summary

- Adds `SelectWidget`, `MultiSelectWidget`, `RelationSelectWidget`, `RelationMultiSelectWidget` with HTMX lazy-load support and `dependent_on` for cascading selects
- Exposes `inspector` on `SQLModelAdapter` so `_build_relation_widgets()` can resolve FK column names (e.g. `country_id`) to relationship names (`country`) for correct `get_choices()` calls
- Fixes `Optional[X | Y]` union detection in `classify_field()` for Python 3.10+
- Adds `dependent_fields` to `AdminOptions` for cascading select configuration
- Adds `choices_view()` endpoint with `field_name` validation, limit guard, and extra query-param forwarding
- Registers `GET /{model}/choices/{field_name}` route
- Adds `data-testid` and `aria-multiselectable` to all select/multiselect templates
- Adds 6 E2E tests for FK relation select: list views, create form preload, submit redirect, update preselect

## Test plan

- [x] `poe lint` — all linters pass (ruff, mypy, basedpyright)
- [x] `poe test:unit` — 277 unit tests pass
- [x] `poe test:e2e` — 39 E2E tests pass (including 6 new relation widget tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)