### PR TITLE
fix(ci): exclude E2E from ci.yml, add playwright install to test.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - run: uv run ruff check .
       - run: uv run ruff format --check .
       - run: uv run mypy src
-      - run: uv run pytest --tb=short --cov=src/hyperadmin --cov-report=xml
+      - run: uv run pytest --tb=short --cov=src/hyperadmin --cov-report=xml --ignore=tests/e2e
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Security checks
         run: uv run poe security-check
 
+      - name: Install Playwright browsers
+        run: uv run playwright install --with-deps chromium
+
       - name: E2E Test package
         run: uv run poe test:e2e
 


### PR DESCRIPTION
## Summary
- **ci.yml**: Exclude `tests/e2e/` from `pytest` — E2E tests are handled by `test.yml`, and `ci.yml` doesn't install Playwright browsers
- **test.yml**: Add `playwright install --with-deps chromium` step before E2E tests

Fixes failing CI run: https://github.com/yevheniidehtiar/hyper-admin/actions/runs/23716066976

## Test plan
- [ ] CI workflow passes without Playwright errors
- [ ] test.yml E2E step installs browsers and runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)