### PR TITLE
feat(ui): custom form layouts with column support (#67)

### DIFF
--- a/examples/simple/admin.py
+++ b/examples/simple/admin.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 from hyperadmin.core.actions import action
 from hyperadmin.core.fieldsets import FieldsetSpec
+from hyperadmin.core.layouts import FormLayout
 from hyperadmin.core.model import ModelAdmin
 from hyperadmin.core.options import AdminOptions
 from hyperadmin.core.registry import site
@@ -27,6 +28,7 @@ class UserAdmin(ModelAdmin):
                 description="Advanced user settings",
             ),
         ],
+        form_layout=FormLayout.TWO_COLUMN
     )
 
     @action(label="Deactivate")

--- a/examples/simple/admin.py
+++ b/examples/simple/admin.py
@@ -28,7 +28,7 @@ class UserAdmin(ModelAdmin):
                 description="Advanced user settings",
             ),
         ],
-        form_layout=FormLayout.TWO_COLUMN
+        form_layout=FormLayout.TWO_COLUMN,
     )
 
     @action(label="Deactivate")

--- a/src/hyperadmin/core/__init__.py
+++ b/src/hyperadmin/core/__init__.py
@@ -5,12 +5,14 @@ from hyperadmin.core.adapters import JsonApiAdapter, ListEnvelope, PaginationMet
 from hyperadmin.core.choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
 from hyperadmin.core.fields import classify_field
 from hyperadmin.core.fieldsets import FieldsetSpec
