### PR TITLE
fix(ci): resolve ruff lint errors and improve ERP E2E fixture

### DIFF
--- a/src/hyperadmin/adapters/sqlalchemy.py
+++ b/src/hyperadmin/adapters/sqlalchemy.py
@@ -33,7 +33,7 @@ class SQLAlchemyAdapter(BaseAdapter):
         search: str | None = None,
         filters: dict[str, Any] | None = None,
         order_by: str | None = None,
-        search_fields: list[str] | None = None,
+        search_fields: list[str] | None = None,  # noqa: ARG002
     ) -> tuple[list[Any], int]:
         where_conditions = []
         if filters:

--- a/src/hyperadmin/core/settings.py
+++ b/src/hyperadmin/core/settings.py
@@ -5,7 +5,7 @@ from typing import Literal
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-_DEFAULT_SECRET_KEY = "hyperadmin-default-secret"
+_DEFAULT_SECRET_KEY = "hyperadmin-default-secret"  # noqa: S105
 _DEFAULT_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 
 ThemeLiteral = Literal["auto", "light", "dark"]

--- a/tests/e2e/test_auth_flow.py
+++ b/tests/e2e/test_auth_flow.py
@@ -9,7 +9,7 @@ Uses accessibility-first selectors per CLAUDE.md E2E Selector Convention.
 from playwright.sync_api import Page, expect
 
 
-def _login(page: Page, base_url: str, password: str = "secret123") -> None:
+def _login(page: Page, base_url: str, password: str = "secret123") -> None:  # noqa: S107
     """Log in as alice with the given password."""
     page.goto(f"{base_url}/admin/login")
     page.get_by_label("Username").fill("alice")

--- a/tests/e2e/test_profit_loss_report.py
+++ b/tests/e2e/test_profit_loss_report.py
@@ -15,7 +15,9 @@ import pytest
 from playwright.sync_api import Page, expect
 
 _IN_CONTAINER = os.environ.get("IS_SANDBOX") == "1"
-_SERVER_TIMEOUT = 15 if _IN_CONTAINER else 5
+# ERP app performs DB creation + permission sync + data seeding on startup,
+# which takes longer than the simple demo app.
+_SERVER_TIMEOUT = 30 if _IN_CONTAINER else 15
 
 
 def _find_free_port() -> int:
@@ -63,6 +65,12 @@ def erp_base_url() -> Iterator[str]:
         deadline = time.time() + _SERVER_TIMEOUT
         last_err: Exception | None = None
         while time.time() < deadline:
+            # If the subprocess already exited, report its stderr immediately
+            if proc.poll() is not None:
+                _stdout, _stderr = proc.communicate()
+                raise RuntimeError(
+                    f"ERP server process exited with code {proc.returncode}:\n{_stderr}"
+                )
             try:
                 r = requests.get(base + "/", timeout=0.5)
                 if r.status_code == HTTPStatus.OK:
@@ -71,7 +79,7 @@ def erp_base_url() -> Iterator[str]:
                 last_err = e
             time.sleep(0.3)
         else:
-            raise RuntimeError(f"ERP server did not start: {last_err}")
+            raise RuntimeError(f"ERP server did not start within {_SERVER_TIMEOUT}s: {last_err}")
 
         yield base
     finally:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -109,7 +109,7 @@ def test_admin_theme_default(mock_fastapi_app: MagicMock) -> None:
 
 
 def test_admin_theme_invalid(mock_fastapi_app: MagicMock) -> None:
-    with pytest.raises(Exception, match="[Ii]nvalid theme|neon"):
+    with pytest.raises(Exception, match=r"[Ii]nvalid theme|neon"):
         HyperAdminSettings(theme="neon")  # type: ignore[arg-type]
 
 
@@ -162,7 +162,7 @@ def test_admin_raises_on_default_secret_in_production_with_auth(
     mock_auth = MagicMock()
     settings = HyperAdminSettings(debug=False)  # default secret_key
 
-    with pytest.raises(ValueError, match="[Ss]ecret|HYPERADMIN_SECRET_KEY"):
+    with pytest.raises(ValueError, match=r"[Ss]ecret|HYPERADMIN_SECRET_KEY"):
         Admin(app=mock_fastapi_app, settings=settings, auth_backend=mock_auth)
 
 


### PR DESCRIPTION
## Summary

- **S105/S107**: Suppress false-positive hardcoded password warnings on `_DEFAULT_SECRET_KEY` (settings default) and test helper `_login()` default arg
- **ARG002**: Suppress unused `search_fields` param in `SQLAlchemyAdapter.list()` — required by base class interface
- **RUF043**: Use raw strings for regex patterns in `pytest.raises(match=...)` calls
- **ERP E2E fixture**: Increase server startup timeout from 5s→15s (ERP app does DB creation + permission sync + seeding), and report subprocess stderr on early exit for better CI debugging

## Test plan
- [ ] CI lint (`ruff check`) passes on all matrix combos
- [ ] E2E `test_profit_loss_report` no longer times out (or reports actionable error if server crashes)