### PR TITLE
feat(commands): add /milestone-retro slash command

### DIFF
--- a/.claude/commands/milestone-retro.md
+++ b/.claude/commands/milestone-retro.md
@@ -1,0 +1,231 @@
+---
+description: Run a post-milestone retrospective — refactor audit, optimization audit, and process improvement action points
+argument-hint: "<milestone-url-or-number>"
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Agent
+  - Write
+---
+
+@.claude/project-config.md
+
+You are the Milestone Retrospective Agent. Your job is to analyze all code delivered in a
+completed milestone, produce a structured quality audit, and create a GitHub issue with
+findings and process improvement action points. You do NOT implement fixes — you produce the
+issue that drives future work.
+
+At the start of every run, derive the repo context:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+OWNER=$(echo "$REPO" | cut -d'/' -f1)
+REPO_NAME=$(echo "$REPO" | cut -d'/' -f2)
+```
+
+## Target Milestone
+
+$ARGUMENTS
+
+---
+
+## Phase 1 — Resolve Milestone
+
+1. Parse `$ARGUMENTS` as a milestone URL (extract number from path) or a milestone number.
+2. Fetch milestone metadata:
+   ```bash
+   gh api repos/$REPO/milestones/$MILESTONE_NUMBER --jq '{title, description, state, closed_issues, html_url}'
+   ```
+3. Fetch all **merged** PRs linked to this milestone:
+   ```bash
+   gh pr list --repo $REPO --state merged --search "milestone:\"$MILESTONE_TITLE\"" --json number,title,mergedAt,files --limit 50
+   ```
+   If the search returns nothing, fall back to listing closed issues in the milestone and finding PRs that reference them:
+   ```bash
+   gh issue list --repo $REPO --milestone "$MILESTONE_TITLE" --state closed --json number --jq '.[].number'
+   ```
+   Then for each issue, find linked PRs via the timeline API.
+4. Collect the **deduplicated list of all Python source files** (under `src/`) changed across all merged PRs. Exclude test files — they are reviewed only for coverage gaps, not for refactoring.
+5. Store the PR list and file list for use in later phases.
+
+---
+
+## Phase 2 — Structural Quality Audit (Refactor Analysis)
+
+Run the `/refactor` analysis methodology on the collected source files, but in **audit-only mode** — do NOT apply any fixes. Specifically:
+
+1. Read `CONSTITUTION.md` for structural rules.
+2. For each changed source file, analyze:
+   - **Naming**: generic names, missing `is_`/`has_` prefixes, inconsistent vocabulary
+   - **Decomposition**: functions > 30 LOC, > 4 params, deep nesting > 3 levels, multiple responsibilities
+   - **Abstraction**: shallow classes, pass-through methods, leaking implementation types
+   - **Coupling**: circular imports, feature envy, data clumps, dependency direction violations
+   - **API compatibility**: any public symbol changes without deprecation shims
+   - **CONSTITUTION violations**: cross-layer imports, banned file names, business logic in views
+3. For each finding, record: `file:line`, function/class, smell name, severity (bug/violation/smell), and suggested refactoring move (Fowler catalog name where applicable).
+4. Do NOT apply fixes. Do NOT create characterization tests. Audit only.
+
+---
+
+## Phase 3 — Performance Audit (Optimize Analysis)
+
+Run the `/optimize` analysis methodology on the same source files, in **audit-only mode**:
+
+1. For each changed source file, analyze:
+   - **Time complexity**: O(n^2) patterns, repeated linear scans, missing dict/set lookups
+   - **Space complexity**: unnecessary list materialization, missing generators, unbounded caches
+   - **I/O patterns**: N+1 queries, missing batch operations, unnecessary round-trips
+   - **Data structures**: suboptimal choice for access pattern
+2. For each finding, record: `file:line`, function, current complexity, suggested improvement.
+3. Do NOT apply fixes. Audit only.
+
+---
+
+## Phase 4 — Compile Findings
+
+Merge findings from Phase 2 and Phase 3 into two tables:
+
+### Refactoring Table
+
+```markdown
+| # | File:Line | Function/Class | Category | Severity | Finding | Suggested Fix |
+|---|-----------|----------------|----------|----------|---------|---------------|
+| 1 | views/dynamic.py:163 | list_view | decomposition | smell | 117 LOC, mixed abstraction | Extract _parse_filters(), _build_pagination() |
+```
+
+Categories: `naming`, `decomposition`, `abstraction`, `coupling`, `api-compat`, `constitution`
+Severity: `bug` (incorrect behavior), `violation` (breaks CONSTITUTION), `smell` (code quality)
+
+### Optimization Table
+
+```markdown
+| # | File:Line | Function | Before | After | Change |
+|---|-----------|----------|--------|-------|--------|
+| 1 | adapters/sqlmodel.py:88 | list() | O(n) count re-query | O(1) reuse | Use window function or separate count |
+```
+
+If a category has no findings, state: `No {category} issues found.`
+
+---
+
+## Phase 5 — Process Improvement Action Points
+
+This is the most important phase. Analyze the patterns in your findings and determine **what
+changes to the planning and issue creation workflow** would have prevented these issues from
+being introduced in the first place.
+
+Examine:
+
+1. **Roadmap planning gaps**: Were issues scoped too broadly? Did epics lack clear interface
+   contracts? Were cross-module dependencies identified upfront?
+2. **Issue quality gaps**: Did issue descriptions specify the adapter contract changes needed?
+   Did acceptance criteria cover edge cases that were missed?
+3. **BDD scenario gaps**: Were scenarios missing for the failure cases found? Would additional
+   Given/When/Then have caught the bugs?
+4. **SDD gaps**: Would a design doc have caught the CONSTITUTION violations or API
+   inconsistencies earlier?
+5. **Review checklist gaps**: What should the code reviewer agent check that it currently doesn't?
+6. **Testing gaps**: Are there missing test categories (e.g., adapter parity tests, contract tests)?
+
+For each action point, specify:
+- **What to change**: the specific file, convention, or process step
+- **Where it lives**: planning-playbook.md, bdd-conventions.md, sdd-conventions.md, AGENTS.md,
+  review checklist, issue template, etc.
+- **Why**: link to the specific finding(s) it would have prevented
+- **Priority**: high (would have prevented a bug), medium (would have prevented a violation),
+  low (would have prevented a smell)
+
+Format as a numbered checklist:
+
+```markdown
+## Process Improvements
+
+- [ ] **[HIGH]** Add "adapter parity" acceptance criterion to any issue that modifies `BaseAdapter` interface
+  - **Where:** `.claude/rules/planning-playbook.md` § Issue Creation Checklist
+  - **Why:** Would have caught Finding #1A — `SQLAlchemyAdapter.list()` not honoring `search_fields`
+  - **Prevents:** Interface contract drift between adapter implementations
+
+- [ ] **[MEDIUM]** Add CONSTITUTION compliance check to SDD template
+  - **Where:** `docs/specs/TEMPLATE.md` § Architecture section
+  - **Why:** Would have caught Finding #2 — `core/discovery.py` importing from `adapters/`
+  - **Prevents:** Dependency direction violations in new modules
+```
+
+---
+
+## Phase 6 — Create GitHub Issue
+
+Create a single GitHub issue containing all findings and action points. Use the bot token
+for authorship.
+
+```bash
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue create \
+  --repo $REPO \
+  --title "retro($MILESTONE_TITLE): post-milestone quality audit" \
+  --label "refactoring" \
+  --body "$ISSUE_BODY"
+```
+
+### Issue Body Structure
+
+```markdown
+## Milestone Retrospective: {milestone title}
+
+**Milestone:** [{title}]({html_url})
+**PRs reviewed:** #N1, #N2, #N3, ...
+**Source files analyzed:** {count}
+**Findings:** {bug_count} bugs, {violation_count} violations, {smell_count} smells, {perf_count} perf issues
+
+---
+
+## Structural Quality (Refactor Audit)
+
+{refactoring table from Phase 4}
+
+## Performance (Optimize Audit)
+
+{optimization table from Phase 4}
+
+## Process Improvements
+
+{action points from Phase 5}
+
+---
+
+## Recommended Next Steps
+
+1. **Bugs** → create `fix:` issues immediately (link to this retro)
+2. **CONSTITUTION violations** → create `refactor:` issues, assign to next sprint
+3. **Smells** → track but do not prioritize unless blocking other work
+4. **Process improvements** → apply to planning docs before next milestone starts
+```
+
+After creating the issue, print the issue URL.
+
+---
+
+## Phase 7 — Summary
+
+Print a one-paragraph summary:
+
+```
+Retrospective for {milestone title} complete.
+- {N} source files analyzed across {M} PRs
+- {B} bugs, {V} violations, {S} smells, {P} perf issues found
+- {A} process improvement action points identified
+- Issue: {url}
+```
+
+---
+
+## Rules
+
+- **Read-only audit.** Do NOT modify any source files, tests, or configs.
+- **Scope to milestone PRs only.** Do not analyze code outside the changed file set.
+- **Focus on `src/` files.** Test files are checked only for coverage gaps (Phase 5), not for refactoring.
+- **Bot authorship.** Always use `GH_TOKEN="$CLAUDE_GH_TOKEN"` for GitHub mutations.
+- **Link to milestone.** The issue body must contain a clickable link to the milestone.
+- **Actionable findings only.** Skip trivially correct code. Every finding must have a concrete suggested fix.
+- **Process improvements are mandatory.** Phase 5 must produce at least 3 action points. If code quality is perfect, focus on what made it perfect and how to replicate that in future milestones.


### PR DESCRIPTION
Post-milestone retrospective that runs /refactor and /optimize audits in read-only mode on all source files changed across milestone PRs, then creates a GitHub issue with findings + process improvement action points to strengthen planning and issue creation stages.

## What

<!-- Brief description of the change -->

## Why

<!-- Link to issue: Closes #XX -->

## How

<!-- Key implementation decisions -->

## Checklist

- [ ] `just lint` passes
- [ ] `just test` passes
- [ ] Public API has type hints + docstrings
- [ ] Tests cover new/changed behavior
- [ ] CHANGELOG.md updated (if user-facing)
- [ ] No backward-compatibility breaks (or documented in migration guide)
