### PR TITLE
fix(container): share host memory, fix hardcoded paths, fix E2E timeouts

### DIFF
--- a/.claude/container/Dockerfile
+++ b/.claude/container/Dockerfile
@@ -66,6 +66,13 @@ RUN npm install -g @anthropic-ai/claude-code
 COPY .claude/container/scripts/init-firewall.sh /usr/local/bin/init-firewall.sh
 RUN chmod +x /usr/local/bin/init-firewall.sh
 
+# ── Memory snapshot from host ──────────────────────────────────────────────────
+# Staged by `just cc-build` (_stage-memory recipe) before docker build.
+# init-memory.sh syncs these into the named volume at container start.
+COPY .claude/container/host-memory/ /image-memory/
+COPY .claude/container/scripts/init-memory.sh /usr/local/bin/init-memory.sh
+RUN chmod +x /usr/local/bin/init-memory.sh
+
 # ── Git identity for Claude Code commits ───────────────────────────────────────
 RUN git config --global user.name "Claude Code" \
     && git config --global user.email "noreply+claude-code@anthropic.com"
@@ -96,8 +103,13 @@ RUN /opt/venv/bin/python -m playwright install chromium
 COPY . .
 
 # ── Post-copy setup ────────────────────────────────────────────────────────────
+# pre-commit install: regenerates .git/hooks/ with container python path
+#   (the COPY above brings host hooks with hardcoded host paths — must overwrite)
+# pre-commit install-hooks: downloads hook environments (best-effort, needs network)
 RUN git config --global --add safe.directory /app \
-    && uv run pre-commit install --install-hooks || true
+    && uv run pre-commit install \
+    && uv run pre-commit install --hook-type commit-msg \
+    && (uv run pre-commit install-hooks || true)
 
 # ── Entrypoint ─────────────────────────────────────────────────────────────────
 # Applies iptables firewall, then exec's the CMD.

--- a/.claude/container/Dockerfile
+++ b/.claude/container/Dockerfile
@@ -105,11 +105,14 @@ COPY . .
 # ── Post-copy setup ────────────────────────────────────────────────────────────
 # pre-commit install: regenerates .git/hooks/ with container python path
 #   (the COPY above brings host hooks with hardcoded host paths — must overwrite)