+from hyperadmin.core.layouts import FormLayout
 
 __all__ = [
     "ActionDef",
     "ChoiceItem",
     "ChoicesProvider",
     "FieldsetSpec",
+    "FormLayout",
     "JsonApiAdapter",
     "ListEnvelope",
     "PaginationMeta",

--- a/src/hyperadmin/core/layouts.py
+++ b/src/hyperadmin/core/layouts.py
@@ -1,0 +1,17 @@
+"""Form layout configuration for HyperAdmin."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class FormLayout(str, Enum):
+    """Controls the column layout of form fields.
+
+    Attributes:
+        SINGLE: Default single-column layout (one field per row).
+        TWO_COLUMN: Two-column grid layout (fields arranged in two columns).
+    """
+
+    SINGLE = "single"
+    TWO_COLUMN = "two-column"

--- a/src/hyperadmin/core/options.py
+++ b/src/hyperadmin/core/options.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 
 from hyperadmin.core.fieldsets import FieldsetSpec
+from hyperadmin.core.layouts import FormLayout
 
 
 class AdminOptions(BaseModel):
@@ -47,5 +48,27 @@ class AdminOptions(BaseModel):
             FieldsetSpec(name="Basic Info", fields=["name", "email"]),
             FieldsetSpec(name="Advanced", fields=["is_active", "rating"], collapsed=True),
         ])
+        ```
+    """
+    form_layout: FormLayout = FormLayout.SINGLE
+    """Controls the column layout of form fields.
+
+    - ``FormLayout.SINGLE``: One field per row (default).
+    - ``FormLayout.TWO_COLUMN``: Fields arranged in a two-column grid.
+
+    Example:
+        ```python
+        AdminOptions(form_layout=FormLayout.TWO_COLUMN)
+        ```
+    """
+    form_fields: list[str] = []
+    """Explicit ordering of fields in create/update forms.
+
+    When non-empty, only these fields are shown, in the specified order.
+    When empty, all editable fields are shown in model-definition order.
+
+    Example:
+        ```python
+        AdminOptions(form_fields=["name", "email", "is_active"])
         ```
     """

--- a/src/hyperadmin/static/css/hyperadmin.css
+++ b/src/hyperadmin/static/css/hyperadmin.css
@@ -857,6 +857,64 @@ body {
 }
 
 /* ==========================================================================
+   Form Layouts — Column Grids
+   ========================================================================== */
+
+.ha-form-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 var(--ha-space-6);
+}
+
+@media (max-width: 768px) {
+  .ha-form-grid-2 {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ==========================================================================
+   Fieldsets
+   ========================================================================== */
+
+.ha-fieldset {
+  border: var(--ha-border-width) solid var(--ha-color-border-light);
+  border-radius: var(--ha-radius-lg);
+  padding: var(--ha-space-4);
+  margin-bottom: var(--ha-space-4);
+}
+
+.ha-fieldset-legend {
+  padding: 0;
+}
+
+.ha-fieldset-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--ha-space-2);
+  font-weight: 600;
+  font-size: var(--ha-font-size-base);
+  color: var(--ha-color-text-strong);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.ha-fieldset-toggle:hover {
+  color: var(--ha-color-primary);
+}
+
+.ha-fieldset-arrow {
+  font-size: var(--ha-font-size-sm);
+}
+
+.ha-fieldset-description {
+  font-size: var(--ha-font-size-sm);
+  color: var(--ha-color-text-muted);
+  margin: var(--ha-space-2) 0 var(--ha-space-4);
+}
+
+/* ==========================================================================
    Accessibility — Skip Link
    ========================================================================== */
 

--- a/src/hyperadmin/templates/components/fieldset.html
+++ b/src/hyperadmin/templates/components/fieldset.html
@@ -1,6 +1,7 @@
 {#- Renders a single fieldset group with collapse/expand toggle.
     Context variables:
       - group: FieldsetGroup instance (name, fields, collapsed, description, slug)
+      - form: PydanticForm instance (for layout_css_class)
 -#}
 {%- if group.name -%}
 <fieldset class="ha-fieldset" data-testid="fieldset-{{ group.slug }}"
@@ -11,14 +12,14 @@
                 data-testid="fieldset-toggle-{{ group.slug }}"
                 @click="open = !open"
                 :aria-expanded="open">
-            <span x-text="open ? '▾' : '▸'" class="ha-fieldset-arrow"></span>
+            <span x-text="open ? '&#9662;' : '&#9656;'" class="ha-fieldset-arrow"></span>
             {{ group.name }}
         </button>
     </legend>
     {%- if group.description -%}
     <p class="ha-fieldset-description" x-show="open">{{ group.description }}</p>
     {%- endif -%}
-    <div x-show="open" x-collapse>
+    <div x-show="open" x-collapse class="{{ form.layout_css_class }}">
         {%- for field in group.fields -%}
             {%- set widget = field.widget -%}
             {%- include field.widget.template_path -%}
@@ -27,8 +28,10 @@
 </fieldset>
 {%- else -%}
 {#- Ungrouped fields (no fieldset header) -#}
+<div class="{{ form.layout_css_class }}">
 {%- for field in group.fields -%}
     {%- set widget = field.widget -%}
     {%- include field.widget.template_path -%}
 {%- endfor -%}
+</div>
 {%- endif -%}

--- a/src/hyperadmin/templates/create.html
+++ b/src/hyperadmin/templates/create.html
@@ -16,10 +16,12 @@
             {%- include "components/fieldset.html" -%}
         {%- endfor -%}
     {%- else -%}
+        <div class="{{ form.layout_css_class }}" data-testid="form-fields">
         {%- for field in form.fields -%}
             {%- set widget = field.widget -%}
             {%- include field.widget.template_path -%}
         {%- endfor -%}
+        </div>
     {%- endif -%}
 {%- endblock -%}
 

--- a/src/hyperadmin/templates/update.html
+++ b/src/hyperadmin/templates/update.html
@@ -16,10 +16,12 @@
             {%- include "components/fieldset.html" -%}
         {%- endfor -%}
     {%- else -%}
+        <div class="{{ form.layout_css_class }}" data-testid="form-fields">
         {%- for field in form.fields -%}
             {%- set widget = field.widget -%}
             {%- include field.widget.template_path -%}
         {%- endfor -%}
+        </div>
     {%- endif -%}
 {%- endblock -%}
 

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -378,6 +378,8 @@ class DynamicModelView:
             exclude=self.form_create_exclude,
             initial=values or {},
             fieldsets=getattr(self.options, "fieldsets", None) or None,
+            form_layout=getattr(self.options, "form_layout", None),
+            form_fields=getattr(self.options, "form_fields", None) or None,
         )
         if errors:
             form.bind(values or {})
@@ -441,6 +443,8 @@ class DynamicModelView:
             include=create_include,
             exclude=self.form_create_exclude,
             fieldsets=getattr(self.options, "fieldsets", None) or None,
+            form_layout=getattr(self.options, "form_layout", None),
+            form_fields=getattr(self.options, "form_fields", None) or None,
         )
         data = self._extract_form_data(form_data, form)
         form.bind(data)
@@ -516,6 +520,8 @@ class DynamicModelView:
             include=self.form_include,
             initial=initial_values,
             fieldsets=getattr(self.options, "fieldsets", None) or None,
+            form_layout=getattr(self.options, "form_layout", None),
+            form_fields=getattr(self.options, "form_fields", None) or None,
         )
 
         if errors:
@@ -557,6 +563,8 @@ class DynamicModelView:
             widgets=relation_widgets,
             include=self.form_include,
             fieldsets=getattr(self.options, "fieldsets", None) or None,
+            form_layout=getattr(self.options, "form_layout", None),
+            form_fields=getattr(self.options, "form_fields", None) or None,
         )
         data = self._extract_form_data(form_data, form)
 

--- a/src/hyperadmin/views/forms.py
+++ b/src/hyperadmin/views/forms.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from starlette.templating import Jinja2Templates
 
     from hyperadmin.core.fieldsets import FieldsetSpec
+    from hyperadmin.core.layouts import FormLayout
 
 
 @dataclass(slots=True)
@@ -243,6 +244,8 @@ class PydanticForm:
         initial: dict[str, Any] | None = None,
         choices_base_url: str = "",
         fieldsets: list[FieldsetSpec] | None = None,
+        form_layout: FormLayout | None = None,
+        form_fields: list[str] | None = None,
     ) -> None:
         self.model = model
         self.widgets = widgets or {}
@@ -253,6 +256,8 @@ class PydanticForm:
         self.errors: dict[str, list[str]] = {}
         self._fields: list[FormField] = []
         self._fieldset_specs: list[FieldsetSpec] = fieldsets or []
+        self._form_layout: FormLayout | None = form_layout
+        self._form_fields: list[str] = form_fields or []
 
     @staticmethod
     def _enum_choices(enum_cls: type[Enum]) -> list[ChoiceItem]:
@@ -347,27 +352,42 @@ class PydanticForm:
                 return True
         return False
 
-    @property
-    def fields(self) -> list[FormField]:
-        if self._fields:
-            return self._fields
+    def _build_all_fields(self) -> dict[str, FormField]:
+        """Build all eligible form fields as a name->FormField mapping."""
+        field_map: dict[str, FormField] = {}
         for name, field in self.model.model_fields.items():
             if self.include and name not in self.include:
                 continue
             if name in self.exclude:
                 continue
-            # Exclude common primary key name by default for create/update forms
             if name == "id":
                 continue
             if self._is_auto_now_field(field):
                 continue
             widget = self._pick_widget(name, field)
-            # Pydantic FieldInfo.default may be PydanticUndefined; use None in that case
             default_val = getattr(field, "default", None)
             if str(default_val) == "PydanticUndefined":
                 default_val = None
             value = self.initial.get(name, default_val if default_val is not None else None)
-            self._fields.append(FormField(name=name, model_field=field, widget=widget, value=value))
+            field_map[name] = FormField(name=name, model_field=field, widget=widget, value=value)
+        return field_map
+
+    @property
+    def fields(self) -> list[FormField]:
+        if self._fields:
+            return self._fields
+
+        field_map = self._build_all_fields()
+
+        # If form_fields is specified, use that ordering (and only those fields)
+        if self._form_fields:
+            for name in self._form_fields:
+                if name in field_map:
+                    self._fields.append(field_map[name])
+        else:
+            # Default: model-definition order
+            self._fields = list(field_map.values())
+
         return self._fields
 
     @property
@@ -445,3 +465,55 @@ class PydanticForm:
                     seen.add(path)
                     assets.append(path)
         return tuple(assets)
