### PR TITLE
docs: sync roadmap, milestones, and GitHub project board

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,17 +2,19 @@
 
 This document outlines the planned features and development phases for HyperAdmin. Our goal is to build a modern, powerful, and easy-to-use admin interface for FastAPI.
 
+> **For detailed epic-level planning, milestone tracking, and priority matrix, see [`docs/roadmap.md`](docs/roadmap.md).**
+
 ---
 
-## ✅ Phase 1: Foundation & The "Walking Skeleton" (Completed)
+## Phase 1: Foundation & The "Walking Skeleton" (Completed)
 
 This initial phase established the project's foundation, including the repository setup, a basic "walking skeleton" of the application, and a CI/CD pipeline. This work proved the core concept and allowed for rapid development.
 
 ---
 
-## 🟡 Phase 2: Core Functionality & Admin UI (In Progress)
+## Phase 2: Core Functionality & Admin UI (Completed)
 
-The goal of this phase is to build a complete and visually appealing admin interface with full CRUD functionality and a modern UI.
+This phase built a complete and visually appealing admin interface with full CRUD functionality and a modern UI.
 
 - **CRUD Implementation**:
     - [x] Add SQLAlchemy and SQLModel as dependencies.
@@ -22,10 +24,13 @@ The goal of this phase is to build a complete and visually appealing admin inter
     - [x] Implement **Delete Action** with HTMX for a seamless UI experience.
 
 - **Admin UI Epics**:
-    - [/] **Navigation Sidebar**: Design and implement a collapsible sidebar for easy navigation between different admin views. (Basic implementation exists)
-    - [x] **Data Table Component**: Create a reusable and feature-rich data table with sorting, pagination, and filtering capabilities.
-    - [x] **Forms & Widgets**: Develop a set of standardized form elements and dashboard widgets for a consistent and modern look and feel.
-    - [x] **Styling & Theming**: Implement a clean and modern design system, with support for custom theming.
+    - [x] **Navigation Sidebar**: Collapsible sidebar for easy navigation between different admin views.
+    - [x] **Data Table Component**: Reusable and feature-rich data table with sorting, pagination, and filtering.
+    - [x] **Forms & Widgets**: Standardized form elements including select/multiselect widgets (enum, FK, M2M, autocomplete).
+    - [x] **Styling & Theming**: Clean and modern design system with theme support.
+    - [x] **Custom Actions Framework**: Register and execute custom actions per model.
+    - [x] **Fieldsets**: Group fields in admin forms with collapsible sections.
+    - [x] **WCAG 2.1 AA Accessibility**: Keyboard navigation, ARIA, color contrast, screen reader support.
 
 - **Documentation & Community Outreach**:
     - [x] Set up a documentation site using MkDocs with the `mkdocs-material` theme.
@@ -35,14 +40,18 @@ The goal of this phase is to build a complete and visually appealing admin inter
 
 ---
 
-## ⚪️ Phase 3: Advanced Features & Polish (Future)
+## Phase 3: Advanced Features & Polish (Future)
 
 With a solid foundation and a polished UI, this phase will focus on adding advanced features and making HyperAdmin even more powerful and flexible.
 
 - **Advanced Features**:
-  - [ ] Authentication and authorization hooks.
-  - [ ] Support for model relationships (e.g., dropdowns for foreign keys).
-  - [ ] Custom actions (e.g., "approve selected items").
+  - [ ] Authentication and authorization hooks (E2E wiring).
+  - [x] Support for model relationships (select/multiselect widgets with FK, M2M, autocomplete).
+  - [x] Custom actions (action framework with bulk and single-object actions).
   - [ ] File uploads.
-  - [ ] Advanced form validation and error handling.
-  - [ ] UI/UX Polish (e.g., pagination, notifications).
+  - [ ] Zero-config admin (3 lines of code).
+  - [ ] Internationalization (i18n).
+  - [ ] Audit / activity log.
+  - [ ] Dashboard builder.
+  - [ ] Real-time updates (WebSocket).
+  - [ ] Plugin & extension system.

--- a/docs/agentic-workflow/issue-proposals/v0.3.0-zero-config-auth.md
+++ b/docs/agentic-workflow/issue-proposals/v0.3.0-zero-config-auth.md
@@ -1,0 +1,39 @@
+# v0.3.0 — Zero-Config & Auth: Issue Proposals
+
+## Epic 2.5.1: Wire Authentication End-to-End (7 issues)
+
+### Core & Models
+1. **feat(auth): ensure User/Group/Permission models are auto-registered to admin** — Export and register auth models with AdminOptions (no delete for User, list_filter on is_active/is_superuser)
+2. **feat(auth): verify SessionAuthBackend protocol compliance** — Ensure SessionAuthBackend fully implements AuthBackend & CurrentUserProvider protocols with async/await
+
+### Auth Logic
+3. **feat(auth): wire AuthenticationMiddleware to admin routes globally** — Redirect unauthenticated requests to login, allow /login & /static, populate request.state.user
+4. **feat(auth): complete session-based login/logout flow** — POST /login validates credentials, stores user_id in session; POST /logout clears session
+5. **feat(auth): wire PermissionChecker to all CRUD view endpoints** — Decorate list/create/detail/edit/delete routes to check permissions, return 403 if denied
+6. **feat(auth): createsuperuser CLI command** — Typer command with --username/--email/--password prompts, Argon2 hashing, unique constraint validation
+
+### E2E
+7. **test(e2e): login -> view protected model -> logout flow** — Playwright test verifies auth middleware -> login -> CRUD access -> logout -> redirect to login
+
+---
+
+## Epic 3.1: Zero-Config Admin (11 issues)
+
+### Core Models & Adapters
+1. **feat(core): model introspection utility for field metadata** — New `core/introspection.py` extracting type, nullable, FK, M2M, choices, length from SQLModel/SQLAlchemy
+2. **feat(core): smart defaults — infer list_display from model structure** — Auto-select 3-5 important fields (id, name/title, email, created_at, status) via heuristics
+3. **feat(core): smart defaults — infer search_fields from model structure** — Auto-include String/Email/Text fields, skip FK/M2M/binary
+4. **feat(core): smart defaults — infer list_filter from model structure** — Auto-include Boolean, Enum, ForeignKey fields; skip unindexed text
+
+### Registry & Discovery
+5. **feat(core): auto-discovery — scan SQLModel metadata for registered models** — `discover_sqlmodel_models()` walks SQLModel registry, returns model classes
+6. **feat(core): auto-register discovered models with smart defaults** — Integration in `Admin.__init__()`: discovery -> AdminOptions generation -> site.register()
+7. **feat(core): add auto_discover parameter to Admin()** — `auto_discover: bool = True`; when False, only explicit registrations used
+
+### Options & Configuration
+8. **feat(core): extend AdminOptions to support None for smart defaults** — `list_display=None` triggers smart defaults; explicit `[]` skips feature
+9. **test: 3-line zero-config demo verification** — Example: `admin = Admin(app, engine=engine); admin.mount("/admin")` with verify CRUD works
+
+### Views & Templates
+10. **feat(views): display inferred field labels in list/detail views** — Auto-generate from field name (e.g., "user_id" -> "User")
+11. **test(e2e): zero-config auto-discovery with mixed models** — 3 models (FK, Enum, relationships), mount without registration, verify all appear with CRUD

