### PR TITLE
feat(agentic): GitHub Projects V2, autonomous team conductor, label-driven merge queue

### DIFF
--- a/.claude/agent-memory/conductor/MEMORY.md
+++ b/.claude/agent-memory/conductor/MEMORY.md
@@ -1,0 +1,7 @@
+# Conductor Agent Memory
+
+Cycle summaries, merge conflict patterns, and escalation history.
+
+## Index
+
+(No entries yet — entries are added as autonomous cycles complete)

--- a/.claude/agents/conductor.md
+++ b/.claude/agents/conductor.md
@@ -45,8 +45,8 @@ GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue view <linked-issue> --json body \
   done
 ```
 
-**Grant** (`merge-granted`): no file overlap, all deps closed, PR rebased on develop.
-**Defer** (`merge-deferred`): overlap detected, open deps, or >2 merges queued — post reason comment.
+**Grant** (`merge-granted`): no file overlap, all deps closed, PR rebased on develop, and fewer than `$MERGE_QUEUE_DEPTH` PRs already carrying `merge-granted`.
+**Defer** (`merge-deferred`): overlap detected, open deps, or merge queue at depth — post reason comment.
 
 ## Limits
 

--- a/.claude/agents/conductor.md
+++ b/.claude/agents/conductor.md
@@ -1,0 +1,69 @@
+---
+name: conductor
+description: Use this agent to orchestrate autonomous team cycles. Fetches ready issues from the GitHub Project, dispatches dev agents in worktrees, coordinates reviews via the code-reviewer agent, and owns merge queue authority — evaluating file overlap and dependency order before granting merge-granted label.
+tools: Bash, Read, Grep, Glob, Agent, EnterWorktree, ExitWorktree, TaskCreate, TaskGet, TaskList, TaskUpdate, Write
+model: opus
+color: red
+---
+
+@.claude/project-config.md
+
+You are the **Conductor** — the orchestration layer and merge authority for HyperAdmin's
+autonomous dev team. Read `.claude/commands/run-autonomous-team.md` and follow its phases.
+
+## Role Summary
+
+| Responsibility | You do |
+|----------------|--------|
+| Work queue | Fetch `agent-task` + `ready` issues, filter blocked, prioritize |
+| Dev dispatch | Claim issues, enter worktrees, run `implement-feature` skill |
+| Review coordination | Dispatch `hyper-admin-code-reviewer` per PR, track iterations |
+| Merge authority | Evaluate `merge-requested` PRs → add `merge-granted` or `merge-deferred` |
+| Safety | Monitor usage limits, enforce cycle caps, handle escalations |
+
+## Merge Queue Logic
+
+When a PR has `merge-requested`, evaluate before granting:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+
+# Files in this PR
+PR_FILES=$(GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr diff <pr-number> --repo "$REPO" --name-only)
+
+# Files in all other open PRs — check for overlap
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr list --repo "$REPO" --state open \
+  --json number | jq -r '.[].number' | while read N; do
+    [ "$N" = "<pr-number>" ] && continue
+    gh pr diff "$N" --repo "$REPO" --name-only 2>/dev/null
+  done
+
+# Dependency check
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue view <linked-issue> --json body \
+  --jq '.body' | grep -oP '(?<=Depends on: #)\d+' | while read DEP; do
+    gh issue view "$DEP" --repo "$REPO" --json state --jq '.state'
+  done
+```
+
+**Grant** (`merge-granted`): no file overlap, all deps closed, PR rebased on develop.
+**Defer** (`merge-deferred`): overlap detected, open deps, or >2 merges queued — post reason comment.
+
+## Limits
+
+- Max `$DEV_AGENT_LIMIT` dev agents per cycle
+- Max `$CONDUCTOR_CYCLE_LIMIT` cycles per session
+- Stop proactively when approaching Claude Max message limits
+
+## Agent Roster
+
+| Agent/Skill | Trigger | When |
+|-------------|---------|------|
+| `implement-feature` skill | Phase 2 dispatch | Per ready issue, in worktree |
+| `hyper-admin-code-reviewer` | Phase 3 | Per new PR with `review` label |
+| `delivery-manager` | Phase 4 | Watches autonomously via label filters |
+
+## Memory
+
+Persist cycle summaries to `.claude/agent-memory/conductor/` using Write.
+Record: issues processed per cycle, blockers encountered, merge conflicts found,
+review feedback patterns. Keep a `MEMORY.md` index.

--- a/.claude/agents/delivery-manager.md
+++ b/.claude/agents/delivery-manager.md
@@ -38,9 +38,29 @@ You are an elite Delivery Manager AI operating within the HyperAdmin project. Yo
   - Never reference `ha-*` CSS classes in test analysis — these are styling-only.
   - Reference `data-testid` values from the project's reference table when diagnosing selector failures.
 
-### 4. Human Notification & Auto-Merge Gate
+### 4. Human Notification & Merge Request
+
 - Notify the appropriate human stakeholder (PM, OPS Manager, or reviewer).
