### PR TITLE
feat(ops): Docker-supervised conductor agent

### DIFF
--- a/.claude/commands/implement-feature.md
+++ b/.claude/commands/implement-feature.md
@@ -3,7 +3,9 @@ description: "Implement a GitHub issue end-to-end (redirects to the implement-fe
 argument-hint: "<issue-number>"
 ---
 
-This command has been replaced by the `implement-feature` skill, which adds:
+This command delegates to the `implement-feature` skill, which:
+- Starts in an isolated worktree via `/start`
+- Claims the issue (labels + project board)
 - Self-evaluating planning loop (validates plan against all project rules before writing any code)
 - Questionnaire gate (posts to the issue and stops if the plan has gaps)
 - Blocker protocol (searches memory, saves WIP as draft PR, halts with issue comment)

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -1,0 +1,43 @@
+---
+description: "Start work in a new isolated worktree branched from develop"
+argument-hint: "<branch-name>"
+---
+
+Start a new isolated worktree session for feature work. This ensures parallel agents
+don't collide and keeps the main working tree clean.
+
+## Steps
+
+1. **Pull latest develop**
+
+```bash
+git fetch origin develop
+```
+
+2. **Enter worktree**
+
+Use `EnterWorktree` with the branch name provided by the user: `$ARGUMENTS`
+
+If `$ARGUMENTS` is empty, generate a random name (e.g., `work/agent-<4-random-hex-chars>`).
+
+3. **Rebase onto develop**
+
+```bash
+git rebase origin/develop
+```
+
+4. **Bootstrap the environment**
+
+```bash
+uv sync --all-extras
+```
+
+5. **Confirm ready**
+
+Print a status summary:
+- Worktree path
+- Branch name
+- Base commit (short SHA + subject from develop)
+- Environment status (uv sync result)
+
+Then say: **Ready. What are we working on?**

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -16,10 +16,10 @@ gh issue view $ARGUMENTS
 ```
 Check `ROADMAP.md` to confirm priority and scope. Do not expand scope.
 
-### 2. Create branch (if not already on one)
-```bash
-git checkout -b issue-$ARGUMENTS
-```
+### 2. Start worktree
+
+Run `/start fix/issue-$ARGUMENTS` to create an isolated worktree branched from `develop`,
+rebase onto latest, and bootstrap the environment.
 
 ### 3. Explore before changing
 - Read relevant source files in `src/hyperadmin/`

--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -97,34 +97,13 @@ Evaluate every item below. Label each **PASS** or **FAIL**:
 
 ## Phase B — Implementation with Blocker Handling
 
-### B1. Create worktree and branch
+### B1. Start worktree
 
-Always work in an isolated worktree branched from the latest `develop`. Never commit or branch off whatever the current working tree happens to be on.
+Run `/start feat/issue-$ARGUMENTS` to create an isolated worktree branched from `develop`,
+rebase onto latest, and bootstrap the environment.
 
-```bash
-# Fetch latest develop first
-git fetch origin develop
-
-# Derive paths
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-WORKTREE_PATH="${REPO_ROOT}/../hyper-admin-issue-$ARGUMENTS"
-BRANCH_NAME="feat/issue-$ARGUMENTS"
-
-# Create worktree+branch, or resume and rebase if it already exists.
-# This project uses rebase-merge: every merged PR rewrites commit hashes on develop,
-# so any existing branch MUST be rebased from origin/develop before new work is added.
-if git worktree list | grep -qF "[$BRANCH_NAME]"; then
-  echo "Resuming existing worktree at $WORKTREE_PATH — rebasing onto origin/develop"
-  cd "$WORKTREE_PATH"
-  git rebase origin/develop
-else
-  git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" origin/develop
-  echo "Created new worktree at $WORKTREE_PATH"
-  cd "$WORKTREE_PATH"
-fi
-```
-
-All subsequent commands (file edits, `poe lint`, `poe test`, `uv run`, etc.) run from inside the worktree path `$WORKTREE_PATH`.
+All subsequent commands (file edits, `poe lint`, `poe test`, `uv run`, etc.) run from inside
+the worktree.
 
 If a draft PR already exists for this branch, resume from the rebased worktree state — do not restart.
 

--- a/docs/agentic-workflow/dev-agents.md
+++ b/docs/agentic-workflow/dev-agents.md
@@ -1,109 +1,257 @@
-# Dev Agents
+# Dev Agent
 
 | Property | Value |
 |---|---|
-| **Runtime** | Claude Code (all sizes) |
-| **Trigger** | Task dispatched from workload queue (GitHub Issue assigned) |
-| **Purpose** | Implement code changes according to task specification |
+| **Runtime** | Claude Code (Opus for size:M/L, Sonnet for size:S) |
+| **Trigger** | User runs `/implement-feature <issue>`, `/fix-issue <issue>`, or launches without arguments |
+| **Purpose** | Pick up GitHub issues, implement code changes, manage issue lifecycle end-to-end |
 | **Est. Cost** | 20k–100k tokens per implementation task |
 
-## Dispatch Strategy
+---
 
-All development tasks are dispatched by the **conductor agent** and executed by Claude Code in isolated git worktrees.
+## Core Behavior
+
+The dev agent is **proactive and self-directed**. It does not wait to be told what to do —
+it finds work, claims it, implements it, and drives the PR through to merge.
+
+### Invocation modes
+
+| Mode | What happens |
+|---|---|
+| `/implement-feature 375` | Implements issue #375 directly |
+| `/fix-issue 401` | Lightweight TDD fix for issue #401 |
+| No issue given | Runs the **work discovery** protocol (see below) |
+
+---
+
+## Work Discovery Protocol (no issue provided)
+
+When the dev agent starts without a specific issue number:
+
+### 1. Find the active milestone
+
+```bash
+gh api repos/{owner}/{repo}/milestones --jq '
+  sort_by(.due_on // .created_at)
+  | map(select(.state == "open"))
+  | .[0]
+  | {number, title, open_issues, due_on}'
+```
+
+If no open milestone exists, report that and stop.
+
+### 2. List ready tickets in that milestone
+
+```bash
+gh issue list \
+  --milestone "<milestone-title>" \
+  --label "agent-task" \
+  --state open \
+  --json number,title,labels,assignees \
+  --jq '[.[] | select(.assignees | length == 0)]'
+```
+
+Prioritize by:
+1. Issues with `blocked_by` dependencies already closed (unblocked)
+2. Issues labeled `size:S` before `size:M` before `size:L`
+3. Issues with higher priority labels (`P0` > `P1` > `P2` > `P3`)
+
+If no `agent-task` issues are unassigned, fall back to any unassigned issue in the milestone.
+
+### 3. Present the pick to the user
 
 ```
-Incoming task from workload queue
-  │
-  ├── size:S → fix-issue skill (lightweight TDD loop)
-  ├── size:M → implement-feature skill (full self-eval loop)
-  └── size:L → implement-feature skill + human checkpoint gate
+Found 4 ready tickets in v0.3.0 — Zero-Config & Auth:
+
+  #363  feat(core): model introspection utility          size:M  P1
+  #364  feat(core): infer list_display                   size:S  P1
+  #365  feat(core): infer search_fields                  size:S  P1
+  #368  feat(core): extend AdminOptions None defaults    size:S  P2
+
+Start with #364? (Y / pick another / skip)
 ```
 
-### fix-issue skill (size:S)
+On confirmation, proceed to implementation.
 
-- One-liner fixes, small utility functions, config tweaks
-- Lightweight loop: branch → explore → test-first → implement → lint+test → PR
-- Runs in an isolated worktree dispatched by the conductor
-- Example: "Add a `--verbose` flag to the CLI parser"
+---
 
-### implement-feature skill (size:M)
+## Issue Lifecycle Management
 
-- Core dev agent for most implementation work
-- Full self-evaluating loop: plan → validate against 16+ checklist items → TDD → PR
-- Blocker protocol: searches agent memory, saves WIP as draft PR, halts with issue comment
-- Runs in an isolated worktree dispatched by the conductor
-- Example: "Implement `RetryPolicy` class with exponential backoff and jitter"
+The dev agent owns the full lifecycle of every issue it works on.
+All label and project board mutations happen **automatically** — never deferred.
 
-### implement-feature + human checkpoint (size:L)
+### Label transitions
 
-- Complex tasks requiring deep architectural reasoning
-- Conductor pauses after planning phase and presents plan to human for approval
-- Human approves or adjusts scope before implementation begins
-- Example: "Redesign the plugin system to support async hooks"
+| Event | Action |
+|---|---|
+| Agent claims issue | Add `in-progress`, remove `ready` if present, assign self |
+| Planning gate fails (questionnaire posted) | Add `needs-clarification`, keep `in-progress` |
+| Blocker hit (draft PR + comment) | Add `blocked`, keep `in-progress` |
+| PR created | Add `review` label to the PR |
+| PR merged | Remove `in-progress`, add `done` |
+| Issue closed | Ensure `done` is present |
 
-## TDD-First Execution
+```bash
+# Claim
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue edit <number> \
+  --remove-label "ready" --add-label "in-progress"
 
-Dev agents must strictly follow the TDD order:
+# Blocker
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue edit <number> \
+  --add-label "blocked"
 
-1. **Test Task**: Write tests in the appropriate directory (`tests/`). Verify they fail.
-2. **Implementation Task**: Write minimal code in `src/` to pass the tests. Verify with `just test`.
+# PR ready for review
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh pr edit <pr-number> \
+  --add-label "review"
 
-## Task Dispatch Protocol
-
-Each task (GitHub Issue) includes a structured body:
-
-```markdown
-## Task specification
-
-**Scope**: `src/core/retry.py` (new file)
-**Size**: M
-
-## Acceptance criteria
-- [ ] `RetryPolicy` dataclass with: max_retries, backoff_factor, jitter
-- [ ] `retry_with_backoff()` async decorator
-- [ ] Type hints on all public API
-- [ ] Docstrings with examples
-
-## Context for agent
-The HTTP client in `src/core/http.py` needs retry capability.
-See the base client class `HttpClient` for the interface.
-
-## Pre-commit requirements
-- ruff format + ruff check must pass
-- mypy --strict must pass
-- pytest must pass with >80% coverage on new code
+# After merge
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue edit <number> \
+  --remove-label "in-progress" --add-label "done"
 ```
+
+### Project board status updates
+
+The dev agent updates the GitHub ProjectV2 board status at each transition:
+
+| Event | Board status |
+|---|---|
+| Agent claims issue | `In progress` |
+| PR merged / issue closed | `Done` |
+
+```bash
+# Move to "In progress"
+gh api graphql -f query='mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "<PROJECT_ID>"
+    itemId: "<ITEM_ID>"
+    fieldId: "<STATUS_FIELD_ID>"
+    value: { singleSelectOptionId: "<IN_PROGRESS_OPTION_ID>" }
+  }) { projectV2Item { id } }
+}'
+```
+
+Use the cached IDs from agent memory (`reference_github_ids.md`) to avoid redundant API lookups.
+
+### Issue comments
+
+The agent posts structured comments at every significant state change:
+
+- **Claimed**: "Starting work on this issue. Branch: `feat/issue-<N>`"
+- **Plan ready**: Summary of implementation plan (sub-tasks, files to touch)
+- **Blocker**: Detailed blocker description with specific unblock request
+- **PR opened**: Link to PR with brief description of changes
+- **PR merged**: "Completed. Merged via PR #<N>."
+
+---
+
+## Execution Flow
+
+```
+1. /start feat/issue-<N>         ← isolated worktree + env bootstrap
+2. Claim issue (labels + board)
+3. Phase A: Planning loop         ← read issue, plan, self-evaluate
+4. Phase B: TDD implementation    ← test-first, blocker protocol
+5. Phase C: Submission            ← lint, test, commit, PR
+6. Phase D: PR monitor cron       ← CI fix, review changes, auto-merge
+7. Issue closed on merge          ← labels + board updated
+```
+
+### Step 1 — Start worktree
+
+Every implementation begins with `/start`:
+
+```
+/start feat/issue-<N>
+```
+
+This creates an isolated worktree from `develop`, rebases, bootstraps `uv sync --all-extras`,
+and confirms the environment is ready.
+
+### Step 2 — Claim the issue
+
+Immediately after entering the worktree:
+
+```bash
+GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue edit <N> \
+  --remove-label "ready" --add-label "in-progress"
+gh issue comment <N> --body "Starting work. Branch: \`feat/issue-<N>\`"
+```
+
+Update the project board status to "In progress".
+
+### Steps 3–6 — Planning, implementation, submission, monitoring
+
+These phases are defined in the skill files:
+
+| Size | Skill | Behavior |
+|---|---|---|
+| `size:S` | `fix-issue` | Lightweight TDD loop, no self-eval gate |
+| `size:M` | `implement-feature` | Full self-evaluating plan, TDD, blocker protocol, PR monitor |
+| `size:L` | `implement-feature` + human checkpoint | Plan presented to user for approval before implementation |
+
+See:
+- `.claude/skills/implement-feature/SKILL.md` — full agentic workflow
+- `.claude/skills/fix-issue/SKILL.md` — lightweight workflow
+
+### Step 7 — Post-merge cleanup
+
+The PR monitor cron (Phase D of `implement-feature`) handles:
+1. Closing the issue with a comment linking the merged PR
+2. Removing `in-progress`, adding `done`
+3. Updating project board to "Done"
+4. Deleting the monitor cron
+
+---
+
+## Dispatch by Conductor
+
+When dispatched by the conductor agent (see `conductor.md`), dev agents run in parallel:
+
+- Up to **3 concurrent agents** in isolated worktrees per cycle
+- Conductor assigns issues, dev agents handle everything from claim to merge
+- Independent tasks dispatched in parallel; dependent tasks queued
+- Max 3 cycles per conductor session (9 issues total cap)
+
+---
 
 ## Failure Handling
 
 ```
-Task dispatched to Claude Code
-  → Agent creates PR
-    → CI passes?
-      Yes → Move to Code Review (add `review` label)
-      No  → Agent retries (max 2 auto-retries)
-        → Still failing?
-          Yes → Label: "needs-human", escalate to human
+Task dispatched
+  -> Agent creates PR
+    -> CI passes?
+      Yes -> Move to Code Review (add `review` label)
+      No  -> Agent auto-fixes (max 2 retries via PR monitor)
+        -> Still failing?
+          Yes -> Label: "blocked", escalate with issue comment
 ```
 
-## Parallel Execution
+### Blocker protocol
 
-The conductor dispatches up to **3 concurrent agents** in isolated worktrees per cycle:
+1. Search agent memory for prior solutions
+2. If found: apply and continue, update memory if refined
+3. If not found: commit WIP, push draft PR, post blocker comment on issue, label `blocked`, HALT
 
-1. Dispatch independent tasks in parallel (up to 3 worktrees)
-2. Queue dependent tasks to auto-dispatch when blockers close
-3. Run up to 3 cycles per session (9 issues total cap)
+### Unrecoverable failures
 
-This turns serial multi-week effort into parallel 1–2 day bursts.
+If the agent cannot proceed after 2 CI fix attempts or encounters an architectural ambiguity:
+- Post a detailed comment on the issue explaining what was tried
+- Label the issue `blocked`
+- Keep the draft PR with WIP code for context
+- HALT and wait for human input
+
+---
 
 ## Rules Enforced
 
-Dev agents (via the implement-feature skill) enforce all project rules during the planning gate:
+Dev agents enforce all project rules during the planning gate:
 
-| Rule | Check |
-|------|-------|
-| `CONSTITUTION.md` | Module boundaries, dependency direction |
-| `planning-playbook.md` | Bottom-up task ordering |
-| `code-style.md` | Type hints, selectinload(), line length |
-| `testing.md` | E2E locator priority, no `ha-*` selectors |
-| `git-workflow.md` | Claude Code identity, Conventional Commits |
+| Rule | Source | Check |
+|---|---|---|
+| Module boundaries, dependency direction | `CONSTITUTION.md` | No cross-layer imports |
+| Bottom-up task ordering | `planning-playbook.md` | Models before logic before views before UI |
+| Type hints, `selectinload()`, line length | `code-style.md` | All new code |
+| Accessibility-first locators, no `ha-*` selectors | `testing.md` | All E2E tests |
+| Claude Code identity, Conventional Commits | `git-workflow.md` | All commits and PRs |
+| BDD scenarios | `bdd-conventions.md` | Every feat/test issue |
+| SDD for large features | `sdd-conventions.md` | size:L or multi-module |

--- a/ops/conductor/.env.example
+++ b/ops/conductor/.env.example
@@ -1,0 +1,19 @@
+# Required — conductor will not start without these
+ANTHROPIC_API_KEY=sk-ant-...
+CLAUDE_GH_TOKEN=ghp_...
+
+# Optional — repo path (defaults to ../../ i.e. hyper-admin root)
+REPO_PATH=../../
+
+# Optional — tuning
+CONDUCTOR_MAX_CYCLES=9
+CONDUCTOR_COOLDOWN=300
+CONDUCTOR_HUMAN_POLL=600
+CONDUCTOR_MAX_BUDGET=20.00
+CONDUCTOR_MAX_TURNS=50
+
+# Optional — notifications
+CONDUCTOR_WEBHOOK_URL=
+
+# Optional — status API port
+STATUS_PORT=9090

--- a/ops/conductor/Dockerfile
+++ b/ops/conductor/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:22-slim AS base
+
+# System deps for Claude Code + git + gh CLI
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git curl ca-certificates jq python3 python3-pip python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install gh CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+
+# Install uv (Python project manager)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && ln -s /root/.local/bin/uv /usr/local/bin/uv
+
+# Install Claude Code CLI globally
+RUN npm install -g @anthropic-ai/claude-code
+
+# Status directory for health checks
+RUN mkdir -p /run/conductor
+
+WORKDIR /workspace
+
+COPY supervisor.sh /usr/local/bin/supervisor.sh
+RUN chmod +x /usr/local/bin/supervisor.sh
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+  CMD /usr/local/bin/healthcheck.sh
+
+COPY healthcheck.sh /usr/local/bin/healthcheck.sh
+RUN chmod +x /usr/local/bin/healthcheck.sh
+
+ENTRYPOINT ["/usr/local/bin/supervisor.sh"]

--- a/ops/conductor/docker-compose.yml
+++ b/ops/conductor/docker-compose.yml
@@ -1,0 +1,65 @@
+services:
+  conductor:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: hyper-admin-conductor
+    restart: unless-stopped
+    environment:
+      # Required — pass from host env or .env file
+      - ANTHROPIC_API_KEY
+      - CLAUDE_GH_TOKEN
+      # Optional tuning
+      - CONDUCTOR_MAX_CYCLES=9
+      - CONDUCTOR_COOLDOWN=300
+      - CONDUCTOR_HUMAN_POLL=600
+      - CONDUCTOR_MAX_BUDGET=20.00
+      - CONDUCTOR_MAX_TURNS=50
+      - HEALTHCHECK_STALE_SECONDS=600
+      # Notifications (optional)
+      - CONDUCTOR_WEBHOOK_URL
+    volumes:
+      - ${REPO_PATH:-../../}:/workspace
+      - claude-sessions:/root/.claude
+      - conductor-status:/run/conductor
+    working_dir: /workspace
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2.0"
+
+  # Lightweight sidecar — exposes /run/conductor/status.json over HTTP
+  status-api:
+    image: python:3.12-slim
+    container_name: conductor-status
+    restart: unless-stopped
+    command: >
+      python3 -c "
+      import http.server, json
+      class H(http.server.BaseHTTPRequestHandler):
+          def do_GET(self):
+              try:
+                  with open('/run/conductor/status.json') as f:
+                      data = f.read()
+                  self.send_response(200)
+                  self.send_header('Content-Type', 'application/json')
+                  self.end_headers()
+                  self.wfile.write(data.encode())
+              except FileNotFoundError:
+                  self.send_response(503)
+                  self.end_headers()
+                  self.wfile.write(b'{\"state\":\"unavailable\"}')
+          def log_message(self, *a): pass
+      http.server.HTTPServer(('0.0.0.0', 8080), H).serve_forever()
+      "
+    ports:
+      - "${STATUS_PORT:-9090}:8080"
+    volumes:
+      - conductor-status:/run/conductor:ro
+    depends_on:
+      - conductor
+
+volumes:
+  claude-sessions:
+  conductor-status:

--- a/ops/conductor/healthcheck.sh
+++ b/ops/conductor/healthcheck.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Docker HEALTHCHECK script for the conductor container.
+# Returns 0 (healthy) if the supervisor is alive and responsive.
+# Returns 1 (unhealthy) if stale or dead — triggers Docker restart policy.
+
+set -euo pipefail
+
+STATUS_FILE="/run/conductor/status.json"
+STALE_THRESHOLD="${HEALTHCHECK_STALE_SECONDS:-600}"  # 10 minutes
+
+# Status file must exist
+if [[ ! -f "$STATUS_FILE" ]]; then
+  echo "UNHEALTHY: no status file"
+  exit 1
+fi
+
+state=$(jq -r '.state // "unknown"' "$STATUS_FILE")
+last_heartbeat=$(jq -r '.last_heartbeat // 0' "$STATUS_FILE")
+pid=$(jq -r '.pid // 0' "$STATUS_FILE")
+now=$(date +%s)
+age=$(( now - last_heartbeat ))
+
+# Check supervisor process is alive
+if [[ "$pid" -gt 0 ]] && ! kill -0 "$pid" 2>/dev/null; then
+  echo "UNHEALTHY: supervisor pid $pid is dead"
+  exit 1
+fi
+
+# Check heartbeat freshness
+if [[ $age -gt $STALE_THRESHOLD ]]; then
+  echo "UNHEALTHY: last heartbeat ${age}s ago (threshold ${STALE_THRESHOLD}s)"
+  exit 1
+fi
+
+# "needs-human" is a valid state — container is alive but waiting
+# "error" is transient — supervisor will retry or exit
+# Both are "healthy" from Docker's perspective (don't restart)
+case "$state" in
+  running|completed|starting|needs-human)
+    echo "HEALTHY: state=$state, heartbeat=${age}s ago"
+    exit 0
+    ;;
+  error)
+    # Only unhealthy if also stale — transient errors self-recover
+    if [[ $age -gt 120 ]]; then
+      echo "UNHEALTHY: error state for ${age}s"
+      exit 1
+    fi
+    echo "HEALTHY: transient error, heartbeat=${age}s ago"
+    exit 0
+    ;;
+  *)
+    echo "UNHEALTHY: unknown state '$state'"
+    exit 1
+    ;;
+esac