--- a/docs/agentic-workflow/issue-proposals/v0.3.1-file-uploads.md
+++ b/docs/agentic-workflow/issue-proposals/v0.3.1-file-uploads.md
@@ -1,0 +1,40 @@
+# v0.3.1 — File Uploads: Issue Proposals
+
+## Epic 3.2: File Upload System (23 issues)
+
+### Phase 1: Storage Backend Protocol
+1. **feat(uploads): define StorageBackend protocol** — Abstract protocol with async save/delete/get_url/exists methods for pluggable backends
+2. **feat(uploads): implement LocalFileSystemStorage** — UUID-based filenames, organized subdirectories per model, FastAPI static serving
+3. **feat(uploads): implement S3-compatible storage backend** — S3Storage using fastapi-storages for S3/Minio/DigitalOcean with pre-signed URLs
+4. **feat(core): wire storage configuration into Admin** — Add `storage` parameter to Admin(), default LocalFileSystemStorage, DI for views/adapters
+
+### Phase 2: Field Types and Validation
+5. **feat(uploads): create FileField and ImageField types** — Pydantic-compatible FileFieldInfo/ImageFieldInfo with size/MIME/extension validation
+6. **feat(core): integrate file field detection into widget selection** — Extend classify_field() for FileFieldInfo/ImageFieldInfo, hint _pick_widget()
+7. **feat(uploads): add file validation and processing** — validate_uploaded_file() checking size/MIME/extension, image dimension validation
+
+### Phase 3: Widget Templates and Endpoints
+8. **feat(views): create FileInputWidget** — HtmxWidget with `<input type="file">`, label/help/errors, ARIA labels
+9. **feat(views): create ImagePreviewWidget with drag-and-drop** — Alpine.js drag-drop zone, preview display, HTMX async preview
+10. **feat(views): implement file upload endpoint** — POST /admin/{model}/upload parsing multipart, validate, store, return JSON metadata
+11. **feat(views): implement file deletion/replacement** — DELETE endpoint, atomic replace, orphaned file cleanup
+
+### Phase 4: Thumbnail Generation
+12. **feat(uploads): add thumbnail generation helper** — Pillow-based resize with aspect ratio, cache in .thumbs/, support local+S3
+13. **feat(views): integrate thumbnails into image preview** — Display thumbnail in widget, async generation, HTMX preview reload
+14. **feat(uploads): add image metadata extraction** — EXIF data (dimensions, camera, orientation), auto-rotate support
+
+### Phase 5: CRUD Form Integration
+15. **feat(views): wire file upload to create/edit forms** — PydanticForm file multipart handling, edit replacement, required validation
+16. **feat(adapters): add file cleanup on model deletion** — Hook adapter.delete() to clean storage files, handle cascades
+17. **feat(views): support file fields in list/detail views** — File icon + filename in list, thumbnail for images, download link in detail
+
+### Phase 6: UX Polish
+18. **feat(ui): enhance drag-and-drop UX** — Visual feedback, prevent defaults, keyboard shortcuts, multi-file prep
+19. **feat(ui): add upload progress indication** — Progress bar with bytes sent/total, estimated time remaining
+20. **feat(ui): add error recovery and retry logic** — Retry button, error messages, toast notifications
+
+### Phase 7: Testing & Documentation
+21. **test: unit tests for storage backends and fields** — LocalFileSystemStorage, S3Storage, FileFieldInfo, ImageFieldInfo >95% coverage
+22. **test(e2e): file upload workflows** — Create with file, preview, download, delete, image thumbnail, permissions
+23. **docs: file upload API reference and usage guide** — FileField, ImageField, StorageBackend, S3 setup, examples

--- a/docs/agentic-workflow/issue-proposals/v0.4.0-i18n-responsive.md
+++ b/docs/agentic-workflow/issue-proposals/v0.4.0-i18n-responsive.md
@@ -1,0 +1,52 @@
+# v0.4.0 — i18n & Responsive: Issue Proposals
+
+## Epic 4.4: Internationalization (19 issues)
+
+### Phase 1: i18n Core Infrastructure
+1. **feat(core): add i18n module with gettext wrapper** — `_()`, `ngettext()` functions, locale discovery, fallback chain
+2. **chore: set up locale directory structure and message catalog infrastructure** — locale/ directory, .pot template, .po format for 7 locales
+3. **feat(core): integrate Babel message extraction pipeline** — Extract from Jinja2 templates, `poe extract-messages` task
+4. **feat(core): add locale parameter to Admin class** — `Admin(locale="en")`, validate against available translations, wire into Jinja2 globals
+
+### Phase 2: String Extraction
+5. **refactor(templates): wrap base template strings with _()** — _base.html, _navbar.html, _sidebar.html, _messages.html
+6. **refactor(templates): wrap layout template strings with _()** — list_layout, detail_layout, form_layout, create, update
+7. **refactor(templates): wrap component template strings with _()** — table, pagination, search_input, filter_bar, alert, button, fieldset
+8. **refactor(templates): wrap widget template strings with _()** — All input widget templates
+9. **refactor(templates): wrap auth/login template strings with _()** — Login page labels and error messages
+
+### Phase 3: Message Catalogs (7 locales)
+10. **feat(i18n): create English (.po) message catalog** — Generate .pot, verify ~80+ strings extracted
+11. **feat(i18n): Spanish (es) translations** — Translate all strings, compile .mo
+12. **feat(i18n): French (fr) translations** — Translate all strings, compile .mo
+13. **feat(i18n): German (de) translations** — Translate all strings, compile .mo
+14. **feat(i18n): Chinese Simplified (zh_CN) translations** — Translate all strings, compile .mo
+15. **feat(i18n): Japanese (ja) translations** — Translate all strings, compile .mo
+16. **feat(i18n): Ukrainian (uk) translations** — Translate all strings, compile .mo
+
+### Phase 4: RTL Support
+17. **feat(ui): implement RTL layout support in CSS** — `[dir="rtl"]` rules for sidebar, navbar, tables, forms
+18. **feat(core): add RTL-aware locale metadata and admin configuration** — Auto-detect RTL from locale, set html[dir="rtl"]
+
+### Phase 5: Optional Polish
+19. **feat(ui): implement locale switcher UI** — Navbar dropdown, session preference storage
+
+---
+
+## Epic 4.3: Responsive Design Overhaul (10 issues)
+
+### Phase 1: CSS & Grid
+20. **refactor(ui): mobile-first responsive CSS architecture** — Reorganize to mobile-first, add sm/md/lg/xl breakpoints, .ha-grid utilities
+21. **feat(ui): collapsible sidebar with Alpine.js toggle** — Hamburger button, slide-in/slide-out animation, z-index management
+22. **feat(ui): swipe gesture support for sidebar** — Touch event detection, left/right swipe open/close
+
+### Phase 2: Component Responsiveness
+23. **feat(ui): responsive data table card layout** — Stacked card UI below 768px, inline column labels, touch-friendly actions
+24. **feat(ui): touch-friendly form controls** — Min 44px height, increased padding, single column stack
+25. **feat(ui): optimize pagination and filter UI for mobile** — Vertical stacking, icon-only mode, full-width filter toggles
+26. **feat(ui): responsive navbar collapse** — Collapsible groups, icon-only brand on small screens
+
+### Phase 3: Testing & Docs
+27. **test(e2e): i18n locale switching and rendering** — Test es/uk locales, fallback, validation
+28. **test(e2e): responsive design on mobile viewport** — Sidebar hamburger, swipe, card layout, tap targets
+29. **docs: i18n developer guide and translation workflow** — Message extraction, compilation, adding locales, contributor guide