-- **Auto-Merge**: If all quality gates pass (Lint ✅, Unit Tests ✅, E2E ✅, Review Approved ✅), this agent is authorized to auto-merge the PR into `develop`.
+- **Merge via Conductor**: When all quality gates pass (Lint ✅, Unit Tests ✅, E2E ✅, Review Approved ✅),
+  do NOT merge directly. Instead, signal the conductor by updating the PR label:
+  ```bash
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr edit <number> --repo "$REPO" \
+    --remove-label "review" --add-label "merge-requested"
+  ```
+  The conductor evaluates the merge queue (file overlap, dependency order, conflict risk) and
+  responds by adding either `merge-granted` or `merge-deferred`.
+
+- **Watch for merge-granted**: Poll for `merge-granted` label on the PR. When seen, execute merge:
+  ```bash
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr merge <number> --repo "$REPO" \
+    --squash --delete-branch
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue edit <issue-number> --repo "$REPO" \
+    --remove-label "in-progress" --add-label "released"
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue close <issue-number> --repo "$REPO"
+  ```
+
+- **merge-deferred**: If conductor adds `merge-deferred`, read the PR comment for reason,
+  notify the human stakeholder, and wait — do not retry automatically.
 - Notification format for PR ready for human review:
   ```
   🚀 **Delivery Update — Issue #<N>**

--- a/.claude/agents/hyper-admin-code-reviewer.md
+++ b/.claude/agents/hyper-admin-code-reviewer.md
@@ -2,7 +2,7 @@
 name: hyper-admin-code-reviewer
 description: Use this agent when code has been written or modified in the HyperAdmin project and needs review for correctness, architecture compliance, style conventions, and best practices specific to the project stack (Python, FastAPI/HTMX, Jinja2, SQLModel/Pydantic, Playwright E2E tests).
 tools: Bash, Read, Grep, Write
-model: haiku
+model: sonnet
 color: blue
 ---
 

--- a/.claude/agents/hyper-admin-code-reviewer.md
+++ b/.claude/agents/hyper-admin-code-reviewer.md
@@ -90,9 +90,14 @@ Verify `data-testid` values match the documented naming table:
 - <optional refactor or style improvement>
 
 ### Verdict
+VERDICT: APPROVED | VERDICT: CHANGES_REQUIRED
 [ APPROVED | APPROVED WITH MINOR FIXES | CHANGES REQUIRED ]
 <one-sentence rationale>
 ```
+
+> **Machine-readable line**: The `VERDICT: APPROVED` or `VERDICT: CHANGES_REQUIRED` line must
+> appear first in the Verdict section. The conductor and delivery-manager parse this line to
+> determine the next label transition without reading the full review prose.
 
 ## Behavior Rules
 

--- a/.claude/commands/plan-roadmap.md
+++ b/.claude/commands/plan-roadmap.md
@@ -1,6 +1,9 @@
 ---
 description: Run the Roadmap Planning Agent workflow
 ---
+
+@.claude/project-config.md
+
 You are the Roadmap Planning Agent. Follow the workflow in `docs/agentic-workflow/roadmap-planning-agent.md`.
 
 1. Read the codebase structure (`ls`, key files, `pyproject.toml`)
@@ -10,6 +13,8 @@ You are the Roadmap Planning Agent. Follow the workflow in `docs/agentic-workflo
 5. Build the dependency DAG and verify no cycles
 6. Calculate delivery timeline given ~10h/week time budget
 7. Output the plan as structured JSON and suggest `gh` CLI commands to materialise it
+8. Include `project_id` and `project_url` in the output JSON (populated after `/plan-to-issues` runs)
+9. Print the GitHub Project URL at the end of the summary so the human can open the board directly
 
 Rules:
 - **Mandatory TDD**: Every functional issue MUST be decomposed into at least two sub-tasks: (1) write failing tests (unit/E2E, edge cases, regressions) and (2) implementation until tests pass.
@@ -18,4 +23,6 @@ Rules:
 - Prefer small, independently testable tasks over monolithic ones
 - Every task must have clear acceptance criteria
 - Never create tasks without dependency links
+- Project name pattern: `${PROJECT_NAME_PREFIX} <milestone-title>` (e.g. `HyperAdmin: v0.3.0 — Actions API`)
+- After materialising via `/plan-to-issues`, the GitHub Project is the source of truth for priorities
 

--- a/.claude/commands/plan-to-issues.md
+++ b/.claude/commands/plan-to-issues.md
@@ -9,8 +9,18 @@ allowed-tools:
   - Agent
 ---
 
+@.claude/project-config.md
+
 You are a planning agent. Your job is to analyze the request, produce an implementation plan,
 and create one GitHub issue per plan step. Do NOT implement anything yourself.
+
+At the start of every run, derive the repo context:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+```
 
 ## Request
 
@@ -86,6 +96,224 @@ BODY
 Map type to existing labels: `feat` → `enhancement`, `fix` → `bug`, `docs` → `documentation`.
 For types without existing labels (`refactor`, `test`, `chore`, `perf`), use only `agent-task` + size.
 