--- a/ops/conductor/supervisor.sh
+++ b/ops/conductor/supervisor.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# Conductor supervisor — runs the conductor agent in a loop,
+# restarts on completion, pauses on "needs-human", exits on fatal error.
+#
+# Status file protocol (/run/conductor/status.json):
+#   state: running | completed | needs-human | error | starting
+#   cycle: current cycle number
+#   last_heartbeat: epoch timestamp
+#   message: human-readable status
+#   session_id: claude session ID for resume
+
+set -euo pipefail
+
+STATUS_FILE="/run/conductor/status.json"
+LOG_DIR="/run/conductor/logs"
+mkdir -p "$LOG_DIR"
+
+CYCLE=0
+MAX_CYCLES="${CONDUCTOR_MAX_CYCLES:-9}"
+COOLDOWN="${CONDUCTOR_COOLDOWN:-300}"
+HUMAN_POLL="${CONDUCTOR_HUMAN_POLL:-600}"
+MAX_BUDGET="${CONDUCTOR_MAX_BUDGET:-20.00}"
+MAX_TURNS="${CONDUCTOR_MAX_TURNS:-50}"
+WEBHOOK_URL="${CONDUCTOR_WEBHOOK_URL:-}"
+STARTED_AT=""
+
+# --- helpers ---
+
+json_escape() {
+  python3 -c "import json,sys; print(json.dumps(sys.stdin.read().strip()))" <<< "$1"
+}
+
+write_status() {
+  local state="$1" message="$2" session_id="${3:-}"
+  local escaped_msg
+  escaped_msg=$(json_escape "$message")
+  cat > "$STATUS_FILE" <<EOF
+{
+  "state": "$state",
+  "cycle": $CYCLE,
+  "last_heartbeat": $(date +%s),
+  "message": $escaped_msg,
+  "session_id": "$session_id",
+  "started_at": "${STARTED_AT}",
+  "pid": $$
+}
+EOF
+}
+
+notify() {
+  local message="$1" level="${2:-info}"
+  echo "[$(date -Iseconds)] [$level] $message"
+
+  if [[ -n "$WEBHOOK_URL" ]]; then
+    local payload
+    payload=$(python3 -c "
+import json, sys
+print(json.dumps({
+    'text': f'conductor ({sys.argv[2]}): {sys.argv[1]}',
+    'level': sys.argv[2],
+    'cycle': int(sys.argv[3])
+}))" "$message" "$level" "$CYCLE")
+    curl -sf -X POST "$WEBHOOK_URL" \
+      -H "Content-Type: application/json" \
+      -d "$payload" 2>/dev/null || true
+  fi
+}
+
+# Sleep in small increments so the heartbeat stays fresh for the health check.
+# Writes a status update every 30s during the wait.
+sleep_with_heartbeat() {
+  local total="$1" state="$2" message="$3"
+  local elapsed=0 step=30
+  while [[ $elapsed -lt $total ]]; do
+    local remaining=$((total - elapsed))
+    local chunk=$(( remaining < step ? remaining : step ))
+    sleep "$chunk"
+    elapsed=$((elapsed + chunk))
+    write_status "$state" "$message (${elapsed}/${total}s)"
+  done
+}
+
+check_prerequisites() {
+  local missing=()
+  [[ -z "${ANTHROPIC_API_KEY:-}" ]] && missing+=("ANTHROPIC_API_KEY")
+  [[ -z "${CLAUDE_GH_TOKEN:-}" ]]   && missing+=("CLAUDE_GH_TOKEN")
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    write_status "error" "Missing env vars: ${missing[*]}"
+    notify "Missing required env vars: ${missing[*]}" "error"
+    exit 1
+  fi
+
+  if ! command -v claude &>/dev/null; then
+    write_status "error" "claude CLI not found"
+    notify "claude CLI not found in PATH" "error"
+    exit 1
+  fi
+
+  if [[ ! -d "/workspace/.git" ]]; then
+    write_status "error" "No git repo at /workspace"
+    notify "No git repo mounted at /workspace" "error"
+    exit 1
+  fi
+}
+
+run_cycle() {
+  CYCLE=$((CYCLE + 1))
+  local log_file="$LOG_DIR/cycle-${CYCLE}.json"
+
+  write_status "running" "Cycle $CYCLE starting" ""
+  notify "Cycle $CYCLE/$MAX_CYCLES starting"
+
+  cd /workspace
+  git fetch origin develop 2>/dev/null || true
+  git checkout develop 2>/dev/null || true
+  git pull origin develop 2>/dev/null || true
+
+  local exit_code=0
+  claude -p "/run-autonomous-team" \
+    --output-format json \
+    --max-turns "$MAX_TURNS" \
+    --max-budget-usd "$MAX_BUDGET" \
+    --permission-mode plan \
+    > "$log_file" 2>&1 || exit_code=$?
+
+  local session_id=""
+  local result=""
+  if [[ -f "$log_file" ]]; then
+    session_id=$(jq -r '.session_id // empty' "$log_file" 2>/dev/null || true)
+    result=$(jq -r '.result // empty' "$log_file" 2>/dev/null || true)
+  fi
+
+  if [[ $exit_code -eq 0 ]]; then
+    if echo "$result" | grep -qiE "needs-human|needs.human|STOP.*user|blocked.*human|cannot.continue"; then
+      write_status "needs-human" "Cycle $CYCLE halted — needs human input" "$session_id"
+      notify "Cycle $CYCLE needs human intervention: $(echo "$result" | head -c 200)" "warn"
+      return 2
+    fi
+
+    write_status "completed" "Cycle $CYCLE completed successfully" "$session_id"
+    notify "Cycle $CYCLE completed"
+    return 0
+  else
+    write_status "error" "Cycle $CYCLE failed (exit $exit_code)" "$session_id"
+    notify "Cycle $CYCLE failed with exit code $exit_code" "error"
+    return 1
+  fi
+}
+
+wait_for_human() {
+  notify "Waiting for human input (polling every ${HUMAN_POLL}s)" "warn"
+  local wait_count=0
+  local max_waits=12  # 12 * 10min = 2 hours max wait
+
+  while [[ $wait_count -lt $max_waits ]]; do
+    sleep_with_heartbeat "$HUMAN_POLL" "needs-human" "Waiting for human ($((wait_count + 1))/$max_waits)"
+    wait_count=$((wait_count + 1))
+
+    # Check if human resolved blockers (issues with in-progress but no blocked label)
+    local unblocked
+    unblocked=$(cd /workspace && GH_TOKEN="$CLAUDE_GH_TOKEN" gh issue list \
+      --label "in-progress" --state open \
+      --json number,labels \
+      --jq '[.[] | select([.labels[].name] | index("blocked") | not)] | length' 2>/dev/null || echo "0")
+
+    if [[ "$unblocked" -gt 0 ]]; then
+      notify "Detected unblocked issues — resuming" "info"
+      return 0
+    fi
+  done
+
+  notify "Max human wait exceeded (${max_waits} polls). Stopping." "error"
+  write_status "error" "Timed out waiting for human input"
+  return 1
+}
+
+# --- Main loop ---
+
+STARTED_AT=$(date -Iseconds)
+check_prerequisites
+write_status "starting" "Supervisor starting, max $MAX_CYCLES cycles"
+notify "Conductor supervisor started (max $MAX_CYCLES cycles, cooldown ${COOLDOWN}s)"
+
+while [[ $CYCLE -lt $MAX_CYCLES ]]; do
+  cycle_result=0
+  run_cycle || cycle_result=$?
+
+  case $cycle_result in
+    0)
+      if [[ $CYCLE -lt $MAX_CYCLES ]]; then
+        sleep_with_heartbeat "$COOLDOWN" "completed" "Cooling down before cycle $((CYCLE + 1))"
+      fi
+      ;;
+    1)
+      notify "Backing off 60s after error" "warn"
+      sleep_with_heartbeat 60 "error" "Backing off after cycle $CYCLE error"
+      ;;
+    2)
+      wait_for_human || exit 1
+      ;;
+  esac
+done
+
+write_status "completed" "All $MAX_CYCLES cycles finished"
+notify "Conductor finished all $MAX_CYCLES cycles" "info"
+exit 0