--- a/docs/agentic-workflow/issue-proposals/v0.5.1-audit-rls.md
+++ b/docs/agentic-workflow/issue-proposals/v0.5.1-audit-rls.md
@@ -1,0 +1,53 @@
+# v0.5.1 — Audit & Row-Level Security: Issue Proposals
+
+## Epic 5.1: Audit / Activity Log (12 issues)
+
+### Phase 1: Core Models & Infrastructure
+1. **feat(audit): create AuditLog model with JSON diff storage** — SQLModel table tracking user_id, model_name, object_id, action, timestamp, old/new values, diff JSON
+2. **feat(core): add audit configuration to AdminOptions** — `enable_audit: bool = True` per-model toggle
+3. **feat(audit): create AuditService class** — `record_operation(user, model_name, object_id, action, old_obj, new_obj)` with JSON diff computation
+
+### Phase 2: Adapter Integration
+4. **feat(adapters): wire AuditService into SQLModelAdapter.create()** — Record "create" operation with new_obj
+5. **feat(adapters): wire AuditService into SQLModelAdapter.update()** — Fetch old_obj before update, record field-level diffs
+6. **feat(adapters): wire AuditService into SQLModelAdapter.delete()** — Fetch object before delete, record "delete" operation
+
+### Phase 3: View Integration
+7. **feat(views): pass audit_service through DynamicModelView** — Add audit_service parameter, pass to adapter
+8. **feat(views): wire request.state.user into audit calls** — Extract user from request, pass to adapter for audit recording
+
+### Phase 4: UI & Retrieval
+9. **feat(views): create AuditLog list view (timeline)** — GET /admin/{model}/{id}/audit-trail endpoint, paginated, ordered by created_at DESC
+10. **feat(ui): create audit trail timeline template** — Per-change: user, action icon, timestamp, collapsible diff
+11. **feat(ui): add audit trail link to detail view** — "View Audit Trail" button, conditionally shown if audit enabled
+12. **feat(views): create audit trail accessor for filtering** — `get_audit_trail(model_name, object_id)` with pagination
+
+---
+
+## Epic 5.2: Row-Level Security & Multi-Tenancy (16 issues)
+
+### Phase 1: Permission Predicates
+1. **feat(auth): create ObjectPermission protocol** — `has_object_permission(user, obj, action) -> bool` with default implementations
+2. **feat(core): add object_permission_checker to AdminOptions** — ObjectPermissionChecker protocol field
+3. **feat(auth): extend ModelPermissionChecker with object-level checks** — Fallback to model-level if no object checker
+
+### Phase 2: Adapter Query Filtering
+4. **feat(adapters): add get_queryset hook to BaseAdapter** — `apply_queryset_filter(session, query, request, action)` abstract method
+5. **feat(adapters): implement get_queryset in SQLModelAdapter** — Call ModelAdmin.get_queryset(request), return filtered select()
+6. **feat(core): add get_queryset hook to ModelAdmin base** — Optional method, default unfiltered, override for tenant/user filtering
+
+### Phase 3: View-Level Permission Checks
+7. **feat(views): enhance detail_view with object-level permission check** — 403 if denied after fetching object
+8. **feat(views): enhance update_view with object-level permission check** — 403 before rendering form
+9. **feat(views): enhance delete_action with object-level permission check** — 403 before deletion
+10. **feat(views): add object permission check helper** — `_check_object_permission(request, obj, action)` method
+
+### Phase 4: Multi-Tenancy
+11. **feat(adapters): create TenantAwareAdapter mixin** — Extract tenant_id from request, filter all queries
+12. **docs: multi-tenant usage patterns** — Example overriding get_queryset for tenant filtering
+
+### Phase 5: Testing
+13. **test: unit tests for object permission checking** — Protocol implementations, superuser bypass
+14. **test: unit tests for get_queryset filtering** — Mock request with state.user, verify adapter filters
+15. **test(e2e): row-level security enforcement** — Two users, verify one cannot access other's records (403)
+16. **test(e2e): multi-tenant filtering** — Two tenants, verify list isolation