+### 5.5 Add issues to GitHub Project
+
+After all child issues are created, add them to a GitHub ProjectV2 so the team can track
+progress, planning, and timeline visually. Milestones and epics appear on the roadmap timeline.
+
+All mutations use `GH_TOKEN="$CLAUDE_GH_TOKEN"` and the runtime-derived `$OWNER`/`$REPO_NAME`.
+
+#### 5.5a — Find or create the project
+
+```bash
+# Get the owner's node ID (required for createProjectV2)
+OWNER_ID=$(GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql -f query='
+  query { viewer { id } }
+' --jq '.data.viewer.id')
+
+# Look for an existing project with the HyperAdmin: prefix
+EXISTING_PROJECT=$(GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+  -f query='query($login: String!) {
+    user(login: $login) {
+      projectsV2(first: 20) { nodes { id title number url } }
+    }
+  }' \
+  -f login="$OWNER" \
+  --jq ".data.user.projectsV2.nodes[] | select(.title | startswith(\"${PROJECT_NAME_PREFIX}\")) | first")
+
+if [ -z "$EXISTING_PROJECT" ]; then
+  PROJECT_TITLE="${PROJECT_NAME_PREFIX} ${MILESTONE_TITLE}"
+  RESULT=$(GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+    -f query='mutation($ownerId: ID!, $title: String!) {
+      createProjectV2(input: {ownerId: $ownerId, title: $title}) {
+        projectV2 { id number url }
+      }
+    }' \
+    -f ownerId="$OWNER_ID" -f title="$PROJECT_TITLE")
+  PROJECT_ID=$(echo "$RESULT" | jq -r '.data.createProjectV2.projectV2.id')
+  PROJECT_URL=$(echo "$RESULT" | jq -r '.data.createProjectV2.projectV2.url')
+else
+  PROJECT_ID=$(echo "$EXISTING_PROJECT" | jq -r '.id')
+  PROJECT_URL=$(echo "$EXISTING_PROJECT" | jq -r '.url')
+fi
+```
+
+#### 5.5b — Ensure custom fields exist
+
+Query existing fields first; create only missing ones to stay idempotent.
+
+```bash
+FIELDS=$(GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+  -f query='query($projectId: ID!) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        fields(first: 20) {
+          nodes {
+            ... on ProjectV2Field { id name }
+            ... on ProjectV2SingleSelectField { id name options { id name } }
+          }
+        }
+      }
+    }
+  }' -f projectId="$PROJECT_ID")
+
+# Create Status field if missing
+if ! echo "$FIELDS" | jq -e '.data.node.fields.nodes[] | select(.name=="Status")' > /dev/null; then
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql -f query='
+    mutation($pid: ID!) {
+      createProjectV2Field(input: {
+        projectId: $pid, dataType: SINGLE_SELECT, name: "Status",
+        singleSelectOptions: [
+          {name:"Backlog",   color:GRAY,   description:"Not yet started"},
+          {name:"Ready",     color:BLUE,   description:"Ready for implementation"},
+          {name:"In Progress",color:YELLOW,description:"Being worked on"},
+          {name:"Review",    color:ORANGE, description:"PR open, awaiting review"},
+          {name:"Done",      color:GREEN,  description:"Merged and complete"}
+        ]
+      }) { projectV2Field { id } }
+    }' -f pid="$PROJECT_ID"
+fi
+
+# Create Size field if missing
+if ! echo "$FIELDS" | jq -e '.data.node.fields.nodes[] | select(.name=="Size")' > /dev/null; then
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql -f query='
+    mutation($pid: ID!) {
+      createProjectV2Field(input: {
+        projectId: $pid, dataType: SINGLE_SELECT, name: "Size",
+        singleSelectOptions: [
+          {name:"S",color:BLUE,  description:"1-2 hours"},
+          {name:"M",color:PURPLE,description:"2-4 hours"},
+          {name:"L",color:RED,   description:"4-8 hours"}
+        ]
+      }) { projectV2Field { id } }
+    }' -f pid="$PROJECT_ID"
+fi
+
+# Create Agent Tier field if missing
+if ! echo "$FIELDS" | jq -e '.data.node.fields.nodes[] | select(.name=="Agent Tier")' > /dev/null; then
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql -f query='
+    mutation($pid: ID!) {
+      createProjectV2Field(input: {
+        projectId: $pid, dataType: SINGLE_SELECT, name: "Agent Tier",
+        singleSelectOptions: [
+          {name:"Claude Code",color:PINK, description:"implement-feature skill"},
+          {name:"Haiku",      color:GRAY, description:"delivery-manager / reviewer"},
+          {name:"Sonnet",     color:BLUE, description:"conductor / complex tasks"}
+        ]
+      }) { projectV2Field { id } }
+    }' -f pid="$PROJECT_ID"
+fi
+
+# Create date fields if missing
+for FNAME in "Start Date" "End Date"; do
+  if ! echo "$FIELDS" | jq -e ".data.node.fields.nodes[] | select(.name==\"$FNAME\")" > /dev/null; then
+    GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+      -f query='mutation($pid: ID!, $name: String!) {
+        createProjectV2Field(input: {projectId: $pid, dataType: DATE, name: $name}) {
+          projectV2Field { id }
+        }
+      }' -f pid="$PROJECT_ID" -f name="$FNAME"
+  fi
+done
+
+# Re-query fields to get all IDs and option IDs for use below
+FIELDS=$(GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+  -f query='query($projectId: ID!) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        fields(first: 20) {
+          nodes {
+            ... on ProjectV2Field { id name }
+            ... on ProjectV2SingleSelectField { id name options { id name } }
+          }
+        }
+      }
+    }
+  }' -f projectId="$PROJECT_ID")
+
+STATUS_FIELD_ID=$(echo "$FIELDS" | jq -r '.data.node.fields.nodes[] | select(.name=="Status") | .id')
+STATUS_BACKLOG_ID=$(echo "$FIELDS" | jq -r '.data.node.fields.nodes[] | select(.name=="Status") | .options[] | select(.name=="Backlog") | .id')
+SIZE_FIELD_ID=$(echo "$FIELDS" | jq -r '.data.node.fields.nodes[] | select(.name=="Size") | .id')
+START_FIELD_ID=$(echo "$FIELDS" | jq -r '.data.node.fields.nodes[] | select(.name=="Start Date") | .id')
+END_FIELD_ID=$(echo "$FIELDS" | jq -r '.data.node.fields.nodes[] | select(.name=="End Date") | .id')
+TODAY=$(date +%Y-%m-%d)
+```
+
+#### 5.5c — Add each issue to the project and set field values
+
+For every issue created in steps 4 and 5 (epic + all children), run this block:
+
+```bash
+# $ISSUE_NUMBER and $TASK_SIZE (S/M/L) must be set per issue
+
+ISSUE_NODE_ID=$(GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+  -f query='query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) { issue(number: $number) { id } }
+  }' \
+  -f owner="$OWNER" -f repo="$REPO_NAME" -F number="$ISSUE_NUMBER" \
+  --jq '.data.repository.issue.id')
+
+ITEM_ID=$(GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+  -f query='mutation($pid: ID!, $cid: ID!) {
+    addProjectV2ItemById(input: {projectId: $pid, contentId: $cid}) {
+      item { id }
+    }
+  }' -f pid="$PROJECT_ID" -f cid="$ISSUE_NODE_ID" \
+  --jq '.data.addProjectV2ItemById.item.id')
+
+# Set Status = Backlog
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+  -f query='mutation($pid: ID!, $iid: ID!, $fid: ID!, $oid: String!) {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: $pid, itemId: $iid, fieldId: $fid,
+      value: {singleSelectOptionId: $oid}
+    }) { projectV2Item { id } }
+  }' -f pid="$PROJECT_ID" -f iid="$ITEM_ID" \
+     -f fid="$STATUS_FIELD_ID" -f oid="$STATUS_BACKLOG_ID"
+
+# Set Size from task label
+SIZE_OPT_ID=$(echo "$FIELDS" | jq -r \
+  ".data.node.fields.nodes[] | select(.name==\"Size\") | .options[] | select(.name==\"$TASK_SIZE\") | .id")
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+  -f query='mutation($pid: ID!, $iid: ID!, $fid: ID!, $oid: String!) {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: $pid, itemId: $iid, fieldId: $fid,
+      value: {singleSelectOptionId: $oid}
+    }) { projectV2Item { id } }
+  }' -f pid="$PROJECT_ID" -f iid="$ITEM_ID" \
+     -f fid="$SIZE_FIELD_ID" -f oid="$SIZE_OPT_ID"
+
+# For epics only: set Start Date = today
+if [ "$IS_EPIC" = "true" ]; then
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+    -f query='mutation($pid: ID!, $iid: ID!, $fid: ID!, $date: Date!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $pid, itemId: $iid, fieldId: $fid, value: {date: $date}
+      }) { projectV2Item { id } }
+    }' -f pid="$PROJECT_ID" -f iid="$ITEM_ID" \
+       -f fid="$START_FIELD_ID" -f date="$TODAY"
+fi
+```
+
+#### 5.5d — Create project views (idempotent)
+
+```bash
+for VIEW in "Kanban:BOARD_LAYOUT" "Roadmap:ROADMAP_LAYOUT" "Table:TABLE_LAYOUT"; do
+  VNAME=$(echo "$VIEW" | cut -d: -f1)
+  VLAYOUT=$(echo "$VIEW" | cut -d: -f2)
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh api graphql \
+    -f query='mutation($pid: ID!, $name: String!, $layout: ProjectV2ViewLayout!) {
+      createProjectV2View(input: {projectId: $pid, name: $name, layout: $layout}) {
+        projectV2View { id name }
+      }
+    }' -f pid="$PROJECT_ID" -f name="$VNAME" -f layout="$VLAYOUT" 2>/dev/null || true
+done
+```
+
+> **Roadmap date binding**: After creation, open the Roadmap view in GitHub UI → view settings
+> → set "Start date" to **Start Date** field and "End date" to **End Date** field.
+> The GraphQL API does not yet expose view date-field binding.
+
 ### 6. Update tracking issue
 
 After all child issues are created, edit the tracking issue body to include the actual issue numbers.
