### PR TITLE
feat(core): Pydantic Settings — HyperAdminSettings (#383)

### DIFF
--- a/examples/erp/main.py
+++ b/examples/erp/main.py
@@ -8,6 +8,7 @@ from examples.erp.db import engine
 from examples.erp.reports.views import router as reports_router
 from hyperadmin.auth.permissions import ModelPermissionChecker, PermissionSyncService
 from hyperadmin.auth.session import SessionAuthBackend
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.main import Admin
 
 
@@ -41,9 +42,10 @@ permission_checker = ModelPermissionChecker(engine=engine)
 base_dir = os.path.dirname(__file__)
 template_dir = os.path.join(base_dir, "templates")
 
-admin = Admin(
-    app,
-    engine=engine,
+# All scalar config lives in HyperAdminSettings.
+# Set HYPERADMIN_SECRET_KEY in your environment or .env file.
+settings = HyperAdminSettings(
+    secret_key=os.environ.get("HYPERADMIN_SECRET_KEY", "super-secret-erp-key"),
     create_tables=False,
     discover_apps=[
         "examples.erp.contacts",
@@ -53,10 +55,16 @@ admin = Admin(
         "hyperadmin.auth",
     ],
     template_dirs=[template_dir],
+    debug=bool(os.environ.get("HYPERADMIN_DEBUG", "")),
+)
+
+admin = Admin(
+    app,
+    engine=engine,
+    settings=settings,
     auth_backend=auth_backend,
     permission_checker=permission_checker,
     permission_registry=permission_registry,
-    session_secret="super-secret-erp-key",  # noqa: S106
 )
 
 # Store admin on app state so custom views can access it (e.g. for templates)
@@ -65,7 +73,6 @@ app.state.admin = admin
 admin.mount(path="/admin")
 
 # Optional: Add custom report to the navigation menu
-# (This is a bit hacky as it reaches into internals, but shows how it could be done)
 assert "nav_items" in admin.templates.env.globals, "Call admin.mount() before adding nav items"
 admin.templates.env.globals["nav_items"].append(
     {"name": "Profit & Loss Report", "url": "/reports/profit-loss", "icon": "ha-icon-chart"}

--- a/examples/simple/main.py
+++ b/examples/simple/main.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlmodel import SQLModel, select
 
 from examples.simple.models import City, Country, User
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.main import Admin
 
 # 1. Create a database engine
@@ -51,18 +52,22 @@ async def create_db_and_tables():
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Load the ML model
     await create_db_and_tables()
     yield
 
 
-# 2. Create a FastAPI app and an Admin instance with auto-discovery
+# 2. Configure HyperAdmin via settings (reads HYPERADMIN_* env vars and .env)
+settings = HyperAdminSettings(
+    discover_apps=["examples.simple"],
+)
+
+# 3. Create a FastAPI app and an Admin instance
 app = FastAPI(lifespan=lifespan)
 
 app.mount("/static", StaticFiles(directory="src/hyperadmin/static"), name="static")
-admin = Admin(app, engine=engine, discover_apps=["examples.simple"])
+admin = Admin(app, engine=engine, settings=settings)
 
-# 3. Mount the admin interface
+# 4. Mount the admin interface
 admin.mount(path="/admin")
 
 

--- a/src/hyperadmin/core/app.py
+++ b/src/hyperadmin/core/app.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from typing import Any
 
@@ -6,8 +7,11 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlmodel import SQLModel
 
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.db import engine as default_engine
 from hyperadmin.discover import discover_admin_modules
+
+logger = logging.getLogger("hyperadmin")
 
 
 class Admin:
@@ -16,85 +20,99 @@ class Admin:
     Mounts static files, wires the database engine, optionally discovers admin
     modules, and registers all model routes on the FastAPI application.
 
-    Example:
-        ```python
+    All scalar configuration lives in ``HyperAdminSettings`` — pass a settings
+    object or let HyperAdmin auto-instantiate one (which reads from environment
+    variables and a ``.env`` file).
+
+    Example::
+
         from fastapi import FastAPI
-        from hyperadmin import Admin
+        from hyperadmin import Admin, HyperAdminSettings
 
         app = FastAPI()
-        admin = Admin(app, engine=engine, discover_apps=["myapp"])
+        settings = HyperAdminSettings(secret_key="my-secret", theme="dark")
+        admin = Admin(app, engine=engine, settings=settings)
         admin.mount("/admin")
-        ```
     """
 
-    #: Valid theme values that can be passed to the ``theme`` parameter.
-    VALID_THEMES = ("auto", "light", "dark")
-
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         app: FastAPI,
-        discover_apps: list[str] | None = None,
-        create_tables: bool = True,
         engine: Any = None,
-        template_dirs: list[str] | None = None,
+        settings: HyperAdminSettings | None = None,
         auth_backend: Any = None,
         permission_checker: Any = None,
         permission_registry: Any = None,
-        session_secret: str | None = None,
-        theme: str = "auto",
-    ):
+    ) -> None:
         """Initialise HyperAdmin and attach it to a FastAPI application.
 
         Args:
             app: The FastAPI application instance to attach the admin to.
-            discover_apps: List of Python module paths to auto-discover
-                ``admin.py`` files in (e.g. ``["myapp", "otherapp"]``).
-            create_tables: When ``True``, registers an ``on_event("startup")``
-                handler that calls ``SQLModel.metadata.create_all``.
             engine: An async SQLAlchemy engine. Defaults to the built-in
                 ``hyperadmin.db.engine`` if not provided.
-            template_dirs: Additional Jinja2 template directories searched
-                before the built-in HyperAdmin templates.
+            settings: A ``HyperAdminSettings`` instance. When ``None``, one is
+                auto-instantiated (reads ``HYPERADMIN_*`` env vars and ``.env``).
             auth_backend: An optional authentication backend implementing the
                 ``AuthBackend`` protocol. When ``None``, auth is disabled.
             permission_checker: An optional ``PermissionChecker`` implementation.
             permission_registry: An optional ``PermissionRegistry`` implementation.
-            session_secret: Secret key for ``SessionMiddleware``. Required when
-                ``auth_backend`` is set.
-            theme: Color theme for the admin interface. Accepted values are
-                ``"auto"`` (respects ``prefers-color-scheme``, default),
-                ``"light"`` (always light), or ``"dark"`` (always dark).
         """
-        if theme not in self.VALID_THEMES:
-            msg = f"Invalid theme {theme!r}. Must be one of {self.VALID_THEMES}"
-            raise ValueError(msg)
-        self.theme = theme
+        self.settings = settings or HyperAdminSettings()
         self.app = app
         self.router = APIRouter()
         self.engine = engine or default_engine
         self.auth_backend = auth_backend
         self.permission_checker = permission_checker
         self.permission_registry = permission_registry
-        self.session_secret = session_secret
-        self.template_dirs = template_dirs or []
-        template_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
-        self.templates = Jinja2Templates(directory=[*self.template_dirs, template_dir])
 
-        # Mount static files for the admin interface
+        self._validate_session_secret()
+
+        template_dirs = self.settings.template_dirs
+        template_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
+        self.templates = Jinja2Templates(directory=[*template_dirs, template_dir])
+
         static_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "static")
         if os.path.exists(static_dir):
             app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
-        if create_tables:
+        if self.settings.create_tables:
 
             @app.on_event("startup")
-            async def startup_event():
+            async def startup_event() -> None:
                 await self._create_db_and_tables()
 
-        if discover_apps:
-            discover_admin_modules(discover_apps)
+        if self.settings.discover_apps:
+            discover_admin_modules(self.settings.discover_apps)
 
-    async def _create_db_and_tables(self):
+    # ── Convenience properties ─────────────────────────────────────────────
+
+    @property
+    def theme(self) -> str:
+        """Active theme from settings."""
+        return self.settings.theme
+
+    # ── Validation helpers ─────────────────────────────────────────────────
+
+    def _validate_session_secret(self) -> None:
+        """Enforce session secret security policy when auth is enabled."""
+        if not self.auth_backend:
+            return
+        if not self.settings.is_default_secret_key:
+            return
+        if self.settings.debug:
+            logger.warning(
+                "Using default session secret. Set HYPERADMIN_SECRET_KEY for production."
+            )
+        else:
+            msg = (
+                "Auth is enabled but no secret_key is configured. "
+                "Set HYPERADMIN_SECRET_KEY (or pass HyperAdminSettings(secret_key=...))."
+            )
+            raise ValueError(msg)
+
+    # ── Internal helpers ───────────────────────────────────────────────────
+
+    async def _create_db_and_tables(self) -> None:
         """Creates the database and all tables using the configured engine."""
         async with self.engine.begin() as conn:
             await conn.run_sync(SQLModel.metadata.create_all)
@@ -150,7 +168,7 @@ class Admin:
         )
         self.app.add_middleware(
             SessionMiddleware,
-            secret_key=self.session_secret or "hyperadmin-default-secret",
+            secret_key=self.settings.secret_key,
         )
 
     async def _sync_permissions(self) -> None:
@@ -174,7 +192,9 @@ class Admin:
         self._register_views()
         self.templates.env.globals["admin_prefix"] = path.rstrip("/")
         self.templates.env.globals["auth_enabled"] = self.auth_backend is not None
-        self.templates.env.globals["theme"] = self.theme
+        self.templates.env.globals["theme"] = self.settings.theme
+        self.templates.env.globals["site_title"] = self.settings.site_title
+        self.templates.env.globals["site_header"] = self.settings.site_header
 
         if self.auth_backend:
             self.router.on_startup.append(self._sync_permissions)

--- a/src/hyperadmin/core/settings.py
+++ b/src/hyperadmin/core/settings.py
@@ -1,0 +1,80 @@
+"""Centralised configuration for HyperAdmin via pydantic-settings BaseSettings."""
+
+from typing import Literal
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_DEFAULT_SECRET_KEY = "hyperadmin-default-secret"
+_DEFAULT_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+ThemeLiteral = Literal["auto", "light", "dark"]
+
+
+class HyperAdminSettings(BaseSettings):
+    """Django-like centralised settings for HyperAdmin.
+
+    All scalar configuration lives here — no duplicate params on ``Admin()``.
+    Values can be provided via environment variables (``HYPERADMIN_*`` prefix),
+    a ``.env`` file, or explicit keyword arguments (highest priority).
+
+    Example::
+
+        settings = HyperAdminSettings(secret_key="my-secret", theme="dark")
+        Admin(app, engine=engine, settings=settings)
+
+        # Or rely entirely on env vars / .env:
+        Admin(app, engine=engine)
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="HYPERADMIN_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    # ── Branding ─────────────────────────────────────────────────────────────
+    site_title: str = "HyperAdmin"
+    site_header: str = "HyperAdmin"
+
+    # ── Security ─────────────────────────────────────────────────────────────
+    secret_key: str = Field(default=_DEFAULT_SECRET_KEY)
+
+    # ── Database ─────────────────────────────────────────────────────────────
+    database_url: str = _DEFAULT_DATABASE_URL
+
+    # ── Runtime behaviour ─────────────────────────────────────────────────────
+    debug: bool = False
+    create_tables: bool = True
+
+    # ── Discovery ─────────────────────────────────────────────────────────────
+    auto_discover: bool = False
+    discover_apps: list[str] = Field(default_factory=list)
+
+    # ── Templates ─────────────────────────────────────────────────────────────
+    template_dirs: list[str] = Field(default_factory=list)
+
+    # ── UI ────────────────────────────────────────────────────────────────────
+    theme: ThemeLiteral = "auto"
+    items_per_page: int = Field(default=20, gt=0)
+
+    # ── Formatting ────────────────────────────────────────────────────────────
+    date_format: str = "%Y-%m-%d"
+    datetime_format: str = "%Y-%m-%d %H:%M:%S"
+
+    # ── Derived helpers ───────────────────────────────────────────────────────
+    @property
+    def is_default_secret_key(self) -> bool:
+        """Return ``True`` when ``secret_key`` has not been changed from the default."""
+        return self.secret_key == _DEFAULT_SECRET_KEY
+
+    @field_validator("theme", mode="before")
+    @classmethod
+    def _validate_theme(cls, value: str) -> str:
+        valid = ("auto", "light", "dark")
+        if value not in valid:
+            msg = f"Invalid theme {value!r}. Must be one of {valid}"
+            raise ValueError(msg)
+        return value

--- a/tests/e2e/test_template_override.py
+++ b/tests/e2e/test_template_override.py
@@ -41,11 +41,12 @@ def override_app_dir() -> Iterator[Path]:
         (app_dir / "main.py").write_text("""
 from pathlib import Path
 from fastapi import FastAPI
-from hyperadmin import Admin
+from hyperadmin import Admin, HyperAdminSettings
 
 app = FastAPI()
 templates_dir = Path(__file__).parent / "templates"
-admin = Admin(app, discover_apps=['my_app'], template_dirs=[str(templates_dir)])
+settings = HyperAdminSettings(discover_apps=['my_app'], template_dirs=[str(templates_dir)])
+admin = Admin(app, settings=settings)
 admin.mount(path="/admin")
 """)
 

--- a/tests/unit/adapters/test_adapter_integration.py
+++ b/tests/unit/adapters/test_adapter_integration.py
@@ -5,6 +5,7 @@ from sqlmodel import Field, SQLModel
 
 from hyperadmin.core.model import ModelAdmin
 from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.db import create_db_and_tables
 from hyperadmin.main import Admin
 
@@ -36,7 +37,7 @@ async def test_list_view_integration():
     # Setup the app inside the test function
     app = FastAPI()
     # Disable the automatic table creation in the Admin class
-    admin = Admin(app, create_tables=False)
+    admin = Admin(app, settings=HyperAdminSettings(create_tables=False))
     admin.mount("/admin")
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/tests/unit/test_admin_prefix.py
+++ b/tests/unit/test_admin_prefix.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import FastAPI
 
 from hyperadmin.core.app import Admin
+from hyperadmin.core.settings import HyperAdminSettings
 
 
 @pytest.fixture
@@ -13,19 +14,28 @@ def mock_app():
     return MagicMock(spec=FastAPI)
 
 
-def test_mount_sets_admin_prefix(mock_app):
-    admin = Admin(app=mock_app, create_tables=False)
+@pytest.fixture
+def settings_no_tables():
+    return HyperAdminSettings(create_tables=False)
+
+
+def test_mount_sets_admin_prefix(
+    mock_app: MagicMock, settings_no_tables: HyperAdminSettings
+) -> None:
+    admin = Admin(app=mock_app, settings=settings_no_tables)
     admin.mount("/admin")
     assert admin.templates.env.globals["admin_prefix"] == "/admin"
 
 
-def test_mount_strips_trailing_slash(mock_app):
-    admin = Admin(app=mock_app, create_tables=False)
+def test_mount_strips_trailing_slash(
+    mock_app: MagicMock, settings_no_tables: HyperAdminSettings
+) -> None:
+    admin = Admin(app=mock_app, settings=settings_no_tables)
     admin.mount("/admin/")
     assert admin.templates.env.globals["admin_prefix"] == "/admin"
 
 
-def test_mount_root_path(mock_app):
-    admin = Admin(app=mock_app, create_tables=False)
+def test_mount_root_path(mock_app: MagicMock, settings_no_tables: HyperAdminSettings) -> None:
+    admin = Admin(app=mock_app, settings=settings_no_tables)
     admin.mount("/")
     assert admin.templates.env.globals["admin_prefix"] == ""

--- a/tests/unit/test_auth_middleware.py
+++ b/tests/unit/test_auth_middleware.py
@@ -49,17 +49,17 @@ def _build_auth_app(async_engine, register_models: bool = True):
     from hyperadmin.auth.permissions import ModelPermissionChecker, PermissionSyncService
     from hyperadmin.auth.session import SessionAuthBackend
     from hyperadmin.core.app import Admin
+    from hyperadmin.core.settings import HyperAdminSettings
 
     app = FastAPI()
     backend = SessionAuthBackend(engine=async_engine)
     admin = Admin(
         app,
         engine=async_engine,
-        create_tables=False,
+        settings=HyperAdminSettings(create_tables=False, secret_key="test-secret-key"),
         auth_backend=backend,
         permission_checker=ModelPermissionChecker(engine=async_engine),
         permission_registry=PermissionSyncService(engine=async_engine),
-        session_secret="test-secret-key",
     )
 
     if register_models:
@@ -87,9 +87,10 @@ def _build_no_auth_app(async_engine):
     from fastapi import FastAPI
 
     from hyperadmin.core.app import Admin
+    from hyperadmin.core.settings import HyperAdminSettings
 
     app = FastAPI()
-    admin = Admin(app, engine=async_engine, create_tables=False)
+    admin = Admin(app, engine=async_engine, settings=HyperAdminSettings(create_tables=False))
     admin.mount("/admin")
     return app
 

--- a/tests/unit/test_auth_protocols.py
+++ b/tests/unit/test_auth_protocols.py
@@ -80,18 +80,24 @@ class TestAdminAuthBackend:
     def test_admin_without_auth_backend(self):
         """Admin(app) still works without auth (backward compatible)."""
         from hyperadmin.core.app import Admin
+        from hyperadmin.core.settings import HyperAdminSettings
 
         app = FastAPI()
-        admin = Admin(app, create_tables=False)
+        admin = Admin(app, settings=HyperAdminSettings(create_tables=False))
         assert admin.auth_backend is None
 
     def test_admin_with_auth_backend(self):
         """Admin(app, auth_backend=backend) stores the backend."""
         from hyperadmin.core.app import Admin
+        from hyperadmin.core.settings import HyperAdminSettings
 
         app = FastAPI()
         mock_backend = AsyncMock()
-        admin = Admin(app, create_tables=False, auth_backend=mock_backend)
+        admin = Admin(
+            app,
+            settings=HyperAdminSettings(create_tables=False, secret_key="test-secret"),
+            auth_backend=mock_backend,
+        )
         assert admin.auth_backend is mock_backend
 
     def test_no_circular_imports(self):

--- a/tests/unit/test_auth_views.py
+++ b/tests/unit/test_auth_views.py
@@ -85,6 +85,7 @@ def _build_app(async_engine, with_auth: bool = True):
     from hyperadmin.auth.session import SessionAuthBackend
     from hyperadmin.core.app import Admin
     from hyperadmin.core.registry import site
+    from hyperadmin.core.settings import HyperAdminSettings
 
     # Clear registry to avoid conflicts
     site._registry.clear()
@@ -96,14 +97,13 @@ def _build_app(async_engine, with_auth: bool = True):
         admin = Admin(
             app,
             engine=async_engine,
-            create_tables=False,
+            settings=HyperAdminSettings(create_tables=False, secret_key="test-secret"),
             auth_backend=backend,
             permission_checker=ModelPermissionChecker(engine=async_engine),
             permission_registry=PermissionSyncService(engine=async_engine),
-            session_secret="test-secret",
         )
     else:
-        admin = Admin(app, engine=async_engine, create_tables=False)
+        admin = Admin(app, engine=async_engine, settings=HyperAdminSettings(create_tables=False))
 
     from hyperadmin.core.model import ModelAdmin
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,5 +1,6 @@
 """Unit tests for the hyperadmin.core module."""
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -8,6 +9,7 @@ from sqlmodel import SQLModel
 
 from hyperadmin import core
 from hyperadmin.core.app import Admin
+from hyperadmin.core.settings import HyperAdminSettings
 
 
 def test_import_core() -> None:
@@ -16,51 +18,77 @@ def test_import_core() -> None:
 
 
 @pytest.fixture
-def mock_fastapi_app():
+def mock_fastapi_app() -> MagicMock:
     return MagicMock(spec=FastAPI)
 
 
-def test_admin_template_dirs(mock_fastapi_app):
-    # Arrange
+# ---------------------------------------------------------------------------
+# Template dirs
+# ---------------------------------------------------------------------------
+
+
+def test_admin_template_dirs(mock_fastapi_app: MagicMock) -> None:
     custom_template_dir = "/my/custom/templates"
+    settings = HyperAdminSettings(template_dirs=[custom_template_dir])
 
-    # Act
-    admin = Admin(app=mock_fastapi_app, template_dirs=[custom_template_dir])
+    admin = Admin(app=mock_fastapi_app, settings=settings)
 
-    # Assert
     assert custom_template_dir in admin.templates.env.loader.searchpath
 
 
-def test_admin_discover_apps(mock_fastapi_app):
-    # Arrange
+# ---------------------------------------------------------------------------
+# App discovery
+# ---------------------------------------------------------------------------
+
+
+def test_admin_discover_apps(mock_fastapi_app: MagicMock) -> None:
     apps_to_discover = ["app1", "app2"]
+    settings = HyperAdminSettings(discover_apps=apps_to_discover)
 
-    # Act
-    with patch("hyperadmin.core.app.discover_admin_modules") as mock_discover_admin_modules:
-        Admin(app=mock_fastapi_app, discover_apps=apps_to_discover)
+    with patch("hyperadmin.core.app.discover_admin_modules") as mock_discover:
+        Admin(app=mock_fastapi_app, settings=settings)
 
-        # Assert
-        mock_discover_admin_modules.assert_called_once_with(apps_to_discover)
+        mock_discover.assert_called_once_with(apps_to_discover)
+
+
+def test_admin_no_discover_when_empty(mock_fastapi_app: MagicMock) -> None:
+    settings = HyperAdminSettings(discover_apps=[])
+
+    with patch("hyperadmin.core.app.discover_admin_modules") as mock_discover:
+        Admin(app=mock_fastapi_app, settings=settings)
+
+        mock_discover.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# create_tables
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_admin_create_tables(mock_fastapi_app):
-    # Arrange
+async def test_admin_create_tables(mock_fastapi_app: MagicMock) -> None:
     mock_engine = MagicMock()
     mock_conn = AsyncMock()
     mock_engine.begin.return_value.__aenter__.return_value = mock_conn
-    Admin(app=mock_fastapi_app, create_tables=True, engine=mock_engine)
+    settings = HyperAdminSettings(create_tables=True)
+    Admin(app=mock_fastapi_app, engine=mock_engine, settings=settings)
 
-    # Act
     mock_fastapi_app.on_event.assert_called_once_with("startup")
     decorator = mock_fastapi_app.on_event.return_value
     decorator.assert_called_once()
     startup_handler = decorator.call_args[0][0]
     await startup_handler()
 
-    # Assert
     mock_engine.begin.assert_called_once()
     mock_conn.run_sync.assert_called_once_with(SQLModel.metadata.create_all)
+
+
+@pytest.mark.anyio
+async def test_admin_no_create_tables_when_disabled(mock_fastapi_app: MagicMock) -> None:
+    settings = HyperAdminSettings(create_tables=False)
+    Admin(app=mock_fastapi_app, settings=settings)
+
+    mock_fastapi_app.on_event.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -69,26 +97,110 @@ async def test_admin_create_tables(mock_fastapi_app):
 
 
 @pytest.mark.parametrize("theme", ["auto", "light", "dark"])
-def test_admin_theme_valid(mock_fastapi_app, theme):
-    """Valid theme values are accepted and stored on the Admin instance."""
-    admin = Admin(app=mock_fastapi_app, theme=theme)
+def test_admin_theme_valid(mock_fastapi_app: MagicMock, theme: str) -> None:
+    settings = HyperAdminSettings(theme=theme)  # type: ignore[arg-type]
+    admin = Admin(app=mock_fastapi_app, settings=settings)
     assert admin.theme == theme
 
 
-def test_admin_theme_default(mock_fastapi_app):
-    """Default theme is 'auto' when not specified."""
+def test_admin_theme_default(mock_fastapi_app: MagicMock) -> None:
     admin = Admin(app=mock_fastapi_app)
     assert admin.theme == "auto"
 
 
-def test_admin_theme_invalid(mock_fastapi_app):
-    """Invalid theme value raises ValueError."""
-    with pytest.raises(ValueError, match="Invalid theme"):
-        Admin(app=mock_fastapi_app, theme="neon")
+def test_admin_theme_invalid(mock_fastapi_app: MagicMock) -> None:
+    with pytest.raises(Exception, match="[Ii]nvalid theme|neon"):
+        HyperAdminSettings(theme="neon")  # type: ignore[arg-type]
 
 
-def test_admin_theme_exposed_to_templates(mock_fastapi_app):
-    """The theme value is available as a Jinja2 template global."""
-    admin = Admin(app=mock_fastapi_app, theme="dark")
+def test_admin_theme_exposed_to_templates(mock_fastapi_app: MagicMock) -> None:
+    settings = HyperAdminSettings(theme="dark")
+    admin = Admin(app=mock_fastapi_app, settings=settings)
     admin.mount("/admin")
     assert admin.templates.env.globals["theme"] == "dark"
+
+
+# ---------------------------------------------------------------------------
+# Settings auto-instantiation
+# ---------------------------------------------------------------------------
+
+
+def test_admin_auto_instantiates_settings(mock_fastapi_app: MagicMock) -> None:
+    admin = Admin(app=mock_fastapi_app)
+    assert isinstance(admin.settings, HyperAdminSettings)
+
+
+def test_admin_uses_provided_settings(mock_fastapi_app: MagicMock) -> None:
+    settings = HyperAdminSettings(site_title="My ERP")
+    admin = Admin(app=mock_fastapi_app, settings=settings)
+    assert admin.settings.site_title == "My ERP"
+
+
+# ---------------------------------------------------------------------------
+# Session secret security (#378)
+# ---------------------------------------------------------------------------
+
+
+def test_admin_warns_on_default_secret_in_debug_with_auth(
+    mock_fastapi_app: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Warning logged when using default secret + auth enabled + debug mode."""
+    mock_auth = MagicMock()
+    settings = HyperAdminSettings(debug=True)  # default secret_key
+
+    with caplog.at_level(logging.WARNING, logger="hyperadmin"):
+        Admin(app=mock_fastapi_app, settings=settings, auth_backend=mock_auth)
+
+    assert any("default session secret" in r.message.lower() for r in caplog.records)
+
+
+def test_admin_raises_on_default_secret_in_production_with_auth(
+    mock_fastapi_app: MagicMock,
+) -> None:
+    """ValueError raised when auth enabled + default secret + debug=False."""
+    mock_auth = MagicMock()
+    settings = HyperAdminSettings(debug=False)  # default secret_key
+
+    with pytest.raises(ValueError, match="[Ss]ecret|HYPERADMIN_SECRET_KEY"):
+        Admin(app=mock_fastapi_app, settings=settings, auth_backend=mock_auth)
+
+
+def test_admin_no_warning_when_secret_set_with_auth(
+    mock_fastapi_app: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No warning or error when explicit secret_key is provided."""
+    mock_auth = MagicMock()
+    settings = HyperAdminSettings(secret_key="my-production-secret", debug=True)
+
+    with caplog.at_level(logging.WARNING, logger="hyperadmin"):
+        Admin(app=mock_fastapi_app, settings=settings, auth_backend=mock_auth)
+
+    assert not any("default session secret" in r.message.lower() for r in caplog.records)
+
+
+def test_admin_no_warning_without_auth(
+    mock_fastapi_app: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No warning when auth is not enabled (even with default secret)."""
+    settings = HyperAdminSettings(debug=True)
+
+    with caplog.at_level(logging.WARNING, logger="hyperadmin"):
+        Admin(app=mock_fastapi_app, settings=settings)
+
+    assert not any("default session secret" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Template globals from settings
+# ---------------------------------------------------------------------------
+
+
+def test_admin_site_title_in_template_globals(mock_fastapi_app: MagicMock) -> None:
+    settings = HyperAdminSettings(site_title="ERP Admin", theme="light")
+    admin = Admin(app=mock_fastapi_app, settings=settings)
+    admin.mount("/admin")
+    assert admin.templates.env.globals["site_title"] == "ERP Admin"
+    assert admin.templates.env.globals["theme"] == "light"

--- a/tests/unit/test_create_integrity_error.py
+++ b/tests/unit/test_create_integrity_error.py
@@ -10,6 +10,7 @@ from sqlmodel import Field, SQLModel
 from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 from hyperadmin.core.model import ModelAdmin
 from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.main import Admin
 
 
@@ -42,7 +43,7 @@ def client():
 
     anyio.run(setup_database)
 
-    admin = Admin(app=app, create_tables=False, engine=engine)
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
     site.register(UniqueUser, UniqueUserAdmin)
     admin.mount(path="/admin")
 

--- a/tests/unit/test_create_view.py
+++ b/tests/unit/test_create_view.py
@@ -10,6 +10,7 @@ from sqlmodel import Field, SQLModel
 from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 from hyperadmin.core.model import ModelAdmin
 from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.main import Admin
 
 
@@ -45,7 +46,7 @@ def client():
 
     anyio.run(setup_database)
 
-    admin = Admin(app=app, create_tables=False, engine=engine)
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
     site.register(ProductTest, ProductTestAdmin)
     admin.mount(path="/admin")
 

--- a/tests/unit/test_delete_action.py
+++ b/tests/unit/test_delete_action.py
@@ -10,6 +10,7 @@ from sqlmodel import Field, SQLModel
 from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 from hyperadmin.core.model import ModelAdmin
 from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.main import Admin
 
 
@@ -50,7 +51,7 @@ def client():
 
     anyio.run(setup_database)
 
-    admin = Admin(app=app, create_tables=False, engine=engine)
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
     site.register(ProductTestDelete, ProductTestDeleteAdmin)
     admin.mount(path="/admin")
 

--- a/tests/unit/test_detail_view.py
+++ b/tests/unit/test_detail_view.py
@@ -10,6 +10,7 @@ from sqlmodel import Field, SQLModel
 from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 from hyperadmin.core.model import ModelAdmin
 from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.main import Admin
 
 
@@ -54,7 +55,7 @@ def client():
 
     anyio.run(setup_database)
 
-    admin = Admin(app=app, create_tables=False, engine=engine)
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
     site.register(ProductTestDetail, ProductTestDetailAdmin)
     admin.mount(path="/admin")
 

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -12,6 +12,7 @@ from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 from hyperadmin.core.model import ModelAdmin
 from hyperadmin.core.options import AdminOptions
 from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.main import Admin
 from hyperadmin.routing import HyperAdminRouter, create_admin_router
 
@@ -63,7 +64,7 @@ def client_factory():
 
         anyio.run(setup_database)
 
-        admin = Admin(app=app, create_tables=False, engine=engine)
+        admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
         site.register(Product, ProductAdmin, options=options or AdminOptions())
         admin.mount(path="/admin")
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,121 @@
+"""Unit tests for HyperAdminSettings — env loading, validation, defaults."""
+
+import pytest
+from pydantic import ValidationError
+
+from hyperadmin.core.settings import HyperAdminSettings
+
+_DEFAULT_SECRET = "hyperadmin-default-secret"
+_DEFAULT_DB_URL = "sqlite+aiosqlite:///:memory:"
+
+
+class TestDefaults:
+    def test_all_fields_have_defaults(self) -> None:
+        settings = HyperAdminSettings()
+        assert settings.site_title == "HyperAdmin"
+        assert settings.site_header == "HyperAdmin"
+        assert settings.secret_key == _DEFAULT_SECRET
+        assert settings.database_url == _DEFAULT_DB_URL
+        assert settings.debug is False
+        assert settings.auto_discover is False
+        assert settings.discover_apps == []
+        assert settings.template_dirs == []
+        assert settings.create_tables is True
+        assert settings.theme == "auto"
+        assert settings.items_per_page == 20
+        assert settings.date_format == "%Y-%m-%d"
+        assert settings.datetime_format == "%Y-%m-%d %H:%M:%S"
+
+    def test_is_default_secret_key_true_when_using_default(self) -> None:
+        settings = HyperAdminSettings()
+        assert settings.is_default_secret_key is True
+
+    def test_is_default_secret_key_false_when_explicit(self) -> None:
+        settings = HyperAdminSettings(secret_key="my-production-secret")
+        assert settings.is_default_secret_key is False
+
+
+class TestEnvVarLoading:
+    def test_site_title_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_SITE_TITLE", "My App")
+        settings = HyperAdminSettings()
+        assert settings.site_title == "My App"
+
+    def test_database_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_DATABASE_URL", "sqlite+aiosqlite:///prod.db")
+        settings = HyperAdminSettings()
+        assert settings.database_url == "sqlite+aiosqlite:///prod.db"
+
+    def test_secret_key_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_SECRET_KEY", "env-secret")
+        settings = HyperAdminSettings()
+        assert settings.secret_key == "env-secret"
+        assert settings.is_default_secret_key is False
+
+    def test_debug_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_DEBUG", "true")
+        settings = HyperAdminSettings()
+        assert settings.debug is True
+
+    def test_theme_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_THEME", "dark")
+        settings = HyperAdminSettings()
+        assert settings.theme == "dark"
+
+    def test_items_per_page_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_ITEMS_PER_PAGE", "50")
+        settings = HyperAdminSettings()
+        assert settings.items_per_page == 50
+
+    def test_create_tables_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_CREATE_TABLES", "false")
+        settings = HyperAdminSettings()
+        assert settings.create_tables is False
+
+    def test_discover_apps_from_env_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_DISCOVER_APPS", '["myapp", "otherapp"]')
+        settings = HyperAdminSettings()
+        assert settings.discover_apps == ["myapp", "otherapp"]
+
+    def test_explicit_kwarg_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_SECRET_KEY", "env-value")
+        settings = HyperAdminSettings(secret_key="explicit")
+        assert settings.secret_key == "explicit"
+
+
+class TestValidation:
+    def test_invalid_theme_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            HyperAdminSettings(theme="neon")
+
+    def test_valid_themes_accepted(self) -> None:
+        for theme in ("auto", "light", "dark"):
+            s = HyperAdminSettings(theme=theme)
+            assert s.theme == theme
+
+    def test_invalid_theme_from_env_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_THEME", "neon")
+        with pytest.raises(ValidationError):
+            HyperAdminSettings()
+
+    def test_items_per_page_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            HyperAdminSettings(items_per_page=0)
+
+    def test_items_per_page_negative_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            HyperAdminSettings(items_per_page=-5)
+
+
+class TestDotEnvFile:
+    def test_loads_from_dotenv_file(
+        self, tmp_path: "pytest.TempPathFactory", monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("HYPERADMIN_SECRET_KEY=file-secret\nHYPERADMIN_THEME=dark\n")
+        monkeypatch.chdir(tmp_path)
+        # pydantic-settings reads .env relative to cwd
+        settings = HyperAdminSettings(_env_file=str(env_file))
+        assert settings.secret_key == "file-secret"
+        assert settings.theme == "dark"
+        assert settings.is_default_secret_key is False

--- a/tests/unit/test_update_view.py
+++ b/tests/unit/test_update_view.py
@@ -10,6 +10,7 @@ from sqlmodel import Field, SQLModel
 from hyperadmin.adapters.sqlmodel import SQLModelAdapter
 from hyperadmin.core.model import ModelAdmin
 from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
 from hyperadmin.main import Admin
 
 
@@ -55,7 +56,7 @@ def client():
 
     anyio.run(setup_database)
 
-    admin = Admin(app=app, create_tables=False, engine=engine)
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
     site.register(ProductTestUpdate, ProductTestUpdateAdmin)
     admin.mount(path="/admin")
 


### PR DESCRIPTION
## Summary

- **#375** — Add `pydantic-settings>=2.0` dep; new `HyperAdminSettings(BaseSettings)` in `core/settings.py` with `HYPERADMIN_` env prefix, `.env` file support, and validation (theme enum, `items_per_page > 0`)
- **#376** — Refactor `Admin.__init__()`: remove 5 scalar params (`session_secret`, `theme`, `create_tables`, `discover_apps`, `template_dirs`); add `settings: HyperAdminSettings | None = None` (auto-instantiated if None); expose `site_title`/`site_header` to Jinja2 globals
- **#377** — `db.py` engine now created from `settings.database_url` and `settings.debug` (no more hardcoded SQLite URL)
- **#378** — Secure session secret: warning in debug mode, `ValueError` in production when auth enabled without explicit `secret_key`
- **#379** — 18 new unit tests in `tests/unit/test_settings.py` covering env var loading, `.env` file, validation, defaults; all existing tests migrated to new API
- **#380** — `examples/erp/main.py` and `examples/simple/main.py` updated to `HyperAdminSettings`-based API

### Breaking change

`Admin.__init__()` no longer accepts `session_secret`, `theme`, `create_tables`, `discover_apps`, `template_dirs` as direct kwargs — these must be passed via `HyperAdminSettings(...)`.

## Test plan

- [x] `uv run poe lint` — all green (ruff, mypy, basedpyright, commitizen)
- [x] `uv run pytest tests/unit/ -q` — 430 passed, 0 failed
- [ ] E2E tests run on CI (`poe test:e2e`)

Closes #375, #376, #377, #378, #379, #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)