--- a/docs/agentic-workflow/issue-proposals/v0.5.2-sso-dashboard.md
+++ b/docs/agentic-workflow/issue-proposals/v0.5.2-sso-dashboard.md
@@ -1,0 +1,71 @@
+# v0.5.2 — SSO & Dashboard: Issue Proposals
+
+## Epic 5.3: SSO & OAuth2 Authentication (17 issues)
+
+### Phase 1: Auth Backend Protocol & MFA Foundation
+1. **feat(auth): create pluggable AuthBackend protocol** — Standard interface for authenticate/login/logout/get_current_user, SSO provisioning hooks
+2. **feat(auth): create MFA TOTP support module** — TOTPProvider using pyotp, mfa_enabled/mfa_secret User fields, backup codes
+3. **feat(auth): add OAuth/SSO models** — OAuthToken table (provider, tokens, scopes), SAMLSession table, SSOProvider enum
+4. **feat(auth): create structured auth exceptions** — AuthenticationError, OAuthProviderError, SAMLValidationError, MFARequiredError
+
+### Phase 2: OAuth2 & OpenID Connect
+5. **feat(auth): create OAuth2/OIDC backend** — Google, GitHub, Azure AD support, token exchange, user provisioning
+6. **feat(auth): add OAuth2 routes** — /oauth/authorize/{provider}, /oauth/callback/{provider}, /oauth/refresh
+7. **feat(auth): create OAuth provider configuration** — OAuthProviderConfig dataclass, env var loading, validation
+
+### Phase 3: SAML2
+8. **feat(auth): create SAML2 backend** — python-saml integration, assertion validation, attribute mapping
+9. **feat(auth): add SAML metadata and ACS endpoints** — /saml/metadata, /saml/acs, /saml/sls
+10. **feat(auth): create SAML configuration** — SAML2Config dataclass, IdP metadata download, certificate handling
+
+### Phase 4: MFA Integration
+11. **feat(auth): wire MFA challenge into login flow** — Check mfa_enabled, redirect to challenge, temp auth state
+12. **feat(auth): create MFA challenge endpoint and template** — TOTP code input, backup code fallback
+13. **feat(auth): add MFA management settings view** — Enable/disable MFA, QR code setup, backup codes display
+14. **test: migration tests for auth model schema changes** — OAuthToken, SAMLSession, User MFA fields
+
+### Phase 5: Session & Logout
+15. **feat(auth): implement OAuth token refresh middleware** — Auto-refresh expired tokens, logout on refresh failure
+16. **feat(auth): add provider-specific logout support** — OAuth provider logout, SAML LogoutRequest
+17. **feat(auth): create session revocation endpoints** — Revoke all sessions, delete tokens, clear sessions
+
+---
+
+## Epic 5.4: Dashboard Builder (23 issues)
+
+### Phase 1: Models & Protocols
+18. **feat(dashboard): create dashboard data models** — DashboardLayout (user, name, default), WidgetConfig (type, position, config JSON, size)
+19. **feat(dashboard): create widget protocol** — DashboardWidget protocol with type, title, render_data(), multiple layout types
+20. **feat(dashboard): create built-in widget implementations** — CountWidget, ChartWidget, RecentItemsWidget, QuickActionsWidget, DataTableWidget
+
+### Phase 2: Adapter Helpers
+21. **feat(adapters): extend with aggregation/analytics methods** — aggregate(group_by, metric, filters), func.count/sum/avg/date_trunc
+22. **feat(dashboard): create high-level aggregation helpers** — count_by_date, sum_by_category, top_records with caching
+
+### Phase 3: Service & Routes
+23. **feat(dashboard): create dashboard service** — Load layout + widgets, render data in parallel, error handling per widget
+24. **feat(dashboard): create dashboard exceptions** — DashboardNotFoundError, WidgetRenderError, InvalidWidgetConfigError
+25. **feat(views): create dashboard view handler** — Render dashboard with widget data, error cards for failed widgets
+
+### Phase 4: Routes
+26. **feat(views): add dashboard routes** — GET /admin/ (dashboard), GET /admin/dashboard/{id}, POST /save-order
+27. **feat(views): create dashboard management endpoints** — Create/rename/delete layouts, list layouts
+
+### Phase 5: Templates & UI
+28. **feat(ui): create dashboard template** — Widget card grid, type-specific content, size classes, empty state
+29. **feat(ui): create dashboard widget card component** — Reusable card with title, content slot, loading/error states
+30. **feat(ui): create dashboard builder template** — Model picker, widget type config, filter setup, save button
+31. **feat(ui): add Sortable.js drag-drop widget reordering** — HTMX on-drop save position, WidgetConfig.position update
+32. **feat(ui): create dashboard.js interactions** — Drag-drop, loading spinners, HTMX event handlers
+
+### Phase 6: Configuration
+33. **feat(core): add dashboard config to Admin class** — dashboard_enabled, default_widgets parameters
+34. **feat(dashboard): create widget plugin registry** — register_widget/get_widget_class for third-party plugins
+35. **feat(core): add ModelAdmin dashboard hooks** — dashboard_widgets, dashboard_filters per model
+
+### Phase 7: Testing & Docs
+36. **test(e2e): dashboard E2E test suite** — Load, widget render, drag-drop, add/remove, chart, error handling
+37. **test: dashboard service unit tests** — Mock adapters, concurrency, cache, error isolation
+38. **test: dashboard integration tests** — Real DB adapter, live data, aggregation queries
+39. **docs: dashboard builder guide** — Overview, tutorial, plugin guide, configuration reference
+40. **docs: dashboard widgets reference** — Built-in widget docs, config options, examples

--- a/docs/agentic-workflow/issue-proposals/v0.8.0-plugins-ai.md
+++ b/docs/agentic-workflow/issue-proposals/v0.8.0-plugins-ai.md
@@ -1,0 +1,46 @@
+# v0.8.0 — Plugins & AI: Issue Proposals
+
+## Epic 6.1: Plugin & Extension System (7 issues)
+
+### Phase 1: Plugin Protocol & Hooks
+1. **feat(plugins): define plugin protocol and entry point discovery** — HyperAdminPlugin ABC, importlib.metadata entry point loading from `hyperadmin.plugins`
+2. **feat(plugins): implement core plugin lifecycle hooks** — on_startup, on_shutdown, on_plugin_load with async hook registry and dispatch
+3. **feat(plugins): create plugin registry and manager** — PluginRegistry class for loaded plugins, version validation, dependency tracking, conflict detection
+4. **feat(plugins): add model registration lifecycle hooks** — on_model_register, on_before_create_form, on_after_delete integrated with core/registry.py
+5. **feat(plugins): add admin mount and route hooks** — on_admin_mount, on_routes_generate, on_middleware_add for plugin route/middleware injection
+6. **feat(plugins): create PluginContext API** — PluginContext dataclass (engine, templates, site registry, request context) for safe admin access
+7. **test: plugin protocol, registry, and hook dispatch unit tests** — 95%+ coverage for loading, hook execution, error handling
+
+---
+
+## Epic 6.5: Additional ORM Adapters (8 issues)
+
+### Phase 2: Adapter Protocol & Implementations
+8. **docs(adapters): audit and document BaseAdapter protocol** — Comprehensive docstrings, type hints, filter/search/ordering contract
+9. **feat(adapters): implement Tortoise ORM adapter** — BaseAdapter for Tortoise models, pagination, search, filtering, M2M loading
+10. **feat(adapters): implement Piccolo ORM adapter** — BaseAdapter for Piccolo models, async query building, eager loading
+11. **feat(adapters): implement MongoDB adapter (Motor/Beanie)** — ObjectId PK conversion, document serialization, aggregation pipeline
+12. **feat(adapters): implement generic REST API adapter** — External REST API data source, GET/POST/PUT/DELETE, auth headers, pagination
+13. **feat(adapters): extend adapter registry for auto-detection** — Detect installed ORM packages, auto-register adapters
+14. **test: integration tests for all new ORM adapters** — CRUD fixtures for Tortoise, Piccolo, MongoDB, REST
+15. **docs: ORM adapter configuration guide** — Setup instructions, examples, migration guide per adapter
+
+---
+
+## Epic 6.6: Custom Pages & Views (4 issues)
+
+### Phase 3: Custom Page Registration
+16. **feat(views): create custom page registry and @custom_page decorator** — CustomPageRegistry for non-CRUD pages with admin nav integration
+17. **feat(views): integrate custom pages into admin routing** — Custom page routes in routing.py, template globals for nav rendering
+18. **feat(views): add iframe and component embedding support** — Component protocol for external tools (Grafana, Metabase), auth token injection
+19. **test: custom page integration tests and documentation** — E2E page registration, nav rendering, embedding; usage guide
+
+---
+
+## Epic 6.3: AI-Powered Features (4 issues)
+
+### Phase 4: AI Integration
+20. **feat(core): add search_fields to AdminOptions and adapter contract** — search_fields list, BaseAdapter.list() respects it, dynamic field search
+21. **feat(ai): implement LLM provider abstraction and NL search** — LLM protocol (OpenAI, Anthropic, local), NL query -> filter DSL conversion
+22. **feat(ai): implement AI-assisted form filling and anomaly detection** — Form field auto-fill from context, anomaly detection for dashboard widgets
+23. **docs: AI features configuration and examples** — LLM setup, NL search examples, graceful degradation without API keys

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-HyperAdmin (v0.1.0) is a Pydantic-native, async-first admin interface for FastAPI powered by HTMX. Phase 2 is ~90% complete with full CRUD, dynamic forms (12+ widgets), FK/M2M relationships, filtering, sorting, search, pagination, and partial auth. The goal: transform HyperAdmin into **the best, fastest, and most accessible Python auto-generated admin panel** — the framework developers choose *over* Django Admin, SQLAdmin, and Flask-Admin.
+HyperAdmin is a Pydantic-native, async-first admin interface for FastAPI powered by HTMX. Phase 2 is complete with full CRUD, dynamic forms (12+ widgets), FK/M2M relationships, custom actions, fieldsets, filtering, sorting, search, pagination, WCAG 2.1 AA accessibility, and theming. The goal: transform HyperAdmin into **the best, fastest, and most accessible Python auto-generated admin panel** — the framework developers choose *over* Django Admin, SQLAdmin, and Flask-Admin.
 
 **Competitors to beat:**
 | Feature | Django Admin | SQLAdmin | Flask-Admin | HyperAdmin (today) |