@@ -101,4 +329,4 @@ Print a markdown table:
 | 43 | test(auth): add login tests | small | test | #42 |
 ```
 
-End with: "Created N issues. Tracking issue: #T"
+End with: "Created N issues. Tracking issue: #T. GitHub Project: $PROJECT_URL"

--- a/.claude/commands/run-autonomous-team.md
+++ b/.claude/commands/run-autonomous-team.md
@@ -201,7 +201,7 @@ done
 **Defer merge** (`merge-deferred`) if ANY of:
 - File overlap with another `merge-requested` PR (risk of conflict)
 - A dependency issue is still open
-- More than 2 merges queued simultaneously (avoid stack conflicts)
+- Already `$MERGE_QUEUE_DEPTH` PRs carrying `merge-granted` pending merge (avoid stack conflicts)
 
 ```bash
 # Grant

--- a/.claude/commands/run-autonomous-team.md
+++ b/.claude/commands/run-autonomous-team.md
@@ -1,0 +1,256 @@
+---
+description: Launch a coordinated team of Claude Code subagents to work through the project backlog
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Agent
+  - EnterWorktree
+  - ExitWorktree
+  - TaskCreate
+  - TaskGet
+  - TaskList
+  - TaskUpdate
+---
+
+@.claude/project-config.md
+
+You are the **Conductor** — an engineering manager orchestrating an autonomous team of
+Claude Code subagents to implement issues from the GitHub Project backlog.
+
+All coordination is GitHub-native: **labels are the message bus**. Agents do not call each
+other directly — each one filters on a specific label combination and acts.
+
+---
+
+## Startup Checks
+
+Before beginning any work, verify the environment is safe:
+
+```bash
+# 1. Bot token present
+[ -n "$CLAUDE_GH_TOKEN" ] || { echo "STOP: CLAUDE_GH_TOKEN is not set"; exit 1; }
+
+# 2. Correct base branch
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+[ "$CURRENT_BRANCH" = "$DEFAULT_BASE_BRANCH" ] \
+  || echo "WARNING: not on $DEFAULT_BASE_BRANCH (on $CURRENT_BRANCH)"
+
+# 3. No uncommitted changes
+git status --porcelain
+
+# 4. Derive repo context
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+```
+
+If `CLAUDE_GH_TOKEN` is unset, **STOP immediately** and tell the user.
+
+---
+
+## Phase 1: Work Queue Discovery
+
+### 1.1 Fetch ready, unblocked issues
+
+```bash
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue list \
+  --repo "$REPO" \
+  --label "agent-task" --label "ready" \
+  --state open \
+  --json number,title,labels,milestone,body \
+  --limit 20
+```
+
+### 1.2 Filter out blocked issues
+
+For each issue, scan its body for `Depends on: #N`. If any referenced issue is still open,
+skip this issue — it is blocked.
+
+```bash
+# For each candidate issue, check its dependency
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue view <dep-number> --json state --jq '.state'
+# If "OPEN" → skip; if "CLOSED" → dependency satisfied
+```
+
+### 1.3 Prioritize
+
+Sort unblocked issues by:
+1. Milestone due date (earliest first)
+2. Size label (S before M before L — quick wins first)
+3. Issues whose closure unblocks other issues (critical path first)
+
+Select up to `$DEV_AGENT_LIMIT` (3) issues for this cycle.
+
+---
+
+## Phase 2: Dev Agent Dispatch
+
+For each selected issue (up to `$DEV_AGENT_LIMIT` per cycle):
+
+### 2.1 Claim the issue
+
+```bash
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue edit <number> \
+  --repo "$REPO" \
+  --remove-label "ready" \
+  --add-label "in-progress"
+```
+
+### 2.2 Dispatch dev agent in an isolated worktree
+
+Use `EnterWorktree` for code isolation, then dispatch `implement-feature`:
+
+```
+EnterWorktree: creates isolated worktree for this issue
+Agent: implement-feature skill
+Prompt: /implement-feature <issue-number>
+ExitWorktree: after agent completes
+```
+
+The dev agent will:
+- Read the issue, plan with self-evaluation gate
+- Implement via TDD
+- Create PR with `CLAUDE_GH_TOKEN` and add the `review` label
+- Or post a blocker comment on the issue and halt
+
+### 2.3 Assess outcome
+
+```bash
+# Check if a PR exists referencing this issue
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr list \
+  --repo "$REPO" --search "closes:#<number>" \
+  --json number,state,headRefName
+```
+
+- **PR created + `review` label**: proceed to Phase 3
+- **Blocker comment posted, no PR**: leave `in-progress`, note in cycle report, move to next issue
+- **Unexpected failure**: add `needs-human` label, post issue comment with error details
+
+---
+
+## Phase 3: Review Agent
+
+For each PR carrying the `review` label, dispatch the code reviewer.
+Track review iterations per PR — max 2 cycles before escalating.
+
+### 3.1 Dispatch reviewer
+
+```
+Agent: hyper-admin-code-reviewer
+Prompt: Review PR #<number> in repo $REPO against the linked issue specification.
+Read the PR diff and the linked issue's acceptance criteria.
+After completing the review, if verdict is APPROVED: approve the PR via:
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr review <number> --repo $REPO --approve
+If CHANGES REQUIRED: request changes via:
+  GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr review <number> --repo $REPO --request-changes --body "<summary>"
+```
+
+### 3.2 After reviewer completes
+
+- **APPROVED**: reviewer has approved the PR on GitHub. Delivery manager's filter
+  (`review` + CI green + GH approval) will fire automatically — proceed to monitor.
+- **CHANGES REQUIRED** (iteration ≤ 2): re-dispatch dev agent to address feedback:
+  ```
+  Agent: implement-feature skill
+  Prompt: Address review feedback on PR #<pr-number> for issue #<issue-number>.
+  The reviewer requested changes — read the review comments and fix them.
+  ```
+- **CHANGES REQUIRED** (iteration > 2): add `needs-human` label, post comment summarising
+  the recurring failure, stop working on this issue.
+
+---
+
+## Phase 4: Merge Queue Evaluation
+
+The delivery manager watches its label filter autonomously. Your job as conductor
+is to evaluate `merge-requested` PRs and grant or defer merges.
+
+### 4.1 Check merge queue
+
+```bash
+# Find all PRs awaiting merge permission
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr list \
+  --repo "$REPO" --label "merge-requested" \
+  --json number,headRefName,body
+```
+
+### 4.2 Evaluate each merge-requested PR
+
+For each PR:
+
+```bash
+# Get the files this PR touches
+PR_FILES=$(GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr diff <pr-number> \
+  --repo "$REPO" --name-only)
+
+# Get files touched by all OTHER open PRs
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr list --repo "$REPO" --state open \
+  --json number,headRefName | jq -r '.[].number' | while read OTHER; do
+  [ "$OTHER" = "<pr-number>" ] && continue
+  gh pr diff "$OTHER" --repo "$REPO" --name-only 2>/dev/null
+done
+```
+
+**Grant merge** (`merge-granted`) if ALL of:
+- No file overlap with other open PRs
+- All `Depends on: #X` issues in the linked issue body are closed
+- PR is rebased on current `develop` (no merge conflicts detectable via diff)
+
+**Defer merge** (`merge-deferred`) if ANY of:
+- File overlap with another `merge-requested` PR (risk of conflict)
+- A dependency issue is still open
+- More than 2 merges queued simultaneously (avoid stack conflicts)
+
+```bash
+# Grant
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr edit <pr-number> --repo "$REPO" \
+  --remove-label "merge-requested" --add-label "merge-granted"
+
+# Defer — also post reason as comment
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr edit <pr-number> --repo "$REPO" \
+  --remove-label "merge-requested" --add-label "merge-deferred"
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr comment <pr-number> --repo "$REPO" \
+  --body "🔁 **Merge deferred by conductor**: <reason>. Will retry after <condition>."
+```
+
+The delivery manager will execute the merge once it sees `merge-granted`.
+
+---
+
+## Phase 5: Cycle Report & Loop Decision
+
+### 5.1 Print cycle report
+
+```
+## Autonomous Team — Cycle N Report
+
+| Issue | Title | Outcome | PR | Notes |
+|-------|-------|---------|----|-------|
+| #N    | ...   | Merged / In Review / Blocked / Escalated | #PR | ... |
+
+Issues completed this cycle: X
+Issues blocked / escalated: Y
+Remaining ready issues: Z
+```
+
+### 5.2 Continue or stop
+
+- **More ready issues + under `$CONDUCTOR_CYCLE_LIMIT` cycles**: start next cycle
+- **Approaching message limit** (your judgment): STOP, print report, tell user
+- **All ready issues processed**: print completion summary
+- **Hard stop**: never exceed `$CONDUCTOR_CYCLE_LIMIT` cycles per session
+
+---
+
+## Safety Rails
+
+- Never push to `$PUBLIC_REPO` — that is the human-reviewed OSS mirror
+- All GitHub writes use `GH_TOKEN="$CLAUDE_GH_TOKEN"`
+- Rollback: if a merged PR breaks `develop`, immediately run:
+  ```bash
+  git revert <merge-sha> && git push origin $DEFAULT_BASE_BRANCH
+  ```
+  Then add `needs-human` on the original issue.
+- If uncertain about anything: add `needs-human`, post a comment, and STOP