-# pre-commit install-hooks: downloads hook environments (best-effort, needs network)
-RUN git config --global --add safe.directory /app \
-    && uv run pre-commit install \
-    && uv run pre-commit install --hook-type commit-msg \
-    && (uv run pre-commit install-hooks || true)
+# Use /opt/venv/bin directly — `uv run` would recreate the venv with a
+# different Python (3.10 vs system 3.11), destroying all installed packages.
+RUN git config --unset-all core.hooksPath \
+    && rm -rf /app/.git/hooks/* \
+    && git config --global --add safe.directory /app \
+    && /opt/venv/bin/pre-commit install \
+    && /opt/venv/bin/pre-commit install --hook-type commit-msg \
+    && (/opt/venv/bin/pre-commit install-hooks || true)
 
 # ── Entrypoint ─────────────────────────────────────────────────────────────────
 # Applies iptables firewall, then exec's the CMD.

--- a/.claude/container/Dockerfile.dockerignore
+++ b/.claude/container/Dockerfile.dockerignore
@@ -16,6 +16,7 @@ build/
 # Git worktrees (can be large)
 .worktrees/
 .claude/worktrees/
+.git/hooks/
 
 # Node
 node_modules/

--- a/.claude/container/README.md
+++ b/.claude/container/README.md
@@ -117,6 +117,27 @@ docker volume rm container_gh-config            # GitHub CLI
 
 ---
 
+## Memory sharing
+
+The container bridges Claude Code's project memory with the host so that
+host-accumulated learnings (feedback, project context, user preferences) are
+available to container agents, and multiple containers share the same memory.
+
+**How it works:**
+
+1. `just cc-build` stages the host memory (`~/.claude/projects/<key>/memory/`)
+   into the build context at `.claude/container/host-memory/` (gitignored).
+2. `docker build` bakes the snapshot into the image at `/image-memory/`.
+3. At startup, `init-memory.sh` copies the snapshot into the named volume at
+   `/root/.claude/projects/-app/memory/` using `cp -u` (update — newer files
+   only), so container-written entries are never overwritten by a stale build.
+4. Multiple containers from the same Compose share the `claude-credentials`
+   named volume, so memory written by one container is visible to the others.
+
+To refresh memory after host changes, rebuild: `just cc-build`.
+
+---
+
 ## SSH deploy key
 
 `just cc-rotate-key` generates an ed25519 keypair in `.claude/container/ssh/`
@@ -160,8 +181,10 @@ Everything else is dropped, making `--dangerously-skip-permissions` safe.
 ├── Dockerfile                  # node:20-bookworm + Python + uv + gh + Claude Code
 ├── Dockerfile.dockerignore     # excludes .venv, caches, secrets from build context
 ├── docker-compose.yml          # service definition, volumes, capabilities
+├── host-memory/                # gitignored — staged by `just cc-build`
 ├── scripts/
-│   └── init-firewall.sh        # iptables whitelist entrypoint
+│   ├── init-firewall.sh        # iptables whitelist entrypoint
+│   └── init-memory.sh          # syncs host memory snapshot into named volume
 ├── ssh/                        # gitignored — generated deploy key
 │   ├── id_ed25519
 │   ├── id_ed25519.pub

--- a/.claude/container/docker-compose.yml
+++ b/.claude/container/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     # NET_ADMIN is required for init-firewall.sh to apply iptables rules
     cap_add:
       - NET_ADMIN
+    # Chromium needs >64 MB shared memory; Docker's default is too small and
+    # causes browser crashes / hangs during Playwright E2E tests.
+    shm_size: '2gb'
     env_file:
       # Load GITHUB_PAT, SLACK_BOT_TOKEN, etc. from project .env at runtime.
       # Path is relative to the compose file location.

--- a/.claude/container/scripts/init-firewall.sh
+++ b/.claude/container/scripts/init-firewall.sh
@@ -22,6 +22,10 @@
 
 set -euo pipefail
 
+# ── Memory bridge ──────────────────────────────────────────────────────────────
+# Sync build-time host memory snapshot into the named volume.
+/usr/local/bin/init-memory.sh
+
 ALLOW_HOSTS=(
     # Anthropic services
     "api.anthropic.com"

--- a/.claude/container/scripts/init-memory.sh
+++ b/.claude/container/scripts/init-memory.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Sync host memory snapshot (baked at build time) into the named volume.
+#
+# At build time, the justfile stages the host's Claude Code project memory
+# into /image-memory/ inside the image.  At container start, this script
+# copies those files into the volume-backed memory directory so that Claude
+# Code inside the container can read/write them.
+#
+# Uses `cp -u` (update) so container-written entries are not overwritten by
+# an older build snapshot on restart.
+
+set -euo pipefail
+
+IMAGE_MEMORY="/image-memory"
+VOLUME_MEMORY="/root/.claude/projects/-app/memory"
+
+MD_COUNT=$(find "$IMAGE_MEMORY" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$MD_COUNT" -gt 0 ]; then
+    mkdir -p "$VOLUME_MEMORY"
+    cp -u "$IMAGE_MEMORY"/*.md "$VOLUME_MEMORY/" 2>/dev/null || true
+    echo "[memory] Synced $MD_COUNT memory files from build snapshot" >&2
+else
+    echo "[memory] No build-time memory snapshot — container starts fresh" >&2
+fi

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -131,11 +131,9 @@ requirement, architectural ambiguity, or any issue that prevents moving forward)
 
 **Step 1 — Search memory for prior solutions:**
 
-Read the memory index and relevant files:
-```
-/Users/yevheniidehtiar/.claude/projects/-Users-yevheniidehtiar--projects-hyper-admin/memory/MEMORY.md
-```
-Then read any memory files whose description matches the blocker topic.
+Read your project memory index (`MEMORY.md`) and any files whose description
+matches the blocker topic. The auto-memory system provides the concrete path
+at runtime.
 
 **If a relevant solution is found** → apply it and continue. Update the memory entry if you
 discovered a refinement.
@@ -181,10 +179,7 @@ Print: `STOPPED: Blocker documented on issue #$ARGUMENTS. Draft PR contains curr
 Once a blocker is resolved (either by memory lookup or by human input on the issue), write a
 memory entry before continuing:
 
-Create a new file in:
-```
-/Users/yevheniidehtiar/.claude/projects/-Users-yevheniidehtiar--projects-hyper-admin/memory/
-```
+Create a new file in your project memory directory (the directory containing `MEMORY.md`).
 
 Name it descriptively (e.g., `feedback_sqlmodel_inspector.md`). Use this format:
 

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ site/
 # Claude Code
 .claude/settings.local.json
 .claude/container/ssh/
+.claude/container/host-memory/*
+!.claude/container/host-memory/.dockerkeep
 
 gha-creds-*.json
 

--- a/justfile
+++ b/justfile
@@ -73,7 +73,7 @@ _compose := "docker compose -f .claude/container/docker-compose.yml"
 _stage-memory:
     #!/usr/bin/env bash
     set -euo pipefail
-    HOST_MEM="$HOME/.claude/projects/$(pwd | tr '/' '-')/memory"
+    HOST_MEM="$HOME/.claude/projects/$(pwd | tr '/.' '-')/memory"
     STAGE=".claude/container/host-memory"
     # Clean previous snapshot but keep .dockerkeep (ensures COPY works on fresh checkouts)
     find "$STAGE" -mindepth 1 ! -name '.dockerkeep' -delete 2>/dev/null || true

--- a/justfile
+++ b/justfile
@@ -69,8 +69,24 @@ build:
 
 _compose := "docker compose -f .claude/container/docker-compose.yml"
 
+# Stage host Claude memory into build context (snapshot for container use)
+_stage-memory:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HOST_MEM="$HOME/.claude/projects/$(pwd | tr '/' '-')/memory"
+    STAGE=".claude/container/host-memory"
+    # Clean previous snapshot but keep .dockerkeep (ensures COPY works on fresh checkouts)
+    find "$STAGE" -mindepth 1 ! -name '.dockerkeep' -delete 2>/dev/null || true
+    mkdir -p "$STAGE"
+    if [ -d "$HOST_MEM" ] && [ "$(ls -A "$HOST_MEM" 2>/dev/null)" ]; then
+        cp "$HOST_MEM"/* "$STAGE/" 2>/dev/null || true
+        echo "[memory] Staged $(find "$STAGE" -name '*.md' | wc -l | tr -d ' ') files from host memory"
+    else
+        echo "[memory] No host memory found — staging empty directory"
+    fi
+
 # Build the Claude Code remote container image
-cc-build:
+cc-build: _stage-memory
     {{ _compose }} build
 
 # Start Claude Code remote-control server (requires prior `just cc-login`)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,8 +7,30 @@ import time
 from collections.abc import Iterator
 from contextlib import closing
 from http import HTTPStatus
+from typing import Any
 
 import pytest
+
+_IN_CONTAINER = os.environ.get("IS_SANDBOX") == "1"
+
+# Server start is slower inside Docker; give it more time.
+_SERVER_TIMEOUT = 15 if _IN_CONTAINER else 5
+
+
+@pytest.fixture(scope="session")
+def browser_type_launch_args(browser_type_launch_args: dict[str, Any]) -> dict[str, Any]:
+    """Add Docker-safe Chromium flags when running inside a container."""
+    if not _IN_CONTAINER:
+        return browser_type_launch_args
+    return {
+        **browser_type_launch_args,
+        "args": [
+            *browser_type_launch_args.get("args", []),
+            "--disable-dev-shm-usage",  # use /tmp instead of /dev/shm (Docker default is 64 MB)
+            "--disable-gpu",
+            "--disable-background-networking",  # avoid firewall-blocked Google service requests
+        ],
+    }
 
 
 def _find_free_port() -> int:
@@ -70,7 +92,7 @@ def demo_base_url(e2e_port: int) -> Iterator[str]:
 
     try:
         # Wait for server readiness
-        deadline = time.time() + 5
+        deadline = time.time() + _SERVER_TIMEOUT
         last_err: Exception | None = None
         while time.time() < deadline:
             try:


### PR DESCRIPTION
## Summary

- **Memory sharing**: `just cc-build` snapshots host Claude memory into the build context; `init-memory.sh` syncs it into the named volume at container start, bridging the `-app` vs host project key mismatch. Multiple containers from the same compose share memory via the existing `claude-credentials` volume.
- **Hardcoded path cleanup**: Replaced `/Users/yevheniidehtiar/...` paths in `SKILL.md` with generic references. Cleaned up dead `mv` entries in `settings.local.json`.
- **Pre-commit hooks**: Split `pre-commit install` from `install-hooks` so hook script regeneration (which fixes stale host python paths copied via `COPY . .`) is a hard build step.
- **E2E in Docker**: Added `shm_size: 2gb` to compose, Docker-safe Chromium launch args (`--disable-dev-shm-usage`, `--disable-background-networking`), and increased server health check timeout to 15s inside containers.

## Test plan

- [ ] `just cc-build` prints "Staged N files from host memory"
- [ ] `just cc-shell` → `ls /root/.claude/projects/-app/memory/` shows memory files
- [ ] `just cc-shell` → `cat /root/.claude/projects/-app/memory/MEMORY.md` matches host
- [ ] `just cc-shell` → `head -1 .git/hooks/pre-commit` shows `/opt/venv/bin/python` (not host path)
- [ ] `poe test:e2e` still passes on host
- [ ] E2E tests pass inside container (`just cc-run "poe test:e2e"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)