@@ -11,7 +11,7 @@ HyperAdmin (v0.1.0) is a Pydantic-native, async-first admin interface for FastAP
 | Pydantic-native | No | Minimal | No | **Yes** |
 | Zero-config | Moderate | Good | Moderate | Good |
 | i18n | Excellent | None | Some | None |
-| Accessibility | Basic | Basic | Basic | Partial (ARIA) |
+| Accessibility | Basic | Basic | Basic | **WCAG 2.1 AA** |
 | Plugin ecosystem | Mature | None | Moderate | None |
 | Real-time | No | No | No | No |
 
@@ -19,8 +19,9 @@ HyperAdmin (v0.1.0) is a Pydantic-native, async-first admin interface for FastAP
 
 ---
 
-## Phase 2.5 — "Ship It" (v0.2.0)
+## v0.2.0 — "Ship It"
 **Theme: Complete the foundation, make it installable and usable by real developers**
+**Milestone: Phase 2: Core Feature Parity (CLOSED) + v0.2.1**
 
 ### Epic 2.5.1: Wire Authentication End-to-End
 Auth models exist but aren't fully connected to endpoints.
@@ -28,38 +29,42 @@ Auth models exist but aren't fully connected to endpoints.
 - Complete session-based login/logout flow with tests
 - Wire `PermissionChecker` to view-level enforcement (403 on denied)
 - `createsuperuser` CLI command verified working
-- E2E test: login → CRUD → logout flow
+- E2E test: login -> CRUD -> logout flow
 