--- a/.claude/project-config.md
+++ b/.claude/project-config.md
@@ -22,6 +22,7 @@ PROJECT_NAME_PREFIX="HyperAdmin:"         # Prefix for GitHub ProjectV2 names
 DEFAULT_BASE_BRANCH="develop"             # Target branch for all autonomous merges
 DEV_AGENT_LIMIT=3                         # Max dev agents per conductor cycle
 CONDUCTOR_CYCLE_LIMIT=3                   # Max cycles per session (9 issues total cap)
+MERGE_QUEUE_DEPTH=2                       # Max concurrent merge-granted PRs (prevents post-rebase conflicts)
 ```
 
 ## GitHub Auth

--- a/.claude/project-config.md
+++ b/.claude/project-config.md
@@ -1,0 +1,68 @@
+# HyperAdmin Project Configuration
+
+Shared constants for all Claude Code commands and agents.
+Reference this file in commands via `@.claude/project-config.md`.
+
+## Runtime-Derived Variables
+
+These must be derived at the start of any command that uses GitHub:
+
+```bash
+# Derive owner and repo from current git remote — works in any fork
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+```
+
+## Static Constants
+
+```bash
+PUBLIC_REPO="Damdy-OSS/hyper-admin"      # Official public OSS mirror — never push autonomously
+PROJECT_NAME_PREFIX="HyperAdmin:"         # Prefix for GitHub ProjectV2 names
+DEFAULT_BASE_BRANCH="develop"             # Target branch for all autonomous merges
+DEV_AGENT_LIMIT=3                         # Max dev agents per conductor cycle
+CONDUCTOR_CYCLE_LIMIT=3                   # Max cycles per session (9 issues total cap)
+```
+
+## GitHub Auth
+
+All GitHub writes by agents must use the bot token:
+
+```bash
+GH_TOKEN="$CLAUDE_GH_TOKEN"
+```
+
+Never use the user's ambient `GH_TOKEN` for issue/PR creation.
+If `CLAUDE_GH_TOKEN` is unset, stop and report to the user — do not fall back to user identity.
+
+## Repository Topology
+
+```
+$REPO  (private dev, default branch: develop)
+  └── autonomous agents open PRs here
+  └── review-agent auto-approves here
+  └── conductor grants merge permission here
+  └── delivery-manager merges to develop here
+
+Damdy-OSS/hyper-admin  (public OSS mirror)
+  └── receives human-reviewed merges only
+  └── NEVER written to by autonomous agents
+```
+
+## Label State Machine (Issue + PR lifecycle)
+
+```
+idea → researched → planned → approved → in-progress → review
+     → merge-requested → merge-granted → released
+                       ↘ merge-deferred  (conductor adds reason as PR comment)
+```
+
+| Label | Set by | Meaning |
+|-------|--------|---------|
+| `in-progress` | conductor / delivery-manager | Dev agent claimed the issue |
+| `review` | dev agent (on PR) | PR open, awaiting review |
+| `merge-requested` | delivery-manager | PR approved + CI green, queued for conductor |
+| `merge-granted` | conductor | Safe to merge, no conflict risk |
+| `merge-deferred` | conductor | Merge blocked; reason in PR comment |
+| `needs-human` | any agent | Escalation required |
+| `released` | delivery-manager | Merged and closed |

--- a/docs/agentic-workflow/dev-agents.md
+++ b/docs/agentic-workflow/dev-agents.md
@@ -2,7 +2,7 @@
 
 | Property | Value |
 |---|---|
-| **Tier** | Production (Primary) / Utility (Tests) |
+| **Tier** | Claude Code (all sizes) |
 | **Trigger** | Task dispatched from workload queue (GitHub Issue assigned) |
 | **Purpose** | Implement code changes according to task specification |
 | **Est. Cost** | 20k - 100k tokens per implementation task |
@@ -12,30 +12,42 @@
 ```
 Incoming task from workload queue
   │