+
+    @property
+    def fieldset_groups(self) -> list[FieldsetGroup]:
+        """Return form fields grouped according to the configured fieldsets.
+
+        If no fieldsets are configured, returns a single group containing all fields.
+        Fields referenced in a fieldset spec but not present in the form are silently
+        skipped. Fields not covered by any fieldset are collected into a trailing
+        "Other fields" group.
+        """
+        all_fields = self.fields
+        if not self._fieldset_specs:
+            return [FieldsetGroup(name="", fields=all_fields, slug="")]
+
+        field_map = {f.name: f for f in all_fields}
+        claimed: set[str] = set()
+        groups: list[FieldsetGroup] = []
+
+        for spec in self._fieldset_specs:
+            group_fields: list[FormField] = []
+            for fname in spec.fields:
+                if fname in field_map:
+                    group_fields.append(field_map[fname])
+                    claimed.add(fname)
+            if group_fields:
+                groups.append(
+                    FieldsetGroup(
+                        name=spec.name,
+                        fields=group_fields,
+                        collapsed=spec.collapsed,
+                        description=spec.description,
+                    )
+                )
+
+        # Collect unclaimed fields into a trailing group
+        unclaimed = [f for f in all_fields if f.name not in claimed]
+        if unclaimed:
+            groups.append(FieldsetGroup(name="Other fields", fields=unclaimed))
+
+        return groups
+
+    @property
+    def layout_css_class(self) -> str:
+        """Return the CSS class for the form layout.
+
+        Returns ``ha-form-grid-2`` for two-column layout, empty string for single.
+        """
+        from hyperadmin.core.layouts import FormLayout  # noqa: PLC0415
+
+        if self._form_layout == FormLayout.TWO_COLUMN:
+            return "ha-form-grid-2"
+        return ""

--- a/src/hyperadmin/views/forms.py
+++ b/src/hyperadmin/views/forms.py
@@ -467,46 +467,6 @@ class PydanticForm:
         return tuple(assets)
 
     @property