+**Status:** Partial — Phase 1 auth epic (#77) closed, E2E wiring still needed
 **Files:** `auth/middleware.py`, `auth/views.py`, `auth/session.py`, `auth/permissions.py`, `core/app.py`
 
 ### Epic 2.5.2: Configurable Search
-Search is hardcoded to `name` and `email` fields.
-- Add `search_fields` to `ModelAdmin` / `AdminOptions`
-- Adapter: build dynamic search across configured fields
-- Support partial match (ILIKE) and exact match modes
+~~Search is hardcoded to `name` and `email` fields.~~
+- ~~Add `search_fields` to `ModelAdmin` / `AdminOptions`~~
+- ~~Adapter: build dynamic search across configured fields~~
+- ~~Support partial match (ILIKE) and exact match modes~~
 
-**Files:** `core/options.py`, `adapters/sqlmodel.py`, `adapters/sqlalchemy.py`, `views/dynamic.py`
+**Status: DONE** — `search_fields` implemented in `AdminOptions`, adapter supports dynamic ILIKE search.
 
 ### Epic 2.5.3: Documentation & Examples
-- Complete "Getting Started" tutorial (install → 3-line admin → customize)
+- Complete "Getting Started" tutorial (install -> 3-line admin -> customize)
 - API reference for `Admin`, `ModelAdmin`, `AdminOptions`, `BaseAdapter`
 - Finalize ERP example as a complete runnable demo
 - Add screenshot/GIF to README
 
+**Status:** In progress under **v0.2.1 — Developer Experience & Examples** milestone (#172, #192–#196)
 **Files:** `docs/`, `examples/`, `README.md`
 
 ### Epic 2.5.4: Polish & Bug Fixes
-- Form validation error display (field-level + non-field errors)
-- Confirmation dialogs for delete actions
+- ~~Form validation error display (field-level + non-field errors)~~
+- ~~Confirmation dialogs for delete actions~~
 - Flash messages / toast notifications for success/error feedback
 - Mobile-responsive sidebar (hamburger menu)
 
+**Status:** Partial — validation errors and delete confirmation done. Flash messages and responsive sidebar remain.
 **Files:** `templates/components/`, `templates/widgets/`, `static/hyperadmin.css`
 
 ---
 
-## Phase 3 — "Developer Love" (v0.3.0)
+## v0.3.0 — "Developer Love"
 **Theme: Make developers productive in minutes, not hours**
+**Milestone: v0.3.0 — Zero-Config & Auth**
 
 ### Epic 3.1: Zero-Config Admin (3 Lines of Code)
 The killer feature — beat every competitor on setup speed:
@@ -72,6 +77,7 @@ admin.mount("/admin")  # auto-discovers all SQLModel models
 - Smart defaults: infer `list_display`, `search_fields`, `list_filter` from model fields
 - Convention-over-configuration: sensible defaults that work 90% of the time
 
+**Status:** Not started
 **Files:** `discover.py`, `core/registry.py`, `core/model.py`, `core/options.py`
 
 ### Epic 3.2: File Upload System
@@ -80,22 +86,25 @@ admin.mount("/admin")  # auto-discovers all SQLModel models
 - Image preview widget with drag-and-drop
 - Thumbnail generation for image fields (Pillow already a dependency)
 
+**Status:** Not started
+**Milestone: v0.3.1 — File Uploads**
 **Files:** `uploads/storage.py`, `uploads/fields.py`, `views/forms.py`, `templates/widgets/file_input.html`
 
 ### Epic 3.3: Custom Model Actions
-- `actions/` module: register custom actions per model
-- Bulk actions on list view (select rows → action dropdown)
-- Single-object actions on detail view
-- Built-in actions: export selected, delete selected
-- Action confirmation dialogs via HTMX
+- ~~`actions/` module: register custom actions per model~~
+- ~~Bulk actions on list view (select rows -> action dropdown)~~
+- ~~Single-object actions on detail view~~
+- ~~Built-in actions: export selected, delete selected~~
+- ~~Action confirmation dialogs via HTMX~~
 
-**Files:** `actions/registry.py`, `actions/builtin.py`, `views/dynamic.py`, `templates/components/action_bar.html`
+**Status: DONE** — `ActionDef`, `@action` decorator, POST endpoint, E2E tests all complete (#41, #184–#187 closed).
 
 ### Epic 3.4: Export / Import
 - CSV and JSON export from list view (respects current filters)
 - CSV/JSON import with validation preview
 - Background processing for large datasets (async task)
 
+**Status:** Not started
 **Files:** `actions/export.py`, `actions/import_data.py`, `templates/components/export_bar.html`
 
 ### Epic 3.5: Advanced Filtering
@@ -105,33 +114,35 @@ admin.mount("/admin")  # auto-discovers all SQLModel models
 - "Save filter" presets per user
 - Filter builder UI (AND/OR conditions)
 
+**Status:** Not started
 **Files:** `core/filters.py`, `views/dynamic.py`, `templates/components/filter_bar.html`
 
 ---
 
-## Phase 4 — "Accessible & Beautiful" (v0.4.0)
+## v0.4.0 — "Accessible & Beautiful"
 **Theme: WCAG 2.1 AA compliance + modern design system — become THE most accessible admin**
+**Milestone: v0.4.0 — i18n & Responsive**
 
 ### Epic 4.1: WCAG 2.1 AA Accessibility Audit & Fix
 No Python admin panel currently claims WCAG compliance — this is a unique differentiator.
-- Full keyboard navigation (Tab, Enter, Escape, Arrow keys)
-- Skip-to-content links
-- Focus management on HTMX swaps (focus trap in modals, restore after swap)
-- `aria-live` regions for all dynamic content updates
-- Color contrast ratios ≥ 4.5:1 for text, ≥ 3:1 for large text
-- Form error announcements for screen readers
-- Automated a11y testing with axe-core in Playwright E2E suite
+- ~~Full keyboard navigation (Tab, Enter, Escape, Arrow keys)~~
+- ~~Skip-to-content links~~
+- ~~Focus management on HTMX swaps (focus trap in modals, restore after swap)~~
+- ~~`aria-live` regions for all dynamic content updates~~
+- ~~Color contrast ratios >= 4.5:1 for text, >= 3:1 for large text~~
+- ~~Form error announcements for screen readers~~
+- ~~Automated a11y testing with axe-core in Playwright E2E suite~~
 
-**Files:** All templates, `static/hyperadmin.css`, `tests/e2e/`
+**Status: DONE** — #72 closed. WCAG 2.1 AA improvements shipped.
 
 ### Epic 4.2: Theme System & Dark Mode
-- CSS custom properties (variables) for all colors, spacing, typography
-- Light/dark mode toggle with system preference detection
-- `prefers-reduced-motion` support
-- Theme configuration via `Admin(theme="dark")` or `Admin(theme=CustomTheme(...))`
-- High-contrast mode for accessibility
+- ~~CSS custom properties (variables) for all colors, spacing, typography~~
+- ~~Light/dark mode toggle with system preference detection~~
+- ~~`prefers-reduced-motion` support~~
+- ~~Theme configuration via `Admin(theme="dark")` or `Admin(theme=CustomTheme(...))`~~
+- ~~High-contrast mode for accessibility~~
 
-**Files:** `static/hyperadmin.css`, `templates/base.html`, `core/app.py`, `core/theme.py`
+**Status: DONE** — #73 closed. Theme system with dark mode shipped.
 
 ### Epic 4.3: Responsive Design Overhaul
 - Mobile-first responsive grid system
@@ -139,6 +150,7 @@ No Python admin panel currently claims WCAG compliance — this is a unique diff
 - Responsive data tables (card layout on small screens)
 - Touch-friendly action buttons and form controls
 
+**Status:** Not started
 **Files:** `static/hyperadmin.css`, `templates/components/`, `templates/base.html`
 
 ### Epic 4.4: Internationalization (i18n)
@@ -150,11 +162,12 @@ Django Admin's i18n is excellent — match and exceed it.
 - `Admin(locale="uk")` configuration
 - Community contribution workflow for new translations
 
+**Status:** Not started
 **Files:** `core/i18n.py`, `locale/`, all templates (wrap strings in `_()`)
 
 ---
 
-## Phase 5 — "Enterprise Ready" (v0.5.0)
+## v0.5.0 — "Enterprise Ready"
 **Theme: Features that make HyperAdmin viable for production enterprise apps**
 
 ### Epic 5.1: Audit / Activity Log
@@ -163,6 +176,8 @@ Django Admin's i18n is excellent — match and exceed it.
 - Audit trail view per object (timeline UI)
 - Configurable: enable/disable per model via `AdminOptions`
 
+**Status:** Not started
+**Milestone: v0.5.1 — Audit & Row-Level Security**
 **Files:** `audit/models.py`, `audit/middleware.py`, `adapters/sqlmodel.py`, `templates/components/audit_trail.html`
 
 ### Epic 5.2: Row-Level Security & Multi-Tenancy
@@ -171,6 +186,8 @@ Django Admin's i18n is excellent — match and exceed it.
 - Tenant-aware adapter filtering (multi-tenant SaaS support)
 - Permission predicates: `has_object_permission(request, obj, action)`
 
+**Status:** Not started
+**Milestone: v0.5.1 — Audit & Row-Level Security**
 **Files:** `auth/permissions.py`, `core/model.py`, `adapters/sqlmodel.py`
 
 ### Epic 5.3: SSO & OAuth2 Authentication
@@ -179,6 +196,8 @@ Django Admin's i18n is excellent — match and exceed it.
 - Pluggable auth backend protocol (already exists, extend it)
 - MFA support (TOTP via `pyotp`)
 
+**Status:** Not started
+**Milestone: v0.5.2 — SSO & Dashboard**
 **Files:** `auth/oauth.py`, `auth/saml.py`, `auth/mfa.py`, `auth/backend.py`
 
 ### Epic 5.4: Dashboard Builder
@@ -188,19 +207,102 @@ Django Admin's i18n is excellent — match and exceed it.
 - Widget protocol for custom dashboard widgets
 - Data aggregation helpers in adapters
 
+**Status:** Not started
+**Milestone: v0.5.2 — SSO & Dashboard**
 **Files:** `dashboard/widgets.py`, `dashboard/layout.py`, `templates/dashboard.html`, `views/dashboard.py`
 
 ### Epic 5.5: Inline Editing & Related Object Management
 - Inline formsets for related objects (edit child objects on parent form)
-- Inline table editing (click cell → edit in place → save via HTMX)
+- Inline table editing (click cell -> edit in place -> save via HTMX)
 - Nested relationship creation (create related object from FK dropdown)
 
+**Status:** Not started — #68 (inline models) open under v0.2.1
 **Files:** `views/forms.py`, `views/dynamic.py`, `templates/components/inline_formset.html`
+
+### Epic: UI/UX Polish
+- ~~Improve the visual design of the admin interface~~
+- ~~Add support for themes~~
+- ~~Improve the accessibility of the admin interface~~
+- Remaining polish items (Epic 2.4, #45)
+
+**Status:** Mostly done — #72, #73, #74 closed. #45 open for remaining polish.
+**Milestone: v0.5.0 — Advanced UX**
 
 ---
 
-## Phase 6 — "The Future" (v1.0.0)
-**Theme: AI-powered, real-time, extensible — the admin panel of 2027**
+## v0.6.0 — "Real-Time Layer"
+**Theme: WebSocket infrastructure and live CRUD notifications**
+**Milestone: v0.6.0 — Real-Time Layer (23 issues)**
+
+### Epic 6.2.1: WebSocket Infrastructure & PubSub Backends (#330)
+- WebSocket endpoint and connection manager
+- PubSub protocol with InMemory and Redis backends
+- Channel-based message routing
+
+### Epic 6.2.2: Real-Time Notifications (#331)
+- CRUD event broadcasting via HTMX `hx-ws`
+- Live updates: new/updated/deleted rows appear without refresh
+- Real-time dashboard widgets
+
+### Epic 6.2.3: Optimistic Concurrency Control (#332)
+- Version-based conflict detection
+- Conflict resolution dialog
+
+**Status:** Not started — 23 issues planned, 0 closed
+
+---
+
+## v0.6.1 — "Presence"
+**Theme: Who is viewing/editing which record**
+**Milestone: v0.6.1 — Presence (9 issues)**
+
+### Epic 6.2.4: Presence Tracking (#333)
+- InMemoryPresence + RedisPresence backends
+- Heartbeat-based with TTL expiry
+- Banner on edit forms showing other editors
+- Collaborative editing indicators
+
+**Status:** Not started — 9 issues planned, 0 closed
+
+---
+
+## v0.7.0 — "High-Volume & High-Load Scalability"
+**Theme: Make HyperAdmin work with 10M+ records and 100 req/s**
+**Milestone: v0.7.0 — High-Volume & High-Load Scalability (34 issues)**
+
+### Epic: Adapter Query Performance (#211)
+- `selectinload` optimization, cursor-based pagination, count estimation, full-text search
+
+### Epic: Engine & Connection Management (#212)
+- Pool tuning, rate limiting, connection lifecycle
+
+### Epic: Filter & Choice Scalability (#213)
+- FK preload threshold, filter cache, lazy loading
+
+### Epic: E2E Scalability Validation & Documentation (#214)
+- Benchmark suite, performance regression CI, documentation
+
+**Status:** Not started — 34 issues planned, 0 closed
+
+---
+
+## v0.7.1 — "Load Testing & Synthetic Data"
+**Theme: Prove scalability with real benchmarks**
+**Milestone: v0.7.1 — Load Testing & Synthetic Data (20 issues)**
+
+### Epic: Synthetic Data Generator (#246)
+- Faker + SQLAlchemy Core bulk inserts for 10M+ records
+
+### Epic: Locust Load Testing Suite (#247)
+- 100 req/s target against 10M+ records
+
+**Status:** Not started — 20 issues planned, 0 closed
+
+---
+
+## v0.8.0 — "The Future"
+**Theme: AI-powered, extensible — the admin panel of 2027**
+**Milestone: v0.8.0 — Plugins & AI**
 
 ### Epic 6.1: Plugin & Extension System
 - Formal plugin registry with entry points (`hyperadmin.plugins`)
@@ -208,16 +310,8 @@ Django Admin's i18n is excellent — match and exceed it.
 - Plugin marketplace/directory (docs site)
 - Plugin template: scaffold a new plugin with `hyperadmin create-plugin`
 
+**Status:** Not started
 **Files:** `plugins/registry.py`, `plugins/hooks.py`, `core/app.py`
-
-### Epic 6.2: Real-Time Updates (WebSocket)
-- WebSocket channel per model list view
-- Live updates: new/updated/deleted rows appear without refresh
-- Real-time dashboard widgets
-- Collaborative editing indicators ("User X is editing this record")
-- Built on Starlette WebSocket support (already in FastAPI)
-
-**Files:** `realtime/channels.py`, `realtime/broadcast.py`, `views/websocket.py`, `templates/components/live_table.html`
 
 ### Epic 6.3: AI-Powered Features
 - Natural language search ("show me orders over $1000 from last month")
@@ -226,17 +320,8 @@ Django Admin's i18n is excellent — match and exceed it.
 - Anomaly detection highlights on dashboards
 - Optional — requires LLM API key, degrades gracefully without
 
+**Status:** Not started
 **Files:** `ai/search.py`, `ai/suggestions.py`, `core/options.py`
-
-### Epic 6.4: Performance & Benchmarks
-- Benchmark suite: measure TTFB, query count, memory usage per operation
-- Target: <100ms TTFB for list views (1M rows with pagination)
-- Query optimization: automatic `select_related` / `selectinload` analysis
-- Response caching with HTMX-aware cache invalidation
-- Virtual scrolling for large lists (HTMX + Intersection Observer)
-- Published benchmark comparison vs. Django Admin, SQLAdmin
-
-**Files:** `benchmarks/`, `core/caching.py`, `adapters/sqlmodel.py`
 
 ### Epic 6.5: Additional ORM Adapters
 - Tortoise ORM adapter
@@ -244,6 +329,7 @@ Django Admin's i18n is excellent — match and exceed it.
 - MongoDB adapter (via Motor/Beanie)
 - Generic REST API adapter (connect to any API as data source)
 
+**Status:** Not started
 **Files:** `adapters/tortoise.py`, `adapters/piccolo.py`, `adapters/mongodb.py`, `adapters/rest.py`
 
 ### Epic 6.6: Custom Pages & Views
@@ -251,7 +337,23 @@ Django Admin's i18n is excellent — match and exceed it.
 - Custom view decorators with admin navigation integration
 - Embedded iframe/component support for external tools
 
+**Status:** Not started
 **Files:** `views/custom.py`, `core/registry.py`, `templates/custom_page.html`
+
+---
+
+## JSON RESTful API (TBD)
+**Theme: Machine-readable RESTful JSON API for all registered models**
+**Milestone: JSON RESTful API (TBD) — may not ship**
+
+### Epic: JSON RESTful API for HyperAdmin (#76)
+- `JsonApiAdapter` protocol and response envelope schema (done: #197 merged)
+- `JsonApiRouter` generating 5 CRUD endpoints per registered model
+- Auth integration for JSON API (session + optional bearer token)
+- Integration tests with permission checks
+- Usage guide with curl examples
+
+**Status:** Protocol layer done, router and auth not started — 7 issues, 0 closed
 
 ---
 
@@ -261,40 +363,45 @@ Each phase has a clear verification approach:
 
 | Phase | Verification |
 |-------|-------------|
-| 2.5 | `poe test` passes, E2E login→CRUD→logout, docs build, example runs |
-| 3 | Zero-config demo works, file upload E2E, bulk action E2E, export CSV verified |
-| 4 | axe-core 0 violations in E2E suite, dark mode toggle works, i18n renders correctly, mobile screenshots |
-| 5 | Audit log populated after CRUD, row-level filter verified, OAuth login flow E2E, dashboard renders widgets |
-| 6 | Benchmark suite runs in CI, WebSocket live update E2E, plugin loads from entry point, NL search returns results |
+| v0.2.x | `poe test` passes, E2E login->CRUD->logout, docs build, example runs |
+| v0.3.x | Zero-config demo works, file upload E2E, export CSV verified |
+| v0.4.x | axe-core 0 violations, i18n renders correctly, mobile screenshots |
+| v0.5.x | Audit log populated after CRUD, row-level filter verified, OAuth login flow E2E, dashboard renders widgets |
+| v0.6.x | WebSocket live update E2E, presence banner E2E |
+| v0.7.x | Benchmark suite runs in CI, 10M rows <100ms TTFB, 100 req/s sustained |
+| v0.8.x | Plugin loads from entry point, NL search returns results |
 
 ## Architecture Compliance
 
 All phases follow CONSTITUTION.md:
-- **Bottom-up ordering**: Models → Core logic → Adapters → Views → Templates (per planning-playbook.md)
+- **Bottom-up ordering**: Models -> Core logic -> Adapters -> Views -> Templates (per planning-playbook.md)
 - **Module boundaries**: New features get their own modules (`audit/`, `dashboard/`, `plugins/`, `realtime/`, `ai/`)
-- **Dependency direction**: views/ → core/ → adapters/ (inward only)
-- **Phase 3 domains**: `auth/`, `actions/`, `uploads/` only touched in their designated phase
+- **Dependency direction**: views/ -> core/ -> adapters/ (inward only)
 - **TDD-first**: Every epic starts with failing tests
 - **300 LOC guardrail**: Large modules split proactively
 
 ## Priority & Impact Matrix
 
-| Epic | Impact | Effort | Priority |
-|------|--------|--------|----------|
-| Wire Auth E2E | High | Medium | P0 |
-| Zero-Config Admin | **Critical** | Low | P0 |
-| WCAG 2.1 AA | **Critical** (unique differentiator) | High | P0 |
-| File Uploads | High | Medium | P1 |
-| Dark Mode | High | Low | P1 |
-| i18n | High | High | P1 |
-| Custom Actions | High | Medium | P1 |
-| Audit Log | High | Medium | P2 |
-| Dashboard Builder | High | High | P2 |
-| Plugin System | Medium | High | P2 |
-| Real-Time | Medium | High | P3 |
-| AI Features | Medium | High | P3 |
-| SSO/OAuth | Medium | Medium | P2 |
-| Additional ORMs | Medium | Medium | P3 |
+| Epic | Impact | Effort | Priority | Status |
+|------|--------|--------|----------|--------|
+| Wire Auth E2E | High | Medium | P0 | Partial |
+| Zero-Config Admin | **Critical** | Low | P0 | Not started |
+| WCAG 2.1 AA | **Critical** | High | P0 | **DONE** |
+| File Uploads | High | Medium | P1 | Not started |
+| Dark Mode | High | Low | P1 | **DONE** |
+| i18n | High | High | P1 | Not started |
+| Custom Actions | High | Medium | P1 | **DONE** |
+| Audit Log | High | Medium | P2 | Not started |
+| Dashboard Builder | High | High | P2 | Not started |
+| Plugin System | Medium | High | P2 | Not started |
+| SSO/OAuth | Medium | Medium | P2 | Not started |
+| Real-Time | Medium | High | P3 | Not started (23 issues planned) |
+| Presence | Medium | Medium | P3 | Not started (9 issues planned) |
+| Scalability | High | High | P3 | Not started (34 issues planned) |
+| Load Testing | Medium | Medium | P3 | Not started (20 issues planned) |
+| AI Features | Medium | High | P3 | Not started |
+| Additional ORMs | Medium | Medium | P3 | Not started |
+| JSON REST API | Medium | Medium | TBD | Partial (protocol done) |
 
 ---
 


### PR DESCRIPTION
## Summary
- Updated `ROADMAP.md` with current progress and forward reference to `docs/roadmap.md`
- Rewrote `docs/roadmap.md` with accurate progress, v0.6/v0.7 split (real-time vs scalability), and updated priority matrix
- Added issue decomposition proposals for 6 new milestones (161 total issues across v0.3.0–v0.8.0)

## GitHub Operations (already applied)
- Moved #38 and #68 to v0.2.1, closed Phase 2 milestone
- Deleted duplicate v0.4.0 milestone (empty)
- Renamed milestones: v0.6.2→v0.6.0 (Real-Time), v0.6.3→v0.6.1 (Presence), v0.6.0→v0.7.0 (Scalability), v0.6.1→v0.7.1 (Load Testing)
- Created 6 placeholder milestones: v0.3.0, v0.3.1, v0.4.0, v0.5.1, v0.5.2, v0.8.0
- Populated GitHub Project #2 with 21 items, Priority field (P0–TBD), and Status
- Updated issue #270 as living roadmap index with milestone links

## Test plan
- [ ] Verify `docs/roadmap.md` renders correctly in MkDocs (`poe docs:serve`)
- [ ] Verify GitHub Project #2 board shows all items with priorities
- [ ] Verify issue #270 body reflects current milestone state
- [ ] Verify all milestones have correct names and due dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)