-  ├── size:S → Gemini CLI (inline fix, < 30 min)
-  ├── size:M → Jules (async PR, 1-4h)
-  └── size:L → Jules + Claude Code (plan first, then implement)
+  ├── size:S → Claude Code via fix-issue skill (lightweight TDD loop)
+  ├── size:M → Claude Code via implement-feature skill (full self-eval loop)
+  └── size:L → Claude Code via implement-feature skill + human checkpoint gate
 ```
 
-### Gemini CLI (size:S)
+> **Note**: Gemini CLI and Jules are paused — Google AI is currently unavailable.
+> All dispatch goes to Claude Code. Jules/Gemini entries are kept below for when
+> Google AI becomes available again.
 
-- One-liner fixes, small utility functions, config changes
-- Run directly in terminal, no async overhead
+### Claude Code — fix-issue skill (size:S)
+
+- One-liner fixes, small utility functions, config tweaks
+- Lightweight loop: branch → explore → test-first → implement → lint+test → PR
+- Runs in an isolated worktree dispatched by the conductor
 - Example: "Add a `--verbose` flag to the CLI parser"
 
-### Jules (size:M)
+### Claude Code — implement-feature skill (size:M)
 
-- Core dev agent — handles most implementation work
-- Runs async on Google Cloud VM, creates PR when done
-- 15 concurrent tasks = dispatch an entire milestone at once
+- Core dev agent for most implementation work
+- Full self-evaluating loop: plan → validate against 16+ checklist items → TDD → PR
+- Blocker protocol: searches memory, saves WIP as draft PR, halts with issue comment
+- Runs in an isolated worktree dispatched by the conductor
 - Example: "Implement `RetryPolicy` class with exponential backoff and jitter"
 
-### Claude Code (size:L or fallback)
+### Claude Code — implement-feature + human checkpoint (size:L)
 
 - Complex tasks requiring deep architectural reasoning
-- Interactive — you guide the implementation in real-time
-- Fallback when Jules produces a PR that fails review
+- Conductor pauses after planning phase and presents plan to human for approval
+- Human approves or adjusts scope before implementation begins
 - Example: "Redesign the plugin system to support async hooks"
+
+### Paused: Gemini CLI (size:S) / Jules (size:M–L)
+
+- Previously used for high-volume parallel dispatch (Jules: 15 concurrent tasks)
+- Currently unavailable — Google AI blocked/broken as of 2026-03
+- Re-enable by updating `scripts/setup-github.sh` labels and conductor dispatch logic
 
 ## TDD-First Execution
 

--- a/docs/agentic-workflow/onboarding.md
+++ b/docs/agentic-workflow/onboarding.md
@@ -17,6 +17,7 @@ Start here. Each row tells you which file to read, why, and when.
 | **Must — before code style** | `.claude/rules/code-style.md` | Python conventions — feature-grouped layout, type hints, 100-char lines, HTMX/Alpine.js | Before writing Python |
 | **Must — before commits** | `.claude/rules/git-workflow.md` | Claude Code commit identity, `CLAUDE_GH_TOKEN` for PRs, Conventional Commits | Before first commit |
 | **Must — before tests** | `.claude/rules/testing.md` | TDD, unit/E2E split, `data-testid` reference, Playwright Chromium install | Before writing tests |
+| **Reference** | `.claude/project-config.md` | Shared constants (public repo, branch, cycle limits) + label state machine + runtime derivation pattern | Always `@`-include in commands/agents that use GitHub |
 | **Reference** | `ROADMAP.md` | Current phase and reserved Phase 3 domains | When scoping a feature |
 | **Reference** | `GEMINI.md` | Gemini CLI conventions (size:S tasks) | When dispatching to Gemini |
 | **Reference** | `JULES.md` | Jules async task conventions (size:M tasks) | When dispatching to Jules |
@@ -83,6 +84,7 @@ Skills are multi-step agentic workflows invoked as `/skill-name`.
 | `/plan-roadmap` | Roadmap Planning Agent — reads codebase, decomposes to milestones/epics/tasks, builds dependency DAG | Decomposing a spec into issues |
 | `/plan-to-issues <request>` | Analyze request, create epic + child GitHub issues with labels/sizes/dependencies | Materializing a plan into the issue tracker |
 | `/plan-to-issues-dry-run <request>` | Same as above, preview only — no issues created | Reviewing a plan before committing |
+| `/run-autonomous-team` | Launch the conductor to orchestrate dev agents through the backlog — picks ready issues, dispatches workers in worktrees, coordinates review, manages merge queue | Autonomous batch implementation |
 | `/oss-triage-audit [dry-run\|live]` | Run `scripts/triage_audit.py` — AI-slop scoring, ego-PR detection, duplicate detection, lifecycle enforcement | Periodic hygiene pass on open issues/PRs |
 
 ---
@@ -93,8 +95,9 @@ These agents run as sub-processes via the `Agent` tool or `claude --agent <name>
 
 | Agent | Model | Role |
 |-------|-------|------|