### PR DESCRIPTION
## Summary

- **`/start` command** — new slash command that creates an isolated worktree from `develop`, rebases, bootstraps env. Used by all dev agent skills.
- **`dev-agents.md` rewrite** — full agent spec with work discovery protocol (auto-picks tickets from next milestone when no issue given), issue lifecycle management (labels + project board), and structured comments at every state change.
- **`implement-feature` / `fix-issue` skills** — Phase B1 replaced with `/start` (was 20+ lines of manual worktree shell).
- **`ops/conductor/`** — Docker sandbox for running the conductor agent headlessly:
  - `Dockerfile` — node:22-slim + Claude Code CLI + gh + uv + git
  - `supervisor.sh` — cycle loop with heartbeat, halt detection (completed / needs-human / error), webhook notifications, `sleep_with_heartbeat` to keep health checks fresh
  - `healthcheck.sh` — Docker HEALTHCHECK: checks PID alive + heartbeat freshness + state semantics
  - `docker-compose.yml` — conductor + status-api sidecar (exposes status.json on port 9090)
  - `.env.example` — all configurable knobs documented

## Test plan

- [ ] `docker compose build` succeeds
- [ ] `docker compose up -d` starts both services
- [ ] `curl localhost:9090` returns status JSON
- [ ] `docker inspect --format='{{.State.Health.Status}}' hyper-admin-conductor` returns "healthy"
- [ ] Conductor picks up `agent-task` + `ready` issues when running
- [ ] On `needs-human` halt, supervisor polls and resumes when blocker clears
- [ ] Webhook notifications fire on state changes (if `CONDUCTOR_WEBHOOK_URL` set)
- [ ] `bash -n supervisor.sh` and `bash -n healthcheck.sh` pass (verified)
- [ ] `poe lint` passes (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)