### PR TITLE
feat(core): fieldsets for grouping fields in admin forms (#66)

### DIFF
--- a/examples/simple/admin.py
+++ b/examples/simple/admin.py
@@ -8,13 +8,26 @@ if TYPE_CHECKING:
     from fastapi import Request
 from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 from hyperadmin.core.actions import action
+from hyperadmin.core.fieldsets import FieldsetSpec
 from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.options import AdminOptions
 from hyperadmin.core.registry import site
 
 
 class UserAdmin(ModelAdmin):
     adapter_class = SQLModelAdapter
     list_filter: ClassVar[list[str]] = ["is_active", "user_type"]
+    options: ClassVar[AdminOptions] = AdminOptions(
+        fieldsets=[
+            FieldsetSpec(name="Basic Info", fields=["name", "email"]),
+            FieldsetSpec(
+                name="Settings",
+                fields=["is_active", "rating", "user_type"],
+                collapsed=True,
+                description="Advanced user settings",
+            ),
+        ],
+    )
 
     @action(label="Deactivate")
     async def deactivate(self, request: Request, item_id: int) -> None:  # noqa: ARG002

--- a/src/hyperadmin/core/__init__.py
+++ b/src/hyperadmin/core/__init__.py
@@ -3,11 +3,13 @@
 from hyperadmin.core.actions import ActionDef, action, collect_actions
 from hyperadmin.core.choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
 from hyperadmin.core.fields import classify_field
+from hyperadmin.core.fieldsets import FieldsetSpec
 
 __all__ = [
     "ActionDef",
     "ChoiceItem",
     "ChoicesProvider",
+    "FieldsetSpec",
     "SelectFieldMeta",
     "action",
     "classify_field",

--- a/src/hyperadmin/core/fieldsets.py
+++ b/src/hyperadmin/core/fieldsets.py
@@ -1,0 +1,22 @@
+"""Fieldset specification for grouping form fields."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class FieldsetSpec:
+    """Defines a group of fields rendered together under a collapsible heading.
+
+    Attributes:
+        name: Display label for the fieldset heading.
+        fields: Ordered list of field names belonging to this group.
+        collapsed: Whether the fieldset starts in a collapsed state.
+        description: Optional help text shown below the heading.
+    """
+
+    name: str
+    fields: list[str] = field(default_factory=list)
+    collapsed: bool = False
+    description: str | None = None

--- a/src/hyperadmin/core/options.py
+++ b/src/hyperadmin/core/options.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
 
+from hyperadmin.core.fieldsets import FieldsetSpec
+
 
 class AdminOptions(BaseModel):
     """Per-model configuration for the HyperAdmin interface.
@@ -32,4 +34,18 @@ class AdminOptions(BaseModel):
     """Cascading select configuration: maps child field name → parent field name.
 
     Example: ``{"city": "country_id"}`` makes the city select reload when country_id changes.
+    """
+    fieldsets: list[FieldsetSpec] = []
+    """Groups of fields rendered together under collapsible headings in create/update forms.
+
+    When non-empty, the form renders fields in the order defined by the fieldsets.
+    Fields not included in any fieldset are rendered in a default ungrouped section.
+
+    Example:
+        ```python
+        AdminOptions(fieldsets=[
+            FieldsetSpec(name="Basic Info", fields=["name", "email"]),
+            FieldsetSpec(name="Advanced", fields=["is_active", "rating"], collapsed=True),
+        ])
+        ```
     """

--- a/src/hyperadmin/core/registry.py
+++ b/src/hyperadmin/core/registry.py
@@ -48,7 +48,7 @@ class SiteRegistry:
             admin_class = ModelAdmin
 
         if options is None:
-            options = AdminOptions()
+            options = getattr(admin_class, "options", None) or AdminOptions()
 
         with self._lock:
             if model in self._registry:

--- a/src/hyperadmin/templates/components/fieldset.html
+++ b/src/hyperadmin/templates/components/fieldset.html
@@ -1,0 +1,34 @@
+{#- Renders a single fieldset group with collapse/expand toggle.
+    Context variables:
+      - group: FieldsetGroup instance (name, fields, collapsed, description, slug)
+-#}
+{%- if group.name -%}
+<fieldset class="ha-fieldset" data-testid="fieldset-{{ group.slug }}"
+    x-data="{ open: {{ 'false' if group.collapsed else 'true' }} }">
+    <legend class="ha-fieldset-legend">
+        <button type="button"
+                class="ha-fieldset-toggle"
+                data-testid="fieldset-toggle-{{ group.slug }}"
+                @click="open = !open"
+                :aria-expanded="open">
+            <span x-text="open ? '▾' : '▸'" class="ha-fieldset-arrow"></span>
+            {{ group.name }}
+        </button>
+    </legend>
+    {%- if group.description -%}
+    <p class="ha-fieldset-description" x-show="open">{{ group.description }}</p>
+    {%- endif -%}
+    <div x-show="open" x-collapse>
+        {%- for field in group.fields -%}
+            {%- set widget = field.widget -%}
+            {%- include field.widget.template_path -%}
+        {%- endfor -%}
+    </div>
+</fieldset>
+{%- else -%}
+{#- Ungrouped fields (no fieldset header) -#}
+{%- for field in group.fields -%}
+    {%- set widget = field.widget -%}
+    {%- include field.widget.template_path -%}
+{%- endfor -%}
+{%- endif -%}

--- a/src/hyperadmin/templates/create.html
+++ b/src/hyperadmin/templates/create.html
@@ -11,10 +11,16 @@
 {%- endblock -%}
 
 {%- block form_body -%}
-    {%- for field in form.fields -%}
-        {%- set widget = field.widget -%}
-        {%- include field.widget.template_path -%}
-    {%- endfor -%}
+    {%- if form.fieldset_groups|length > 1 or (form.fieldset_groups|length == 1 and form.fieldset_groups[0].name) -%}
+        {%- for group in form.fieldset_groups -%}
+            {%- include "components/fieldset.html" -%}
+        {%- endfor -%}
+    {%- else -%}
+        {%- for field in form.fields -%}
+            {%- set widget = field.widget -%}
+            {%- include field.widget.template_path -%}
+        {%- endfor -%}
+    {%- endif -%}
 {%- endblock -%}
 
 {%- block form_actions -%}

--- a/src/hyperadmin/templates/update.html
+++ b/src/hyperadmin/templates/update.html
@@ -11,10 +11,16 @@
 {%- endblock -%}
 
 {%- block form_body -%}
-    {%- for field in form.fields -%}
-        {%- set widget = field.widget -%}
-        {%- include field.widget.template_path -%}
-    {%- endfor -%}
+    {%- if form.fieldset_groups|length > 1 or (form.fieldset_groups|length == 1 and form.fieldset_groups[0].name) -%}
+        {%- for group in form.fieldset_groups -%}
+            {%- include "components/fieldset.html" -%}
+        {%- endfor -%}
+    {%- else -%}
+        {%- for field in form.fields -%}
+            {%- set widget = field.widget -%}
+            {%- include field.widget.template_path -%}
+        {%- endfor -%}
+    {%- endif -%}
 {%- endblock -%}
 
 {%- block form_actions -%}

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -377,6 +377,7 @@ class DynamicModelView:
             include=create_include,
             exclude=self.form_create_exclude,
             initial=values or {},
+            fieldsets=getattr(self.options, "fieldsets", None) or None,
         )
         if errors:
             form.bind(values or {})
@@ -439,6 +440,7 @@ class DynamicModelView:
             widgets=relation_widgets,
             include=create_include,
             exclude=self.form_create_exclude,
+            fieldsets=getattr(self.options, "fieldsets", None) or None,
         )
         data = self._extract_form_data(form_data, form)
         form.bind(data)
@@ -509,7 +511,11 @@ class DynamicModelView:
             field_names=self.form_include or [], selected_values=initial_values
         )
         form = PydanticForm(
-            self.model, widgets=relation_widgets, include=self.form_include, initial=initial_values
+            self.model,
+            widgets=relation_widgets,
+            include=self.form_include,
+            initial=initial_values,
+            fieldsets=getattr(self.options, "fieldsets", None) or None,
         )
 
         if errors:
@@ -546,7 +552,12 @@ class DynamicModelView:
         relation_widgets = await self._build_relation_widgets(
             field_names=self.form_include or [],
         )
-        form = PydanticForm(self.model, widgets=relation_widgets, include=self.form_include)
+        form = PydanticForm(
+            self.model,
+            widgets=relation_widgets,
+            include=self.form_include,
+            fieldsets=getattr(self.options, "fieldsets", None) or None,
+        )
         data = self._extract_form_data(form_data, form)
 
         form.bind(data)

--- a/src/hyperadmin/views/forms.py
+++ b/src/hyperadmin/views/forms.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
     from starlette.templating import Jinja2Templates
 
+    from hyperadmin.core.fieldsets import FieldsetSpec
+
 
 @dataclass(slots=True)
 class HtmxWidget:
@@ -207,6 +209,29 @@ class FormField:
             return "text"
 
 
+@dataclass(slots=True)
+class FieldsetGroup:
+    """A resolved group of ``FormField`` instances for template rendering.
+
+    Attributes:
+        name: Display heading for the fieldset.
+        fields: The ``FormField`` instances belonging to this group.
+        collapsed: Whether the fieldset starts collapsed.
+        description: Optional help text shown under the heading.
+        slug: URL-safe identifier derived from *name*, used in ``data-testid``.
+    """
+
+    name: str
+    fields: list[FormField]
+    collapsed: bool = False
+    description: str | None = None
+    slug: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.slug:
+            self.slug = self.name.lower().replace(" ", "-")
+
+
 class PydanticForm:
     def __init__(
         self,
@@ -217,6 +242,7 @@ class PydanticForm:
         exclude: list[str] | None = None,
         initial: dict[str, Any] | None = None,
         choices_base_url: str = "",
+        fieldsets: list[FieldsetSpec] | None = None,
     ) -> None:
         self.model = model
         self.widgets = widgets or {}
@@ -226,6 +252,7 @@ class PydanticForm:
         self.choices_base_url = choices_base_url
         self.errors: dict[str, list[str]] = {}
         self._fields: list[FormField] = []
+        self._fieldset_specs: list[FieldsetSpec] = fieldsets or []
 
     @staticmethod
     def _enum_choices(enum_cls: type[Enum]) -> list[ChoiceItem]:
@@ -342,6 +369,46 @@ class PydanticForm:
             value = self.initial.get(name, default_val if default_val is not None else None)
             self._fields.append(FormField(name=name, model_field=field, widget=widget, value=value))
         return self._fields
+
+    @property
+    def fieldset_groups(self) -> list[FieldsetGroup]:
+        """Return form fields grouped according to the configured fieldsets.
+
+        If no fieldsets are configured, returns a single group containing all fields.
+        Fields referenced in a fieldset spec but not present in the form are silently
+        skipped. Fields not covered by any fieldset are collected into a trailing
+        "Other fields" group.
+        """
+        all_fields = self.fields
+        if not self._fieldset_specs:
+            return [FieldsetGroup(name="", fields=all_fields, slug="")]
+
+        field_map = {f.name: f for f in all_fields}
+        claimed: set[str] = set()
+        groups: list[FieldsetGroup] = []
+
+        for spec in self._fieldset_specs:
+            group_fields: list[FormField] = []
+            for fname in spec.fields:
+                if fname in field_map:
+                    group_fields.append(field_map[fname])
+                    claimed.add(fname)
+            if group_fields:
+                groups.append(
+                    FieldsetGroup(
+                        name=spec.name,
+                        fields=group_fields,
+                        collapsed=spec.collapsed,
+                        description=spec.description,
+                    )
+                )
+
+        # Collect unclaimed fields into a default group
+        remaining = [f for f in all_fields if f.name not in claimed]
+        if remaining:
+            groups.append(FieldsetGroup(name="Other fields", fields=remaining))
+
+        return groups
 
     def bind(self, data: dict[str, Any]) -> None:
         for f in self.fields:

--- a/tests/e2e/create_view/test_user_create_view.py
+++ b/tests/e2e/create_view/test_user_create_view.py
@@ -37,6 +37,8 @@ def test_create_user_form_rendering(page: Page, demo_base_url: str):
     expect(page.get_by_test_id("model-form")).to_be_visible()
     expect(page.get_by_label("Name*")).to_be_visible()
     expect(page.get_by_label("Email*")).to_be_visible()
+    # Settings fieldset is collapsed by default; expand it to verify fields
+    page.get_by_test_id("fieldset-toggle-settings").click()
     expect(page.get_by_label("Is active*")).to_be_visible()
     expect(page.get_by_label("Rating*")).to_be_visible()
     expect(page.get_by_label("User type*")).to_be_visible()
@@ -57,6 +59,8 @@ def test_create_user_successful_submission(debug_page: Page, demo_base_url: str)
     page.goto(f"{demo_base_url}/admin/user/create")
     page.get_by_label("Name*").fill("Test User")
     page.get_by_label("Email*").fill("test@example.com")
+    # Expand collapsed Settings fieldset to access fields
+    page.get_by_test_id("fieldset-toggle-settings").click()
     page.get_by_label("Is active*").check()
     page.get_by_label("Rating*").fill("4.5")
     page.get_by_label("User type*").select_option("ADMIN")

--- a/tests/e2e/test_fieldsets.py
+++ b/tests/e2e/test_fieldsets.py
@@ -1,0 +1,101 @@
+"""E2E tests for fieldset grouping in create/update forms."""
+
+import re
+
+from playwright.sync_api import Page, expect
+
+
+def test_create_form_renders_fieldsets(page: Page, demo_base_url: str) -> None:
+    """Verify that the User create form renders configured fieldsets."""
+    page.goto(f"{demo_base_url}/admin/user/create")
+
+    # "Basic Info" fieldset should be visible (not collapsed)
+    basic = page.get_by_test_id("fieldset-basic-info")
+    expect(basic).to_be_visible()
+    expect(basic).to_contain_text("Basic Info")
+
+    # Fields inside Basic Info should be visible
+    expect(page.get_by_label("Name")).to_be_visible()
+    expect(page.get_by_label("Email")).to_be_visible()
+
+
+def test_create_form_collapsed_fieldset(page: Page, demo_base_url: str) -> None:
+    """Verify that a collapsed fieldset starts hidden and can be expanded."""
+    page.goto(f"{demo_base_url}/admin/user/create")
+
+    # "Settings" fieldset exists
+    settings = page.get_by_test_id("fieldset-settings")
+    expect(settings).to_be_visible()
+
+    # The toggle button exists
+    toggle = page.get_by_test_id("fieldset-toggle-settings")
+    expect(toggle).to_be_visible()
+    expect(toggle).to_contain_text("Settings")
+
+    # Fields should be hidden initially (collapsed=True)
+    is_active = page.locator('input[name="is_active"]')
+    expect(is_active).to_be_hidden()
+
+    # Click toggle to expand
+    toggle.click()
+
+    # Now fields should be visible
+    expect(is_active).to_be_visible()
+
+
+def test_fieldset_toggle_collapse(page: Page, demo_base_url: str) -> None:
+    """Verify that clicking the toggle collapses an open fieldset."""
+    page.goto(f"{demo_base_url}/admin/user/create")
+
+    toggle = page.get_by_test_id("fieldset-toggle-basic-info")
+    expect(toggle).to_be_visible()
+
+    # Fields are visible initially
+    name_input = page.get_by_label("Name")
+    expect(name_input).to_be_visible()
+
+    # Click to collapse
+    toggle.click()
+
+    # Fields should now be hidden
+    expect(name_input).to_be_hidden()
+
+
+def test_fieldset_description_visible(page: Page, demo_base_url: str) -> None:
+    """Verify that fieldset description text is rendered."""
+    page.goto(f"{demo_base_url}/admin/user/create")
+
+    # Expand the Settings fieldset first
+    toggle = page.get_by_test_id("fieldset-toggle-settings")
+    toggle.click()
+
+    # Description should be visible
+    settings = page.get_by_test_id("fieldset-settings")
+    expect(settings).to_contain_text("Advanced user settings")
+
+
+def test_product_form_no_fieldsets(page: Page, demo_base_url: str) -> None:
+    """Verify that Product (no fieldsets configured) renders fields without fieldset wrappers."""
+    page.goto(f"{demo_base_url}/admin/product/create")
+
+    # No fieldset elements should be present
+    fieldsets = page.locator("fieldset.ha-fieldset")
+    expect(fieldsets).to_have_count(0)
+
+    # Fields should still render normally
+    expect(page.get_by_label("Name")).to_be_visible()
+
+
+def test_create_user_with_fieldsets_submits(page: Page, demo_base_url: str) -> None:
+    """Verify that form submission works correctly with fieldsets."""
+    page.goto(f"{demo_base_url}/admin/user/create")
+
+    # Fill in Basic Info fields
+    page.get_by_label("Name").fill("Fieldset Test User")
+    page.get_by_label("Email").fill("fieldset@test.com")
+
+    # Submit form
+    page.get_by_role("button", name="Create").click()
+
+    # Should redirect to detail page on success
+    expect(page).to_have_url(re.compile(r".*/admin/user/\d+"))

--- a/tests/unit/test_fieldsets.py
+++ b/tests/unit/test_fieldsets.py
@@ -1,0 +1,152 @@
+"""Unit tests for fieldset specification and form grouping."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from hyperadmin.core.fieldsets import FieldsetSpec
+from hyperadmin.core.options import AdminOptions
+from hyperadmin.views.forms import FieldsetGroup, PydanticForm
+
+# --- FieldsetSpec dataclass ---
+
+
+def test_fieldset_spec_defaults() -> None:
+    fs = FieldsetSpec(name="Basic")
+    assert fs.name == "Basic"
+    assert fs.fields == []
+    assert fs.collapsed is False
+    assert fs.description is None
+
+
+def test_fieldset_spec_with_fields() -> None:
+    fs = FieldsetSpec(name="Info", fields=["name", "email"], collapsed=True, description="Help")
+    assert fs.fields == ["name", "email"]
+    assert fs.collapsed is True
+    assert fs.description == "Help"
+
+
+# --- FieldsetGroup ---
+
+
+def test_fieldset_group_slug_auto() -> None:
+    group = FieldsetGroup(name="Basic Info", fields=[])
+    assert group.slug == "basic-info"
+
+
+def test_fieldset_group_slug_explicit() -> None:
+    group = FieldsetGroup(name="Advanced", fields=[], slug="adv")
+    assert group.slug == "adv"
+
+
+def test_fieldset_group_empty_name() -> None:
+    group = FieldsetGroup(name="", fields=[])
+    assert group.slug == ""
+
+
+# --- AdminOptions.fieldsets ---
+
+
+def test_admin_options_fieldsets_default() -> None:
+    opts = AdminOptions()
+    assert opts.fieldsets == []
+
+
+def test_admin_options_fieldsets_set() -> None:
+    opts = AdminOptions(
+        fieldsets=[
+            FieldsetSpec(name="Basic", fields=["name"]),
+            FieldsetSpec(name="Extra", fields=["email"], collapsed=True),
+        ]
+    )
+    assert len(opts.fieldsets) == 2
+    assert opts.fieldsets[0].name == "Basic"
+    assert opts.fieldsets[1].collapsed is True
+
+
+# --- PydanticForm.fieldset_groups ---
+
+
+class SimpleModel(BaseModel):
+    name: str = ""
+    email: str = ""
+    age: int = 0
+    bio: str = ""
+
+
+def test_fieldset_groups_no_fieldsets() -> None:
+    form = PydanticForm(SimpleModel)
+    groups = form.fieldset_groups
+    assert len(groups) == 1
+    assert groups[0].name == ""
+    field_names = [f.name for f in groups[0].fields]
+    assert "name" in field_names
+    assert "email" in field_names
+
+
+def test_fieldset_groups_with_specs() -> None:
+    specs = [
+        FieldsetSpec(name="Identity", fields=["name", "email"]),
+        FieldsetSpec(name="Details", fields=["age"], collapsed=True, description="Extra info"),
+    ]
+    form = PydanticForm(SimpleModel, fieldsets=specs)
+    groups = form.fieldset_groups
+
+    # 3 groups: Identity, Details, Other fields (bio is unclaimed)
+    assert len(groups) == 3
+
+    assert groups[0].name == "Identity"
+    assert [f.name for f in groups[0].fields] == ["name", "email"]
+    assert groups[0].collapsed is False
+
+    assert groups[1].name == "Details"
+    assert [f.name for f in groups[1].fields] == ["age"]
+    assert groups[1].collapsed is True
+    assert groups[1].description == "Extra info"
+
+    assert groups[2].name == "Other fields"
+    assert [f.name for f in groups[2].fields] == ["bio"]
+
+
+def test_fieldset_groups_all_fields_claimed() -> None:
+    specs = [
+        FieldsetSpec(name="All", fields=["name", "email", "age", "bio"]),
+    ]
+    form = PydanticForm(SimpleModel, fieldsets=specs)
+    groups = form.fieldset_groups
+    assert len(groups) == 1
+    assert groups[0].name == "All"
+    assert len(groups[0].fields) == 4
+
+
+def test_fieldset_groups_skips_unknown_fields() -> None:
+    specs = [
+        FieldsetSpec(name="Partial", fields=["name", "nonexistent"]),
+    ]
+    form = PydanticForm(SimpleModel, fieldsets=specs)
+    groups = form.fieldset_groups
+    # "Partial" group has only "name", remaining fields go to "Other fields"
+    assert groups[0].name == "Partial"
+    assert [f.name for f in groups[0].fields] == ["name"]
+    assert groups[1].name == "Other fields"
+
+
+def test_fieldset_groups_empty_spec_skipped() -> None:
+    specs = [
+        FieldsetSpec(name="Empty", fields=["nonexistent_only"]),
+        FieldsetSpec(name="Real", fields=["name"]),
+    ]
+    form = PydanticForm(SimpleModel, fieldsets=specs)
+    groups = form.fieldset_groups
+    # "Empty" group should be skipped (no matching fields)
+    assert groups[0].name == "Real"
+    assert groups[1].name == "Other fields"
+
+
+def test_fieldset_group_slug_generation() -> None:
+    specs = [
+        FieldsetSpec(name="Basic Info", fields=["name"]),
+    ]
+    form = PydanticForm(SimpleModel, fieldsets=specs)
+    groups = form.fieldset_groups
+    assert groups[0].slug == "basic-info"


### PR DESCRIPTION
Closes #66

## Summary
- Add `FieldsetSpec` dataclass in `src/hyperadmin/core/fieldsets.py` for defining field groups with name, fields, collapsed state, and description
- Add `fieldsets` option to `AdminOptions` in `src/hyperadmin/core/options.py`
- Add `FieldsetGroup` and `fieldset_groups` property to `PydanticForm` for resolving specs into rendered groups
- Add `components/fieldset.html` template with Alpine.js-powered collapse/expand toggle
- Update `create.html` and `update.html` templates to render fieldset groups when configured
- Fix `SiteRegistry.register()` to preserve class-defined options instead of overwriting
- Configure `UserAdmin` in example app with two fieldsets (Basic Info + collapsed Settings)
- 13 unit tests covering `FieldsetSpec`, `FieldsetGroup`, `AdminOptions.fieldsets`, and `PydanticForm.fieldset_groups`
- 6 E2E tests covering fieldset rendering, collapse/expand, description text, and form submission
- Updated existing User create E2E tests to handle collapsed fieldset

## Test plan
- [x] `poe lint` passes (ruff, mypy, basedpyright, commitizen)
- [x] `poe test:unit` passes (331 tests)
- [x] `poe test:e2e` passes (48 tests)