-| `delivery-manager` | haiku | Monitors in-progress issues, coordinates PR reviews, triggers E2E tests, extracts preview URLs, posts structured Slack notifications, enforces delivery pipeline, auto-merge gate |
-| `hyper-admin-code-reviewer` | haiku | Reviews PRs against CONSTITUTION.md, planning-playbook, code-style, E2E conventions — 8-section structured checklist with pass/fail verdict |
+| `conductor` | opus | Orchestrates autonomous team cycles — dispatches dev agents in worktrees, coordinates reviews, **owns merge queue authority** (evaluates file overlap + dependency order → `merge-granted` / `merge-deferred`) |
+| `delivery-manager` | haiku | Watches label filters: adds `merge-requested` when PR is approved + CI green; executes merge when `merge-granted` appears; posts Slack delivery notifications |
+| `hyper-admin-code-reviewer` | haiku | Reviews PRs against CONSTITUTION.md, planning-playbook, code-style, E2E conventions — 8-section checklist with machine-readable `VERDICT: APPROVED` / `VERDICT: CHANGES_REQUIRED` |
 | `oss-triage-auditor` | sonnet | Delegates to `scripts/triage_audit.py` for AI-slop/ego-PR detection, duplicate detection, lifecycle label enforcement, TTL |
 
 Each agent has a persistent memory directory under `.claude/agent-memory/<agent-name>/`.
@@ -145,6 +148,7 @@ Two headless agents have dedicated memory directories:
 
 | Agent | Directory |
 |-------|-----------|
+| `conductor` | `.claude/agent-memory/conductor/` |
 | `delivery-manager` | `.claude/agent-memory/delivery-manager/` |
 | `hyper-admin-code-reviewer` | `.claude/agent-memory/hyper-admin-code-reviewer/` |
 

--- a/docs/agentic-workflow/orchestration.md
+++ b/docs/agentic-workflow/orchestration.md
@@ -84,12 +84,58 @@ All agents read from and write to this file. It's version-controlled, so you hav
 
 | Feature | Status | Usage |
 |---|---|---|
-| Projects V2 (REST + GraphQL API) | GA | Create board, add items, set custom fields |
+| Projects V2 (GraphQL API) | **Implemented** | Created by `/plan-to-issues` — board, custom fields, 3 views |
 | Sub-issues | GA (April 2025) | Epic → Task hierarchy |
 | Issue dependencies | GA (August 2025) | `blocked_by` / `blocking` between tasks |
 | Issue types (Bug, Feature, Task) | GA (April 2025) | Classify epics vs tasks |
 | Milestones | Stable | Group tasks into releases |
-| Labels | Stable | Size, agent tier, area, state |
-| Custom fields on Projects | GA | Estimated hours, agent tier |
-| Roadmap view | GA | Timeline with dependencies |
+| Labels | Stable | Size, agent tier, area, state — **labels are the message bus** |
+| Custom fields on Projects | **Implemented** | Status, Size, Agent Tier, Start Date, End Date |
+| Roadmap view | **Implemented** | Created automatically; date fields need manual binding in UI |
 | Advanced search (`is:blocked`) | GA | Find bottleneck tasks |
+
+## Autonomous Team Orchestration
+
+The autonomous team runs as a label-driven state machine. No agent-to-agent direct calls —
+each agent filters on specific label combinations and acts.
+
+### Conductor (`/run-autonomous-team`)
+
+The conductor is the entry point and merge authority. It runs in the foreground and:
+
+1. Fetches issues with `agent-task` + `ready` labels
+2. Dispatches up to 3 dev agents per cycle (each in an isolated worktree)
+3. Coordinates review via `hyper-admin-code-reviewer` agent
+4. Evaluates `merge-requested` PRs → grants or defers based on file overlap and dependency order
+
+### Label-Based Agent Workload Filters
+
+| Agent | Watches | Action |
+|-------|---------|--------|
+| **Conductor** | Issues: `agent-task` + `ready` | Claim → dispatch dev agent in worktree |
+| **Conductor** | PRs: `merge-requested` | Evaluate queue → add `merge-granted` or `merge-deferred` |
+| **review-agent** | PRs: `review` | Auto-approve via `gh pr review --approve` |
+| **delivery-manager** | PRs: `review` + CI green + GH approval | Add `merge-requested`, remove `review` |
+| **delivery-manager** | PRs: `merge-granted` | Execute merge → add `released`, close issue |
+
+### Merge Queue Evaluation (Conductor)
+
+Before granting a merge, the conductor checks:
+- **File overlap**: `gh pr diff --name-only` compared across all open PRs
+- **Dependency order**: `Depends on: #X` in issue body → `#X` must be closed (merged)
+- **Queue depth**: max 2 concurrent merges to avoid post-rebase conflicts
+
+### Limits and Safety Rails
+
+| Rail | Value |
+|------|-------|
+| Dev agents per cycle | 3 |
+| Cycles per session | 3 (9 issues max) |
+| Review iterations per PR | 2 (then `needs-human`) |
+| Merge queue depth | 2 simultaneous |
+| Rollback | `git revert <merge-sha>` if `develop` breaks |
+
+### Project Config
+
+All commands and agents reference `@.claude/project-config.md` for shared constants.
+Owner/repo are derived at runtime via `gh repo view` — no hardcoded values in command files.

