### PR TITLE
feat(ui): theme support with light and dark mode (#73)

### DIFF
--- a/src/hyperadmin/core/app.py
+++ b/src/hyperadmin/core/app.py
@@ -27,6 +27,9 @@ class Admin:
         ```
     """
 
+    #: Valid theme values that can be passed to the ``theme`` parameter.
+    VALID_THEMES = ("auto", "light", "dark")
+
     def __init__(  # noqa: PLR0913
         self,
         app: FastAPI,
@@ -38,6 +41,7 @@ class Admin:
         permission_checker: Any = None,
         permission_registry: Any = None,
         session_secret: str | None = None,
+        theme: str = "auto",
     ):
         """Initialise HyperAdmin and attach it to a FastAPI application.
 
@@ -57,7 +61,14 @@ class Admin:
             permission_registry: An optional ``PermissionRegistry`` implementation.
             session_secret: Secret key for ``SessionMiddleware``. Required when
                 ``auth_backend`` is set.
+            theme: Color theme for the admin interface. Accepted values are
+                ``"auto"`` (respects ``prefers-color-scheme``, default),
+                ``"light"`` (always light), or ``"dark"`` (always dark).
         """
+        if theme not in self.VALID_THEMES:
+            msg = f"Invalid theme {theme!r}. Must be one of {self.VALID_THEMES}"
+            raise ValueError(msg)
+        self.theme = theme
         self.app = app
         self.router = APIRouter()
         self.engine = engine or default_engine
@@ -163,6 +174,7 @@ class Admin:
         self._register_views()
         self.templates.env.globals["admin_prefix"] = path.rstrip("/")
         self.templates.env.globals["auth_enabled"] = self.auth_backend is not None
+        self.templates.env.globals["theme"] = self.theme
 
         if self.auth_backend:
             self.router.on_startup.append(self._sync_permissions)

--- a/src/hyperadmin/static/css/hyperadmin.css
+++ b/src/hyperadmin/static/css/hyperadmin.css
@@ -159,12 +159,26 @@
    Dark Mode Tokens — Three-way system
    ========================================================================== */
 
-/* Manual dark (user toggled via data-theme attribute) */
+/* Shared dark-mode overrides — applied by class toggle, data-theme, or OS preference */
+.ha-theme-dark,
 :root[data-theme="dark"] {
   --ha-color-primary: #2dd4b8;
   --ha-color-primary-hover: #05bfa4;
   --ha-color-primary-light: #00504a;
   --ha-color-primary-text: #2dd4b8;
+  --ha-color-danger: #f87171;
+  --ha-color-danger-hover: #fca5a5;
+  --ha-color-danger-light: #450a0a;
+  --ha-color-danger-text: #fca5a5;
+  --ha-color-success: #4ade80;
+  --ha-color-success-light: #052e16;
+  --ha-color-success-text: #86efac;
+  --ha-color-warning: #facc15;
+  --ha-color-warning-light: #422006;
+  --ha-color-warning-text: #fde68a;
+  --ha-color-info-light: #1e3a5f;
+  --ha-color-info-text: #93c5fd;
+  --ha-color-info-border: #3b82f6;
 
   --ha-color-text: var(--ha-color-neutral-200);
   --ha-color-text-muted: var(--ha-color-neutral-300);
@@ -180,15 +194,32 @@
   --ha-surface-base: var(--ha-color-neutral-950);
   --ha-surface-raised: var(--ha-color-neutral-800);
   --ha-surface-sunken: var(--ha-color-neutral-900);
+
+  --ha-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3), 0 1px 2px -1px rgba(0, 0, 0, 0.3);
+  --ha-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -2px rgba(0, 0, 0, 0.3);
+  --ha-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -4px rgba(0, 0, 0, 0.3);
 }
 
-/* System preference (applies when no data-theme set) */
+/* Auto mode: respect OS preference when no explicit theme is set */
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
+  :root:not(.ha-theme-light):not([data-theme="light"]) {
     --ha-color-primary: #2dd4b8;
     --ha-color-primary-hover: #05bfa4;
     --ha-color-primary-light: #00504a;
     --ha-color-primary-text: #2dd4b8;
+    --ha-color-danger: #f87171;
+    --ha-color-danger-hover: #fca5a5;
+    --ha-color-danger-light: #450a0a;
+    --ha-color-danger-text: #fca5a5;
+    --ha-color-success: #4ade80;
+    --ha-color-success-light: #052e16;
+    --ha-color-success-text: #86efac;
+    --ha-color-warning: #facc15;
+    --ha-color-warning-light: #422006;
+    --ha-color-warning-text: #fde68a;
+    --ha-color-info-light: #1e3a5f;
+    --ha-color-info-text: #93c5fd;
+    --ha-color-info-border: #3b82f6;
 
     --ha-color-text: var(--ha-color-neutral-200);
     --ha-color-text-muted: var(--ha-color-neutral-300);
@@ -204,6 +235,10 @@
     --ha-surface-base: var(--ha-color-neutral-950);
     --ha-surface-raised: var(--ha-color-neutral-800);
     --ha-surface-sunken: var(--ha-color-neutral-900);
+
+    --ha-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3), 0 1px 2px -1px rgba(0, 0, 0, 0.3);
+    --ha-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3), 0 2px 4px -2px rgba(0, 0, 0, 0.3);
+    --ha-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -4px rgba(0, 0, 0, 0.3);
   }
 }
 
@@ -1325,4 +1360,51 @@ body {
   :root {
     --ha-sidebar-width: 12rem;
   }
+}
+
+/* ==========================================================================
+   Theme Toggle
+   ========================================================================== */
+
+.ha-theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background: none;
+  border: var(--ha-border-width) solid var(--ha-color-border);
+  border-radius: var(--ha-radius);
+  cursor: pointer;
+  color: var(--ha-color-text-muted);
+  transition: color var(--ha-transition), border-color var(--ha-transition);
+  padding: 0;
+  margin-right: var(--ha-space-2);
+}
+
+.ha-theme-toggle:hover {
+  color: var(--ha-color-text-strong);
+  border-color: var(--ha-color-text-muted);
+}
+
+.ha-theme-toggle .ha-icon-sun,
+.ha-theme-toggle .ha-icon-moon {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+/* In light mode: show moon icon (click to go dark) */
+.ha-theme-toggle .ha-icon-moon { display: block; }
+.ha-theme-toggle .ha-icon-sun  { display: none; }
+
+/* In dark mode: show sun icon (click to go light) */
+.ha-theme-dark .ha-theme-toggle .ha-icon-moon,
+html[data-theme="dark"] .ha-theme-toggle .ha-icon-moon { display: none; }
+.ha-theme-dark .ha-theme-toggle .ha-icon-sun,
+html[data-theme="dark"] .ha-theme-toggle .ha-icon-sun  { display: block; }
+
+/* Auto mode with OS dark preference */
+@media (prefers-color-scheme: dark) {
+  html:not(.ha-theme-light):not([data-theme="light"]) .ha-theme-toggle .ha-icon-moon { display: none; }
+  html:not(.ha-theme-light):not([data-theme="light"]) .ha-theme-toggle .ha-icon-sun  { display: block; }
 }

--- a/src/hyperadmin/templates/_base.html
+++ b/src/hyperadmin/templates/_base.html
@@ -1,9 +1,25 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-ha-default-theme="{{ theme|default('auto') }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}HyperAdmin{% endblock %}</title>
+    <script>
+      // Theme initialisation — runs before CSS to prevent flash of wrong theme.
+      (function() {
+        var defaultTheme = document.documentElement.getAttribute('data-ha-default-theme') || 'auto';
+        var stored = localStorage.getItem('ha-theme');
+        var theme = stored || defaultTheme;
+        if (theme === 'dark') {
+          document.documentElement.classList.add('ha-theme-dark');
+          document.documentElement.setAttribute('data-theme', 'dark');
+        } else if (theme === 'light') {
+          document.documentElement.classList.add('ha-theme-light');
+          document.documentElement.setAttribute('data-theme', 'light');
+        }
+        // 'auto' leaves no class — media query handles it
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -47,6 +63,34 @@
           }
         });
       });
+
+      /**
+       * Toggle the active theme between light and dark.
+       * Persists the choice in localStorage so it survives page reloads.
+       */
+      function haToggleTheme() {
+        var html = document.documentElement;
+        var isDark = html.classList.contains('ha-theme-dark') ||
+                     html.getAttribute('data-theme') === 'dark';
+
+        // If currently in auto mode, detect effective theme from OS preference
+        if (!isDark && !html.classList.contains('ha-theme-light') &&
+            html.getAttribute('data-theme') !== 'light') {
+          isDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        }
+
+        if (isDark) {
+          html.classList.remove('ha-theme-dark');
+          html.classList.add('ha-theme-light');
+          html.setAttribute('data-theme', 'light');
+          localStorage.setItem('ha-theme', 'light');
+        } else {
+          html.classList.remove('ha-theme-light');
+          html.classList.add('ha-theme-dark');
+          html.setAttribute('data-theme', 'dark');
+          localStorage.setItem('ha-theme', 'dark');
+        }
+      }
     </script>
 </head>
 <body class="ha-page">

--- a/src/hyperadmin/templates/_navbar.html
+++ b/src/hyperadmin/templates/_navbar.html
@@ -1,6 +1,19 @@
 <nav class="ha-navbar" aria-label="Main navigation">
     <div class="ha-navbar-inner">
         <a href="{{ admin_prefix }}/" class="ha-navbar-brand">HyperAdmin</a>
+        <div style="display:flex;align-items:center;gap:0.5rem;">
+        <button type="button"
+                class="ha-theme-toggle"
+                onclick="haToggleTheme()"
+                aria-label="Toggle dark mode"
+                data-testid="theme-toggle">
+            <svg class="ha-icon-sun" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8.66-13.66l-.71.71M4.05 19.95l-.71.71M21 12h-1M4 12H3m16.66 7.66l-.71-.71M4.05 4.05l-.71-.71M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+            </svg>
+            <svg class="ha-icon-moon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.005 9.005 0 0012 21a9.005 9.005 0 008.354-5.646z"/>
+            </svg>
+        </button>
         <div x-data="{ open: false }" class="ha-navbar-user">
             {% if auth_enabled and request.state.user %}
             <button @click="open = !open" @keydown.escape="open = false" class="ha-navbar-user-btn" aria-haspopup="true" :aria-expanded="open">
@@ -32,6 +45,7 @@
                 <a href="#" class="ha-dropdown-item" role="menuitem">Settings</a>
             </div>
             {% endif %}
+        </div>
         </div>
     </div>
 </nav>

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -61,3 +61,34 @@ async def test_admin_create_tables(mock_fastapi_app):
     # Assert
     mock_engine.begin.assert_called_once()
     mock_conn.run_sync.assert_called_once_with(SQLModel.metadata.create_all)
+
+
+# ---------------------------------------------------------------------------
+# Theme configuration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("theme", ["auto", "light", "dark"])
+def test_admin_theme_valid(mock_fastapi_app, theme):
+    """Valid theme values are accepted and stored on the Admin instance."""
+    admin = Admin(app=mock_fastapi_app, theme=theme)
+    assert admin.theme == theme
+
+
+def test_admin_theme_default(mock_fastapi_app):
+    """Default theme is 'auto' when not specified."""
+    admin = Admin(app=mock_fastapi_app)
+    assert admin.theme == "auto"
+
+
+def test_admin_theme_invalid(mock_fastapi_app):
+    """Invalid theme value raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid theme"):
+        Admin(app=mock_fastapi_app, theme="neon")
+
+
+def test_admin_theme_exposed_to_templates(mock_fastapi_app):
+    """The theme value is available as a Jinja2 template global."""
+    admin = Admin(app=mock_fastapi_app, theme="dark")
+    admin.mount("/admin")
+    assert admin.templates.env.globals["theme"] == "dark"


### PR DESCRIPTION
Closes #73

- Added `theme` parameter to `Admin.__init__()` (auto/light/dark)
- CSS custom properties for light/dark themes
- localStorage persistence with flash-free loading
- Theme toggle button in navbar with sun/moon icons
- 4 unit tests