### PR TITLE
feat(ui): WCAG 2.1 AA accessibility improvements (#72)

### DIFF
--- a/src/hyperadmin/static/css/hyperadmin.css
+++ b/src/hyperadmin/static/css/hyperadmin.css
@@ -855,3 +855,56 @@ body {
 .ha-filter-toggle .ha-icon {
   transition: transform 0.2s;
 }
+
+/* ==========================================================================
+   Accessibility — Skip Link
+   ========================================================================== */
+
+.ha-skip-link {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: 100;
+  padding: var(--ha-space-2) var(--ha-space-4);
+  background-color: var(--ha-color-primary);
+  color: #ffffff;
+  font-weight: 700;
+  text-decoration: none;
+  border-radius: var(--ha-radius);
+}
+
+.ha-skip-link:focus {
+  position: fixed;
+  top: var(--ha-space-2);
+  left: var(--ha-space-2);
+  width: auto;
+  height: auto;
+  overflow: visible;
+}
+
+/* ==========================================================================
+   Accessibility — Focus Visible
+   ========================================================================== */
+
+:focus-visible {
+  outline: 2px solid var(--ha-color-primary);
+  outline-offset: 2px;
+}
+
+/* ==========================================================================
+   Accessibility — Reduced Motion
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/hyperadmin/templates/_base.html
+++ b/src/hyperadmin/templates/_base.html
@@ -50,12 +50,13 @@
     </script>
 </head>
 <body class="ha-page">
+    <a href="#main-content" class="ha-skip-link">Skip to main content</a>
     <div class="ha-container">
         {% block messages %}{% include "_messages.html" %}{% endblock %}
         {% block navbar %}{% include "_navbar.html" %}{% endblock %}
         <div class="ha-layout">
             {% block sidebar %}{% include "_sidebar.html" %}{% endblock %}
-            <main class="ha-content">
+            <main id="main-content" role="main" class="ha-content">
                 {% block content %}{% endblock %}
             </main>
         </div>

--- a/src/hyperadmin/templates/_messages.html
+++ b/src/hyperadmin/templates/_messages.html
@@ -1,4 +1,4 @@
-<div class="ha-toast-container">
+<div class="ha-toast-container" aria-live="polite" aria-atomic="true">
     <div x-data="{ show: false }" x-show="show" x-init="setTimeout(() => show = false, 5000)" class="ha-toast ha-alert-success" role="alert">
         <strong class="ha-alert-title">Success!</strong>
         <span>Your action was successful.</span>

--- a/src/hyperadmin/templates/_navbar.html
+++ b/src/hyperadmin/templates/_navbar.html
@@ -1,35 +1,35 @@
-<nav class="ha-navbar">
+<nav class="ha-navbar" aria-label="Main navigation">
     <div class="ha-navbar-inner">
         <a href="{{ admin_prefix }}/" class="ha-navbar-brand">HyperAdmin</a>
         <div x-data="{ open: false }" class="ha-navbar-user">
             {% if auth_enabled and request.state.user %}
-            <button @click="open = !open" class="ha-navbar-user-btn">
-                <svg class="ha-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <button @click="open = !open" @keydown.escape="open = false" class="ha-navbar-user-btn" aria-haspopup="true" :aria-expanded="open">
+                <svg class="ha-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0z"></path>
                 </svg>
                 <span data-testid="current-user">{{ request.state.user.username }}</span>
-                <svg class="ha-icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <svg class="ha-icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
             </button>
-            <div x-show="open" @click.away="open = false" x-cloak class="ha-dropdown">
+            <div x-show="open" @click.away="open = false" @keydown.escape="open = false" x-cloak class="ha-dropdown" role="menu">
                 <form method="post" action="{{ admin_prefix }}/logout">
-                    <button type="submit" class="ha-dropdown-item" data-testid="logout-btn">Logout</button>
+                    <button type="submit" class="ha-dropdown-item" data-testid="logout-btn" role="menuitem">Logout</button>
                 </form>
             </div>
             {% else %}
-            <button @click="open = !open" class="ha-navbar-user-btn">
-                <svg class="ha-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <button @click="open = !open" @keydown.escape="open = false" class="ha-navbar-user-btn" aria-haspopup="true" :aria-expanded="open">
+                <svg class="ha-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0z"></path>
                 </svg>
                 <span>Admin</span>
-                <svg class="ha-icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <svg class="ha-icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
             </button>
-            <div x-show="open" @click.away="open = false" x-cloak class="ha-dropdown">
-                <a href="#" class="ha-dropdown-item">Profile</a>
-                <a href="#" class="ha-dropdown-item">Settings</a>
+            <div x-show="open" @click.away="open = false" @keydown.escape="open = false" x-cloak class="ha-dropdown" role="menu">
+                <a href="#" class="ha-dropdown-item" role="menuitem">Profile</a>
+                <a href="#" class="ha-dropdown-item" role="menuitem">Settings</a>
             </div>
             {% endif %}
         </div>

--- a/src/hyperadmin/templates/_sidebar.html
+++ b/src/hyperadmin/templates/_sidebar.html
@@ -1,13 +1,14 @@
-<aside class="ha-sidebar" data-testid="sidebar">
+<aside class="ha-sidebar" data-testid="sidebar" aria-label="Sidebar navigation">
     <div class="ha-sidebar-inner">
         <h2 class="ha-sidebar-title">Menu</h2>
+        <nav aria-label="Sidebar">
         <ul class="ha-sidebar-nav">
             {%- for item in nav_items -%}
             {%- if not auth_enabled or not request.state.user or item.get('visible', true) -%}
             <li>
-                <a href="{{ admin_prefix }}{{ item.url }}" class="ha-sidebar-link">
+                <a href="{{ admin_prefix }}{{ item.url }}" class="ha-sidebar-link"{% if request.url.path == admin_prefix ~ item.url %} aria-current="page"{% endif %}>
                     {%- if item.icon -%}
-                    <i class="{{ item.icon }}"></i>
+                    <i class="{{ item.icon }}" aria-hidden="true"></i>
                     {%- endif -%}
                     {{ item.name }}
                 </a>
@@ -15,5 +16,6 @@
             {%- endif -%}
             {%- endfor -%}
         </ul>
+        </nav>
     </div>
 </aside>

--- a/src/hyperadmin/templates/components/filter_bar.html
+++ b/src/hyperadmin/templates/components/filter_bar.html
@@ -1,15 +1,17 @@
 {%- if filter_metadata -%}
-<div class="ha-card ha-filter-bar" data-testid="filter-bar">
+<div class="ha-card ha-filter-bar" data-testid="filter-bar" x-data="{ filtersOpen: {{ 'true' if active_filters else 'false' }} }">
     <button type="button"
             class="ha-filter-toggle"
-            onclick="document.getElementById('filter-content').classList.toggle('hidden'); this.querySelector('.ha-icon').classList.toggle('rotate-180')">
-        <svg class="ha-icon ha-icon-sm {% if not active_filters %}rotate-0{% else %}rotate-180{% endif %}" viewBox="0 0 24 24">
+            @click="filtersOpen = !filtersOpen"
+            aria-controls="filter-content"
+            :aria-expanded="filtersOpen">
+        <svg class="ha-icon ha-icon-sm" :class="filtersOpen ? 'rotate-180' : 'rotate-0'" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M19 9l-7 7-7-7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
         Filters
     </button>
 
-    <div id="filter-content" class="ha-filter-content {% if not active_filters %}hidden{% endif %}">
+    <div id="filter-content" class="ha-filter-content" x-show="filtersOpen" x-cloak>
         <div class="ha-filter-container">
             {%- for filter in filter_metadata -%}
             <div class="ha-form-group ha-filter-group">

--- a/src/hyperadmin/templates/components/pagination.html
+++ b/src/hyperadmin/templates/components/pagination.html
@@ -1,3 +1,4 @@
+<nav aria-label="Pagination">
 <div class="ha-pagination">
     <div class="ha-pagination-info" data-testid="pagination-info">
         Showing {{- pagination.start_index }} to {{ pagination.end_index }} of {{ pagination.total_items }} results
@@ -17,7 +18,7 @@
         </a>
         {%- endif -%}
 
-        <div class="ha-pagination-page" data-testid="pagination-page">
+        <div class="ha-pagination-page" data-testid="pagination-page" aria-current="page">
             Page {{ pagination.page }} of {{ pagination.total_pages }}
         </div>
 
@@ -33,3 +34,4 @@
         {%- endif -%}
     </div>
 </div>
+</nav>

--- a/src/hyperadmin/templates/components/sortable_header.html
+++ b/src/hyperadmin/templates/components/sortable_header.html
@@ -3,9 +3,9 @@
     {%- for key, value in active_filters.items() -%}&filter_{{ key }}={{ value }}{%- endfor -%}
 {%- endset -%}
 {%- if field == '__str__' -%}
-<th class="ha-table-th">{{ display_name }}</th>
+<th class="ha-table-th" scope="col">{{ display_name }}</th>
 {%- else -%}
-<th class="ha-table-th">
+<th class="ha-table-th" scope="col"{% if sort_by == field %} aria-sort="{{ 'ascending' if sort_direction == 'asc' else 'descending' }}"{% endif %}>
     <a href="{{- url_for(model_name|lower ~ '-list') }}?sort_by={{ field }}&sort_direction={{ 'desc' if sort_by == field and sort_direction == 'asc' else 'asc' }}&search={{ search_query }}&page={{ pagination.page }}{{ filter_params -}}"
        hx-get="{{- url_for(model_name|lower ~ '-list') }}?sort_by={{ field }}&sort_direction={{ 'desc' if sort_by == field and sort_direction == 'asc' else 'asc' }}&search={{ search_query }}&page={{ pagination.page }}{{ filter_params -}}"
        hx-target="#model-list"

--- a/src/hyperadmin/templates/components/table.html
+++ b/src/hyperadmin/templates/components/table.html
@@ -1,11 +1,11 @@
 <div id="model-list" class="ha-table-wrapper">
-    <table class="ha-table" data-testid="list-table">
+    <table class="ha-table" data-testid="list-table" aria-label="{{ model_name }} list">
         <thead>
             <tr class="ha-table-header">
                 {%- for field in fields -%}
                     {%- include "components/sortable_header.html" -%}
                 {%- endfor -%}
-                <th class="ha-table-th ha-table-th-center">Actions</th>
+                <th class="ha-table-th ha-table-th-center" scope="col">Actions</th>
             </tr>
         </thead>
         <tbody class="ha-table-body">

--- a/tests/e2e/test_admin_dashboard.py
+++ b/tests/e2e/test_admin_dashboard.py
@@ -10,5 +10,5 @@ def test_admin_dashboard_loads_correctly(page: Page, demo_base_url):
     expect(page.locator("h1")).to_have_text("Welcome to HyperAdmin Dashboard")
 
     # Verify that the navbar and sidebar are present
-    expect(page.locator("nav")).to_be_visible()
+    expect(page.get_by_role("navigation", name="Main navigation")).to_be_visible()
     expect(page.locator("aside")).to_be_visible()

--- a/tests/e2e/test_list_view.py
+++ b/tests/e2e/test_list_view.py
@@ -11,7 +11,7 @@ def test_admin_interface_loads(page: Page, demo_base_url: str) -> None:
     expect(page).to_have_title("User List | HyperAdmin")
     expect(page.get_by_role("link", name="HyperAdmin")).to_be_visible()
     expect(page.get_by_test_id("sidebar").get_by_role("link", name="Users")).to_be_visible()
-    expect(page.get_by_role("navigation")).to_be_visible()
+    expect(page.get_by_role("navigation", name="Main navigation")).to_be_visible()
     expect(page.get_by_role("complementary")).to_be_visible()
     expect(page.get_by_role("main")).to_be_attached()
 
@@ -24,7 +24,11 @@ def test_admin_navigation_structure(page: Page, demo_base_url: str) -> None:
     expect(sidebar.get_by_text("Menu")).to_be_visible()
     expect(sidebar.get_by_role("link", name="Users")).to_be_visible()
 
-    expect(page.get_by_role("navigation").get_by_role("link", name="HyperAdmin")).to_be_visible()
+    expect(
+        page.get_by_role("navigation", name="Main navigation").get_by_role(
+            "link", name="HyperAdmin"
+        )
+    ).to_be_visible()
 
 
 def test_responsive_admin_interface(page: Page, demo_base_url: str) -> None:
@@ -42,7 +46,7 @@ def test_admin_interface_styling(page: Page, demo_base_url: str) -> None:
 
     expect(page.locator("body")).to_have_class("ha-page")
     expect(page.get_by_role("main")).to_have_class("ha-content")
-    expect(page.get_by_role("navigation")).to_have_class("ha-navbar")
+    expect(page.get_by_role("navigation", name="Main navigation")).to_have_class("ha-navbar")
     expect(page.get_by_role("complementary")).to_have_class("ha-sidebar")
 
 
@@ -50,7 +54,7 @@ def test_admin_interface_accessibility(page: Page, demo_base_url: str) -> None:
     page.goto(demo_base_url + "/admin/user")
 
     expect(page).to_have_title("User List | HyperAdmin")
-    expect(page.get_by_role("navigation")).to_be_visible()
+    expect(page.get_by_role("navigation", name="Main navigation")).to_be_visible()
     expect(page.get_by_role("main")).to_be_attached()
     expect(page.get_by_role("complementary")).to_be_visible()
 


### PR DESCRIPTION
Closes #72

## Summary

- Add skip-to-content link, role=main, and id=main-content to the base layout
- Add aria-label, aria-haspopup, :aria-expanded, @keydown.escape, aria-hidden on decorative SVGs, and role=menu/role=menuitem to navbar dropdowns
- Add aria-label=Sidebar navigation to sidebar aside, wrap nav list in nav element, add aria-current=page on active link, and aria-hidden=true on decorative icons
- Add aria-live=polite and aria-atomic=true to toast container
- Add aria-label to data table, scope=col to all th headers
- Add aria-sort attribute to sortable column headers reflecting current sort direction
- Wrap pagination in nav aria-label=Pagination with aria-current=page on current page indicator
- Convert filter bar toggle to Alpine.js with aria-expanded, aria-controls, and aria-hidden on decorative SVG
- Add CSS skip-link styles, :focus-visible outline for keyboard navigation, and @media (prefers-reduced-motion: reduce) to disable animations
- Update E2E tests to use named get_by_role selectors to accommodate new multiple navigation landmarks

## Test plan

- [x] All linters pass (poe lint)
- [x] All unit tests pass
- [x] All E2E tests pass (42 tests)