--- a/docs/agentic-workflow/roadmap-planning-agent.md
+++ b/docs/agentic-workflow/roadmap-planning-agent.md
@@ -140,15 +140,23 @@ gh api repos/{owner}/{repo}/milestones \
 
 ### Project Board Views
 
-1. **Kanban** — Backlog → Ready → In Progress → Review → Done
-2. **Roadmap** — timeline view grouped by milestone, dependency arrows
-3. **Cost overview** — table view sorted by cost, grouped by agent tier
+Created automatically by `/plan-to-issues` (Step 5.5) via GitHub Projects V2 GraphQL API:
+
+1. **Kanban** (`BOARD_LAYOUT`) — columns map to Status field: Backlog → Ready → In Progress → Review → Done
+2. **Roadmap** (`ROADMAP_LAYOUT`) — timeline grouped by milestone; after creation, bind Start Date / End Date fields in the GitHub UI (API does not yet expose date-field binding)
+3. **Table** (`TABLE_LAYOUT`) — sortable by any field; default view for cost/effort overview
+
+Custom fields created per project: **Status**, **Size**, **Agent Tier**, **Start Date**, **End Date**.
+
+All GraphQL operations use `GH_TOKEN="$CLAUDE_GH_TOKEN"` and runtime-derived owner/repo
+(no hardcoded values). See `.claude/commands/plan-to-issues.md` Step 5.5 for full implementation.
 
 ## Output Contract
 
 ```json
 {
   "plan_id": "plan-2025-03-22-abc123",
+  "project_id": "PVT_xxxxxxxxxxxx",
   "project_url": "https://github.com/users/owner/projects/1",
   "milestones": [
     {

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -16,6 +16,10 @@ gh label create "qa-passed" --repo "$REPO" --color "0E8A16" --description "All t
 gh label create "released" --repo "$REPO" --color "5319E7" --description "Shipped in a release" || true
 gh label create "needs-human" --repo "$REPO" --color "D93F0B" --description "Agent escalation, human intervention needed" || true
 
+# Work Queue Labels (used by conductor / run-autonomous-team)
+gh label create "agent-task" --repo "$REPO" --color "D4C5F9" --description "Assigned to autonomous agent for implementation" || true
+gh label create "ready"      --repo "$REPO" --color "0E8A16" --description "Issue unblocked and approved — ready for autonomous pickup" || true
+
 # Sizing & Triage Labels
 gh label create "size:S" --repo "$REPO" --color "C5DEF5" --description "1-2 hours effort" || true
 gh label create "size:M" --repo "$REPO" --color "BFD4F2" --description "2-4 hours effort" || true

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -27,6 +27,11 @@ gh label create "community" --repo "$REPO" --color "BFDADC" --description "From 
 gh label create "scheduled:auto" --repo "$REPO" --color "FEF2C0" --description "Created by scheduled agent (high confidence)" || true
 gh label create "scheduled:review-needed" --repo "$REPO" --color "F9D0C4" --description "Needs human review" || true
 
+# Merge Queue Labels (used by conductor / delivery-manager)
+gh label create "merge-requested" --repo "$REPO" --color "FEF2C0" --description "PR approved + CI green, queued for conductor evaluation" || true
+gh label create "merge-granted"   --repo "$REPO" --color "0E8A16" --description "Conductor approved merge — safe to merge, no conflict risk" || true
+gh label create "merge-deferred"  --repo "$REPO" --color "D93F0B" --description "Conductor deferred merge — reason in PR comment" || true
+
 echo "✓ GitHub labels configured for $REPO"
 
 # Initialize Project Memory if gh command available


### PR DESCRIPTION
## Summary

- **GitHub Projects V2**: `/plan-to-issues` now creates a ProjectV2 board automatically — Kanban, Roadmap, and Table views with custom fields (Status, Size, Agent Tier, Start/End Date). All GraphQL ops use runtime-derived owner/repo via `gh repo view` (no hardcoded values).
- **`/run-autonomous-team`**: New conductor command orchestrating dev agents through the backlog in a 5-phase label-driven loop (discovery → dispatch → review → merge queue → cycle report).
- **Conductor agent**: Opus-powered, owns merge queue authority. Evaluates file overlap and dependency order before adding `merge-granted` or `merge-deferred`.
- **Label-based message bus**: `merge-requested → merge-granted / merge-deferred → released` — no direct agent-to-agent calls.
- **`project-config.md`**: Shared constants file, `@`-included in all commands. Replaces hardcoded values.
- **Gemini/Jules paused**: Dev agent docs updated to Claude-only tiering.

## Test plan

- [x] Run `/plan-to-issues` on a small feature → verify ProjectV2 created in GitHub UI with correct fields and views
- [x] Run `/run-autonomous-team` with 1+ issues labeled `agent-task` + `ready` → verify conductor claims issue, dispatches dev agent, review fires
- [ ] Verify `merge-requested` → `merge-granted` flow: conductor evaluates no-conflict PR and grants
- [ ] Check donation research issue #279 exists with correct labels
- [x] Verify `scripts/setup-github.sh` creates the 3 new merge-queue labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)