-    def fieldset_groups(self) -> list[FieldsetGroup]:
-        """Return form fields grouped according to the configured fieldsets.
-
-        If no fieldsets are configured, returns a single group containing all fields.
-        Fields referenced in a fieldset spec but not present in the form are silently
-        skipped. Fields not covered by any fieldset are collected into a trailing
-        "Other fields" group.
-        """
-        all_fields = self.fields
-        if not self._fieldset_specs:
-            return [FieldsetGroup(name="", fields=all_fields, slug="")]
-
-        field_map = {f.name: f for f in all_fields}
-        claimed: set[str] = set()
-        groups: list[FieldsetGroup] = []
-
-        for spec in self._fieldset_specs:
-            group_fields: list[FormField] = []
-            for fname in spec.fields:
-                if fname in field_map:
-                    group_fields.append(field_map[fname])
-                    claimed.add(fname)
-            if group_fields:
-                groups.append(
-                    FieldsetGroup(
-                        name=spec.name,
-                        fields=group_fields,
-                        collapsed=spec.collapsed,
-                        description=spec.description,
-                    )
-                )
-
-        # Collect unclaimed fields into a trailing group
-        unclaimed = [f for f in all_fields if f.name not in claimed]
-        if unclaimed:
-            groups.append(FieldsetGroup(name="Other fields", fields=unclaimed))
-
-        return groups
-
-    @property
     def layout_css_class(self) -> str:
         """Return the CSS class for the form layout.
 

--- a/tests/e2e/test_form_layouts.py
+++ b/tests/e2e/test_form_layouts.py
@@ -1,0 +1,29 @@
+"""E2E tests for custom form layouts (#67).
+
+Verifies that form layout CSS classes are applied correctly in create/update
+views, and that form_fields ordering is reflected in the rendered DOM.
+"""
+
+import re
+
+from playwright.sync_api import Page, expect
+
+
+def test_user_create_form_has_two_column_layout(page: Page, demo_base_url: str):
+    """UserAdmin has form_layout=TWO_COLUMN; the form should render with ha-form-grid-2."""
+    page.goto(f"{demo_base_url}/admin/user/create")
+    expect(page.get_by_test_id("model-form")).to_be_visible()
+
+    # The form-fields container should have the two-column CSS class
+    grid = page.get_by_test_id("form-fields")
+    expect(grid).to_have_class(re.compile(r"ha-form-grid-2"))
+
+
+def test_product_create_form_has_single_column_layout(page: Page, demo_base_url: str):
+    """ProductAdmin has default (single) layout; no ha-form-grid-2 class."""
+    page.goto(f"{demo_base_url}/admin/product/create")
+    expect(page.get_by_test_id("model-form")).to_be_visible()
+
+    grid = page.get_by_test_id("form-fields")
+    # Should not have the two-column class
+    expect(grid).not_to_have_class(re.compile(r"ha-form-grid-2"))

--- a/tests/e2e/test_form_layouts.py
+++ b/tests/e2e/test_form_layouts.py
@@ -14,9 +14,12 @@ def test_user_create_form_has_two_column_layout(page: Page, demo_base_url: str):
     page.goto(f"{demo_base_url}/admin/user/create")
     expect(page.get_by_test_id("model-form")).to_be_visible()
 
-    # The form-fields container should have the two-column CSS class
-    grid = page.get_by_test_id("form-fields")
-    expect(grid).to_have_class(re.compile(r"ha-form-grid-2"))
+    # UserAdmin uses fieldsets + TWO_COLUMN layout, so the layout class
+    # is applied inside each fieldset's inner div, not on a top-level form-fields div.
+    fieldset = page.get_by_test_id("fieldset-basic-info")
+    expect(fieldset).to_be_visible()
+    grid = fieldset.locator(".ha-form-grid-2")
+    expect(grid).to_be_visible()
 
 
 def test_product_create_form_has_single_column_layout(page: Page, demo_base_url: str):

--- a/tests/unit/test_form_layouts.py
+++ b/tests/unit/test_form_layouts.py
@@ -1,0 +1,278 @@
+"""Unit tests for custom form layouts (#67).
+
+Covers:
+- FormLayout enum values
+- AdminOptions.form_layout / form_fields configuration
+- FieldsetSpec dataclass
+- FieldsetGroup slug generation
+- PydanticForm field ordering via form_fields
+- PydanticForm.fieldset_groups grouping logic
+- PydanticForm.layout_css_class for single / two-column layouts
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from hyperadmin.core.fieldsets import FieldsetSpec
+from hyperadmin.core.layouts import FormLayout
+from hyperadmin.core.options import AdminOptions
+from hyperadmin.views.forms import FieldsetGroup, PydanticForm
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class SampleModel(BaseModel):
+    name: str = Field(title="Name")
+    email: str = Field(title="Email")
+    age: int = Field(title="Age")
+    bio: str | None = Field(None, title="Biography")
+
+
+# ---------------------------------------------------------------------------
+# FormLayout enum
+# ---------------------------------------------------------------------------
+
+
+def test_form_layout_single_value() -> None:
+    assert FormLayout.SINGLE == "single"
+
+
+def test_form_layout_two_column_value() -> None:
+    assert FormLayout.TWO_COLUMN == "two-column"
+
+
+def test_form_layout_is_string_subclass() -> None:
+    assert isinstance(FormLayout.SINGLE, str)
+    assert isinstance(FormLayout.TWO_COLUMN, str)
+
+
+# ---------------------------------------------------------------------------
+# FieldsetSpec dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_fieldset_spec_defaults() -> None:
+    fs = FieldsetSpec(name="Basic")
+    assert fs.name == "Basic"
+    assert fs.fields == []
+    assert fs.collapsed is False
+    assert fs.description is None
+
+
+def test_fieldset_spec_with_fields() -> None:
+    fs = FieldsetSpec(name="Info", fields=["name", "email"], collapsed=True, description="Help")
+    assert fs.fields == ["name", "email"]
+    assert fs.collapsed is True
+    assert fs.description == "Help"
+
+
+# ---------------------------------------------------------------------------
+# FieldsetGroup
+# ---------------------------------------------------------------------------
+
+
+def test_fieldset_group_slug_auto() -> None:
+    group = FieldsetGroup(name="Basic Info", fields=[])
+    assert group.slug == "basic-info"
+
+
+def test_fieldset_group_slug_explicit() -> None:
+    group = FieldsetGroup(name="Advanced", fields=[], slug="adv")
+    assert group.slug == "adv"
+
+
+def test_fieldset_group_empty_name() -> None:
+    group = FieldsetGroup(name="", fields=[])
+    assert group.slug == ""
+
+
+# ---------------------------------------------------------------------------
+# AdminOptions — new fields
+# ---------------------------------------------------------------------------
+
+
+def test_admin_options_fieldsets_default() -> None:
+    opts = AdminOptions()
+    assert opts.fieldsets == []
+
+
+def test_admin_options_form_layout_default() -> None:
+    opts = AdminOptions()
+    assert opts.form_layout == FormLayout.SINGLE
+
+
+def test_admin_options_form_fields_default() -> None:
+    opts = AdminOptions()
+    assert opts.form_fields == []
+
+
+def test_admin_options_form_layout_two_column() -> None:
+    opts = AdminOptions(form_layout=FormLayout.TWO_COLUMN)
+    assert opts.form_layout == FormLayout.TWO_COLUMN
+
+
+def test_admin_options_form_fields_custom() -> None:
+    opts = AdminOptions(form_fields=["name", "email"])
+    assert opts.form_fields == ["name", "email"]
+
+
+def test_admin_options_fieldsets_custom() -> None:
+    opts = AdminOptions(
+        fieldsets=[
+            FieldsetSpec(name="Basic", fields=["name", "email"]),
+            FieldsetSpec(name="Extra", fields=["age"], collapsed=True),
+        ]
+    )
+    assert len(opts.fieldsets) == 2
+    assert opts.fieldsets[0].name == "Basic"
+    assert opts.fieldsets[1].collapsed is True
+
+
+# ---------------------------------------------------------------------------
+# PydanticForm.fields — ordering via form_fields
+# ---------------------------------------------------------------------------
+
+
+def test_form_fields_default_order() -> None:
+    form = PydanticForm(model=SampleModel)
+    names = [f.name for f in form.fields]
+    assert names == ["name", "email", "age", "bio"]
+
+
+def test_form_fields_custom_order() -> None:
+    form = PydanticForm(model=SampleModel, form_fields=["bio", "age", "name"])
+    names = [f.name for f in form.fields]
+    assert names == ["bio", "age", "name"]
+
+
+def test_form_fields_subset() -> None:
+    """form_fields should act as both an ordering AND inclusion filter."""
+    form = PydanticForm(model=SampleModel, form_fields=["email", "name"])
+    names = [f.name for f in form.fields]
+    assert names == ["email", "name"]
+    assert "age" not in names
+    assert "bio" not in names
+
+
+def test_form_fields_skips_unknown() -> None:
+    """Unknown field names in form_fields are silently skipped."""
+    form = PydanticForm(model=SampleModel, form_fields=["name", "nonexistent", "age"])
+    names = [f.name for f in form.fields]
+    assert names == ["name", "age"]
+
+
+# ---------------------------------------------------------------------------
+# PydanticForm.layout_css_class
+# ---------------------------------------------------------------------------
+
+
+def test_layout_css_class_single() -> None:
+    form = PydanticForm(model=SampleModel, form_layout=FormLayout.SINGLE)
+    assert form.layout_css_class == ""
+
+
+def test_layout_css_class_two_column() -> None:
+    form = PydanticForm(model=SampleModel, form_layout=FormLayout.TWO_COLUMN)
+    assert form.layout_css_class == "ha-form-grid-2"
+
+
+def test_layout_css_class_none_defaults_empty() -> None:
+    form = PydanticForm(model=SampleModel)
+    assert form.layout_css_class == ""
+
+
+# ---------------------------------------------------------------------------
+# PydanticForm.fieldset_groups
+# ---------------------------------------------------------------------------
+
+
+def test_fieldset_groups_no_fieldsets() -> None:
+    """Without fieldsets, returns a single unnamed group with all fields."""
+    form = PydanticForm(model=SampleModel)
+    groups = form.fieldset_groups
+    assert len(groups) == 1
+    assert groups[0].name == ""
+    assert [f.name for f in groups[0].fields] == ["name", "email", "age", "bio"]
+
+
+def test_fieldset_groups_with_fieldsets() -> None:
+    form = PydanticForm(
+        model=SampleModel,
+        fieldsets=[
+            FieldsetSpec(name="Contact", fields=["name", "email"]),
+            FieldsetSpec(name="Details", fields=["age"], collapsed=True),
+        ],
+    )
+    groups = form.fieldset_groups
+    # Two declared groups + one "Other fields" for unclaimed "bio"
+    assert len(groups) == 3
+    assert groups[0].name == "Contact"
+    assert [f.name for f in groups[0].fields] == ["name", "email"]
+    assert groups[1].name == "Details"
+    assert groups[1].collapsed is True
+    assert [f.name for f in groups[1].fields] == ["age"]
+    assert groups[2].name == "Other fields"
+    assert [f.name for f in groups[2].fields] == ["bio"]
+
+
+def test_fieldset_groups_all_fields_claimed() -> None:
+    """When all fields are claimed, no trailing group is created."""
+    form = PydanticForm(
+        model=SampleModel,
+        fieldsets=[
+            FieldsetSpec(name="All", fields=["name", "email", "age", "bio"]),
+        ],
+    )
+    groups = form.fieldset_groups
+    assert len(groups) == 1
+    assert groups[0].name == "All"
+
+
+def test_fieldset_groups_unknown_fields_skipped() -> None:
+    """Fields referenced in a fieldset but not on the model are skipped."""
+    form = PydanticForm(
+        model=SampleModel,
+        fieldsets=[
+            FieldsetSpec(name="Partial", fields=["name", "nonexistent"]),
+        ],
+    )
+    groups = form.fieldset_groups
+    assert groups[0].name == "Partial"
+    assert [f.name for f in groups[0].fields] == ["name"]
+
+
+def test_fieldset_groups_with_form_fields_ordering() -> None:
+    """form_fields + fieldsets: fieldsets group the ordered fields."""
+    form = PydanticForm(
+        model=SampleModel,
+        form_fields=["age", "name"],
+        fieldsets=[
+            FieldsetSpec(name="Ordered", fields=["age", "name"]),
+        ],
+    )
+    groups = form.fieldset_groups
+    assert len(groups) == 1
+    assert [f.name for f in groups[0].fields] == ["age", "name"]
+
+
+# ---------------------------------------------------------------------------
+# Combined: layout + fieldsets
+# ---------------------------------------------------------------------------
+
+
+def test_two_column_with_fieldsets() -> None:
+    """Two-column layout + fieldsets: layout_css_class is set, groups are formed."""
+    form = PydanticForm(
+        model=SampleModel,
+        form_layout=FormLayout.TWO_COLUMN,
+        fieldsets=[
+            FieldsetSpec(name="Basic", fields=["name", "email"]),
+        ],
+    )
+    assert form.layout_css_class == "ha-form-grid-2"
+    groups = form.fieldset_groups
+    assert groups[0].name == "Basic"
+    assert len(groups) == 2  # Basic + Other fields (age, bio)


### PR DESCRIPTION
## Summary
- Add FormLayout enum (single, two-column) and form_fields ordering to AdminOptions
- Include FieldsetSpec for field grouping with collapsible headings (dependency for #66)
- PydanticForm gains fieldset_groups, layout_css_class, and form_fields ordering support
- Templates (create.html, update.html) render column layouts via ha-form-grid-2 CSS grid class
- Fix: preserve class-defined options in SiteRegistry.register() to avoid overwriting admin config

## Test plan
- [x] 27 unit tests covering FormLayout, FieldsetSpec, FieldsetGroup, AdminOptions new fields, PydanticForm field ordering, layout CSS class, and fieldset grouping
- [x] 2 E2E tests verifying two-column layout renders on User create form and single-column on Product
- [x] poe lint passes (ruff, mypy, basedpyright)
- [x] poe test:unit passes (345 tests)
- [x] Pre-push hooks pass (unit + E2E + security)

Closes #67