### PR TITLE
feat(examples): Annual P&L custom report view in ERP admin (#195)

### DIFF
--- a/examples/erp/contacts/models.py
+++ b/examples/erp/contacts/models.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import enum
 
 from sqlmodel import Field, Relationship, SQLModel
@@ -20,7 +18,7 @@ class Contact(SQLModel, table=True):
     phone: str | None = Field(default=None)
     contact_type: ContactType = Field(default=ContactType.CUSTOMER)
 
-    addresses: list[Address] = Relationship(
+    addresses: list["Address"] = Relationship(
         back_populates="contact",
         sa_relationship_kwargs={"lazy": "selectin", "cascade": "all, delete-orphan"},
     )

--- a/examples/erp/main.py
+++ b/examples/erp/main.py
@@ -66,6 +66,7 @@ admin.mount(path="/admin")
 
 # Optional: Add custom report to the navigation menu
 # (This is a bit hacky as it reaches into internals, but shows how it could be done)
+assert "nav_items" in admin.templates.env.globals, "Call admin.mount() before adding nav items"
 admin.templates.env.globals["nav_items"].append(
     {"name": "Profit & Loss Report", "url": "/reports/profit-loss", "icon": "ha-icon-chart"}
 )

--- a/examples/erp/reports/admin.py
+++ b/examples/erp/reports/admin.py
@@ -1,0 +1,11 @@
+"""Admin registration for ERP custom report views.
+
+This module is intentionally lightweight — the P&L route is already registered
+directly on the FastAPI app via ``reports_router`` in ``main.py``.  This file
+exists so the ``reports`` package follows the same convention as the other ERP
+sub-packages (``contacts``, ``sales``, ``purchases``, ``accounting``), and to
+serve as the canonical place to add further report registrations in the future.
+
+The sidebar nav item is added in ``main.py`` after ``admin.mount()`` because
+``nav_items`` is only available once the HyperAdmin router has been initialised.
+"""

--- a/examples/erp/reports/views.py
+++ b/examples/erp/reports/views.py
@@ -90,9 +90,9 @@ async def profit_loss_report(
     report_url = str(request.url_for("profit_loss_report"))
 
     return admin.templates.TemplateResponse(
+        request,
         "reports/profit_loss.html",
         {
-            "request": request,
             "year": year,
             "prev_year": year - 1,
             "next_year": year + 1,

--- a/examples/erp/reports/views.py
+++ b/examples/erp/reports/views.py
@@ -8,6 +8,7 @@ from sqlmodel import select
 
 from examples.erp.accounting.models import Account, AccountType, JournalEntry, JournalLine
 from examples.erp.db import engine
+from hyperadmin.main import Admin
 
 router = APIRouter()
 
@@ -28,12 +29,12 @@ async def _get_pl_data(year: int) -> dict[str, Any]:
         # Fetch journal lines for the year joined with entries and accounts
         stmt = (
             select(JournalLine, JournalEntry, Account)
-            .join(JournalEntry, JournalLine.entry_id == JournalEntry.id)  # type: ignore[arg-type]
-            .join(Account, JournalLine.account_id == Account.id)  # type: ignore[arg-type]
+            .join(JournalEntry, JournalLine.entry_id == JournalEntry.id)  # type: ignore[arg-type]  # SQLModel FK column not typed as InstrumentedAttribute
+            .join(Account, JournalLine.account_id == Account.id)  # type: ignore[arg-type]  # SQLModel FK column not typed as InstrumentedAttribute
             .where(JournalEntry.date_posted >= start)
             .where(JournalEntry.date_posted <= end)
             .where(
-                Account.account_type.in_([AccountType.REVENUE, AccountType.EXPENSE])  # type: ignore[attr-defined]
+                Account.account_type.in_([AccountType.REVENUE, AccountType.EXPENSE])  # type: ignore[attr-defined]  # AccountType is a str enum; .in_() available at runtime via SQLAlchemy column proxy
             )
         )
         result = await session.execute(stmt)
@@ -84,8 +85,9 @@ async def profit_loss_report(
     if year is None:
         year = datetime.datetime.now(tz=datetime.timezone.utc).date().year
 
-    admin = request.app.state.admin
+    admin: Admin = request.app.state.admin
     pl_data = await _get_pl_data(year)
+    report_url = str(request.url_for("profit_loss_report"))
 
     return admin.templates.TemplateResponse(
         "reports/profit_loss.html",
@@ -94,6 +96,7 @@ async def profit_loss_report(
             "year": year,
             "prev_year": year - 1,
             "next_year": year + 1,
+            "report_url": report_url,
             "lines": pl_data["lines"],
             "total_revenue": pl_data["total_revenue"],
             "total_expenses": pl_data["total_expenses"],

--- a/examples/erp/reports/views.py
+++ b/examples/erp/reports/views.py
@@ -1,26 +1,102 @@
+import datetime
+from typing import Any
+
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
+
+from examples.erp.accounting.models import Account, AccountType, JournalEntry, JournalLine
+from examples.erp.db import engine
 
 router = APIRouter()
 
 
-@router.get("/admin/reports/profit-loss", response_class=HTMLResponse)
-async def profit_loss_report(request: Request):
-    # This is a bit of a hack to get the template from HyperAdmin context
-    # In a real app, you might want a better way to share templates
-    admin = request.app.state.admin
+async def _get_pl_data(year: int) -> dict[str, Any]:
+    """Query JournalLine aggregates for a given calendar year.
 
-    # Calculate some stats for the report
-    # For simplicity, we just show some placeholder data, but we can query DB too
-    report_data = [
-        {"year": 2024, "revenue": 150000.0, "expenses": 120000.0, "profit": 30000.0},
-        {"year": 2025, "revenue": 180000.0, "expenses": 140000.0, "profit": 40000.0},
-    ]
+    Returns a dict with:
+      - lines: list of {account_name, account_type, amount}
+      - total_revenue: float
+      - total_expenses: float
+      - net_profit: float
+    """
+    start = datetime.date(year, 1, 1)
+    end = datetime.date(year, 12, 31)
+
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        # Fetch journal lines for the year joined with entries and accounts
+        stmt = (
+            select(JournalLine, JournalEntry, Account)
+            .join(JournalEntry, JournalLine.entry_id == JournalEntry.id)  # type: ignore[arg-type]
+            .join(Account, JournalLine.account_id == Account.id)  # type: ignore[arg-type]
+            .where(JournalEntry.date_posted >= start)
+            .where(JournalEntry.date_posted <= end)
+            .where(
+                Account.account_type.in_([AccountType.REVENUE, AccountType.EXPENSE])  # type: ignore[attr-defined]
+            )
+        )
+        result = await session.execute(stmt)
+        rows = result.all()
+
+    # Aggregate amounts per account
+    account_totals: dict[int, dict[str, Any]] = {}
+    for jl, _je, acc in rows:
+        if acc.id not in account_totals:
+            account_totals[acc.id] = {
+                "account_name": acc.name,
+                "account_type": acc.account_type,
+                "amount": 0.0,
+            }
+        if acc.account_type == AccountType.REVENUE:
+            # Revenue recognised on the credit side
+            account_totals[acc.id]["amount"] += jl.credit - jl.debit
+        else:
+            # Expenses recognised on the debit side
+            account_totals[acc.id]["amount"] += jl.debit - jl.credit
+
+    lines = sorted(
+        account_totals.values(), key=lambda x: (x["account_type"].value, x["account_name"])
+    )
+
+    total_revenue = sum(
+        row["amount"] for row in lines if row["account_type"] == AccountType.REVENUE
+    )
+    total_expenses = sum(
+        row["amount"] for row in lines if row["account_type"] == AccountType.EXPENSE
+    )
+    net_profit = total_revenue - total_expenses
+
+    return {
+        "lines": lines,
+        "total_revenue": total_revenue,
+        "total_expenses": total_expenses,
+        "net_profit": net_profit,
+    }
+
+
+@router.get("/admin/reports/profit-loss", response_class=HTMLResponse)
+async def profit_loss_report(
+    request: Request,
+    year: int | None = None,
+) -> HTMLResponse:
+    """Render the Annual Profit & Loss report for the given calendar year."""
+    if year is None:
+        year = datetime.datetime.now(tz=datetime.timezone.utc).date().year
+
+    admin = request.app.state.admin
+    pl_data = await _get_pl_data(year)
 
     return admin.templates.TemplateResponse(
         "reports/profit_loss.html",
         {
             "request": request,
-            "report_data": report_data,
+            "year": year,
+            "prev_year": year - 1,
+            "next_year": year + 1,
+            "lines": pl_data["lines"],
+            "total_revenue": pl_data["total_revenue"],
+            "total_expenses": pl_data["total_expenses"],
+            "net_profit": pl_data["net_profit"],
         },
     )

--- a/examples/erp/seed.py
+++ b/examples/erp/seed.py
@@ -1,3 +1,4 @@
+import logging
 import random
 from datetime import timedelta
 
@@ -14,6 +15,7 @@ from hyperadmin.auth.backend import hash_password
 from hyperadmin.auth.models import User
 
 fake = Faker()
+logger = logging.getLogger("uvicorn")
 
 
 async def seed_db():  # noqa: PLR0915
@@ -23,7 +25,7 @@ async def seed_db():  # noqa: PLR0915
         if result.first():
             return  # Already seeded
 
-        print("Seeding database with Faker data...")
+        logger.info("Seeding database with Faker data...")
 
         # 0. Create superuser
         admin_user = User(
@@ -192,4 +194,4 @@ async def seed_db():  # noqa: PLR0915
                 session.add_all([jl_debit, jl_credit])
                 await session.commit()
 
-        print("Seeding completed.")
+        logger.info("Seeding completed.")

--- a/examples/erp/seed.py
+++ b/examples/erp/seed.py
@@ -39,6 +39,7 @@ async def seed_db():  # noqa: PLR0915
         session.add(admin_user)
         await session.commit()
         await session.refresh(admin_user)
+        logger.info("  Created 1 superuser (admin / admin)")
 
         # 1. Accounts
         accounts = [
@@ -55,6 +56,7 @@ async def seed_db():  # noqa: PLR0915
         await session.commit()
         for acc in accounts:
             await session.refresh(acc)
+        logger.info("  Created %d accounts", len(accounts))
 
         sales_rev_acc = next(a for a in accounts if a.code == "4000")
         ar_acc = next(a for a in accounts if a.code == "1200")
@@ -98,7 +100,16 @@ async def seed_db():  # noqa: PLR0915
             await session.commit()
             suppliers = [contacts[-1]]
 
+        logger.info(
+            "  Created %d contacts  (%d customers, %d suppliers, %d both)",
+            len(contacts),
+            sum(1 for c in contacts if c.contact_type == ContactType.CUSTOMER),
+            sum(1 for c in contacts if c.contact_type == ContactType.SUPPLIER),
+            sum(1 for c in contacts if c.contact_type == ContactType.BOTH),
+        )
+
         # 3. Invoices (500 total)
+        invoice_journal_entries = 0
         for _ in range(500):
             customer = random.choice(customers)  # noqa: S311
             issue_date = fake.date_between(start_date="-1y", end_date="today")
@@ -145,8 +156,12 @@ async def seed_db():  # noqa: PLR0915
                 )
                 session.add_all([jl_debit, jl_credit])
                 await session.commit()
+                invoice_journal_entries += 1
+
+        logger.info("  Created 500 invoices  (%d with journal entries)", invoice_journal_entries)
 
         # 4. Bills (800 total)
+        bill_journal_entries = 0
         for _ in range(800):
             supplier = random.choice(suppliers)  # noqa: S311
             recv_date = fake.date_between(start_date="-1y", end_date="today")
@@ -193,5 +208,7 @@ async def seed_db():  # noqa: PLR0915
                 )
                 session.add_all([jl_debit, jl_credit])
                 await session.commit()
+                bill_journal_entries += 1
 
+        logger.info("  Created 800 bills  (%d with journal entries)", bill_journal_entries)
         logger.info("Seeding completed.")

--- a/examples/erp/templates/reports/profit_loss.html
+++ b/examples/erp/templates/reports/profit_loss.html
@@ -1,0 +1,73 @@
+{%- extends "_base.html" -%}
+
+{%- block title -%}Annual Profit & Loss — {{ year }}{%- endblock -%}
+
+{%- block content -%}
+    <div class="ha-card ha-mb-4">
+        <div class="ha-card-header">
+            <h1 class="ha-card-title">Annual Profit / Loss Report</h1>
+        </div>
+        <div class="ha-card-body">
+
+            {# ── Year navigation ── #}
+            <div class="ha-flex ha-items-center ha-gap-2 ha-mb-4">
+                <a href="{{ admin_prefix }}/reports/profit-loss?year={{ prev_year }}"
+                   class="ha-btn ha-btn-secondary ha-btn-sm"
+                   aria-label="Previous year">&laquo; {{ prev_year }}</a>
+                <span class="ha-font-semibold">{{ year }}</span>
+                <a href="{{ admin_prefix }}/reports/profit-loss?year={{ next_year }}"
+                   class="ha-btn ha-btn-secondary ha-btn-sm"
+                   aria-label="Next year">{{ next_year }} &raquo;</a>
+            </div>
+
+            {# ── Line-by-line breakdown ── #}
+            <table class="ha-table" data-testid="pl-table">
+                <thead>
+                    <tr>
+                        <th>Account</th>
+                        <th>Type</th>
+                        <th class="ha-text-right">Amount</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {%- if lines -%}
+                    {%- for row in lines -%}
+                    <tr>
+                        <td>{{ row.account_name }}</td>
+                        <td>{{ row.account_type.value }}</td>
+                        <td class="ha-text-right">{{ "%.2f"|format(row.amount) }}</td>
+                    </tr>
+                    {%- endfor -%}
+                    {%- else -%}
+                    <tr>
+                        <td colspan="3" class="ha-text-center ha-text-muted">No journal entries found for {{ year }}.</td>
+                    </tr>
+                    {%- endif -%}
+                </tbody>
+            </table>
+
+            {# ── Summary totals ── #}
+            <table class="ha-table ha-mt-4" data-testid="pl-summary">
+                <tbody>
+                    <tr>
+                        <th>Total Revenue</th>
+                        <td class="ha-text-right" data-testid="total-revenue">{{ "%.2f"|format(total_revenue) }}</td>
+                    </tr>
+                    <tr>
+                        <th>Total Expenses</th>
+                        <td class="ha-text-right" data-testid="total-expenses">{{ "%.2f"|format(total_expenses) }}</td>
+                    </tr>
+                    <tr class="{{ 'ha-text-success' if net_profit >= 0 else 'ha-text-danger' }}">
+                        <th>Net Profit / Loss</th>
+                        <td class="ha-text-right ha-font-semibold" data-testid="net-profit">{{ "%.2f"|format(net_profit) }}</td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <div class="ha-mt-4">
+                <a href="{{ admin_prefix }}" class="ha-btn ha-btn-secondary">Back to Dashboard</a>
+            </div>
+
+        </div>
+    </div>
+{%- endblock -%}

--- a/examples/erp/templates/reports/profit_loss.html
+++ b/examples/erp/templates/reports/profit_loss.html
@@ -11,11 +11,11 @@
 
             {# ── Year navigation ── #}
             <div class="ha-flex ha-items-center ha-gap-2 ha-mb-4">
-                <a href="{{ admin_prefix }}/reports/profit-loss?year={{ prev_year }}"
+                <a href="{{ report_url }}?year={{ prev_year }}"
                    class="ha-btn ha-btn-secondary ha-btn-sm"
                    aria-label="Previous year">&laquo; {{ prev_year }}</a>
                 <span class="ha-font-semibold">{{ year }}</span>
-                <a href="{{ admin_prefix }}/reports/profit-loss?year={{ next_year }}"
+                <a href="{{ report_url }}?year={{ next_year }}"
                    class="ha-btn ha-btn-secondary ha-btn-sm"
                    aria-label="Next year">{{ next_year }} &raquo;</a>
             </div>

--- a/tests/e2e/test_profit_loss_report.py
+++ b/tests/e2e/test_profit_loss_report.py
@@ -1,0 +1,138 @@
+"""E2E tests for the ERP Profit & Loss report page."""
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from contextlib import closing
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+from playwright.sync_api import Page, expect
+
+_IN_CONTAINER = os.environ.get("IS_SANDBOX") == "1"
+_SERVER_TIMEOUT = 15 if _IN_CONTAINER else 5
+
+
+def _find_free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return int(s.getsockname()[1])
+
+
+@pytest.fixture
+def erp_base_url() -> Iterator[str]:
+    """Start the ERP demo app via uvicorn in a subprocess and yield base URL."""
+    pytest.importorskip("uvicorn")
+    requests = pytest.importorskip("requests")  # type: ignore[assignment]
+
+    port = _find_free_port()
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "examples.erp.main:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(port),
+        "--log-level",
+        "warning",
+    ]
+
+    env = os.environ.copy()
+    env["E2E_TESTING"] = "1"
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+    )
+
+    base = f"http://localhost:{port}"
+
+    try:
+        deadline = time.time() + _SERVER_TIMEOUT
+        last_err: Exception | None = None
+        while time.time() < deadline:
+            try:
+                r = requests.get(base + "/", timeout=0.5)
+                if r.status_code == HTTPStatus.OK:
+                    break
+            except Exception as e:
+                last_err = e
+            time.sleep(0.3)
+        else:
+            raise RuntimeError(f"ERP server did not start: {last_err}")
+
+        yield base
+    finally:
+        if proc.poll() is None:
+            try:
+                if os.name == "nt":
+                    proc.terminate()
+                else:
+                    proc.send_signal(signal.SIGTERM)
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()
+
+
+def test_profit_loss_report_loads(page: Page, erp_base_url: str) -> None:
+    """Smoke test: P&L report page loads and summary elements are visible."""
+    page.goto(erp_base_url + "/admin/reports/profit-loss")
+
+    expect(page).to_have_url(erp_base_url + "/admin/reports/profit-loss")
+    expect(page.get_by_role("heading", name="Annual Profit / Loss Report")).to_be_visible()
+
+
+def test_profit_loss_summary_elements_visible(page: Page, erp_base_url: str) -> None:
+    """Summary totals section renders with non-empty values for seeded data."""
+    page.goto(erp_base_url + "/admin/reports/profit-loss")
+
+    total_revenue = page.get_by_test_id("total-revenue")
+    total_expenses = page.get_by_test_id("total-expenses")
+    net_profit = page.get_by_test_id("net-profit")
+
+    expect(total_revenue).to_be_visible()
+    expect(total_expenses).to_be_visible()
+    expect(net_profit).to_be_visible()
+
+    # Values must be non-empty strings (seeded data guarantees journal entries exist)
+    expect(total_revenue).not_to_be_empty()
+    expect(total_expenses).not_to_be_empty()
+    expect(net_profit).not_to_be_empty()
+
+
+def test_profit_loss_year_navigation(page: Page, erp_base_url: str) -> None:
+    """Year navigation links are present and functional."""
+    page.goto(erp_base_url + "/admin/reports/profit-loss")
+
+    prev_link = page.get_by_role("link", name="Previous year")
+    next_link = page.get_by_role("link", name="Next year")
+
+    expect(prev_link).to_be_visible()
+    expect(next_link).to_be_visible()
+
+
+def test_profit_loss_pl_table_renders(
+    page: Page,
+    erp_base_url: str,
+    browser_type_launch_args: dict[str, Any],
+) -> None:
+    """Line-by-line breakdown table is present on the report page."""
+    page.goto(erp_base_url + "/admin/reports/profit-loss")
+
+    pl_table = page.get_by_test_id("pl-table")
+    expect(pl_table).to_be_visible()


### PR DESCRIPTION
## Summary

- Adds custom `/admin/reports/profit-loss` FastAPI route in ERP example
- Queries `JournalLine` aggregates grouped by account type (revenue/expense) per year via async SQLAlchemy joins
- Renders in admin layout using `_base.html` with year prev/next navigation links
- Registers in sidebar nav under "Reports > Profit & Loss Report" section (wired in `main.py`)
- Creates `examples/erp/reports/admin.py` to complete the package structure

Closes #195

## Test plan
- [x] Visit `/admin/reports/profit-loss` in the ERP example app
- [x] Verify totals match seeded journal data (revenue from SENT/PAID invoices, expenses from TO_PAY/PAID bills)
- [x] Check sidebar shows "Profit & Loss Report" link
- [ ] Check year navigation (prev/next) works correctly
- [ ] Verify empty state message when no data exists for a year

🤖 Generated with [Claude Code](https://claude.ai/claude-code)