### PR TITLE
fix(commands): use git reset instead of rebase in /start worktree setup

### DIFF
--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -20,10 +20,13 @@ Use `EnterWorktree` with the branch name provided by the user: `$ARGUMENTS`
 
 If `$ARGUMENTS` is empty, generate a random name (e.g., `work/agent-<4-random-hex-chars>`).
 
-3. **Rebase onto develop**
+3. **Reset to latest develop**
+
+Since this is a fresh worktree with no prior work, reset to the tip of develop
+instead of rebasing (avoids replaying the entire history and hitting conflicts):
 
 ```bash
-git rebase origin/develop
+git reset --hard origin/develop
 ```
 
 4. **Bootstrap the environment**


### PR DESCRIPTION
EnterWorktree creates a branch from HEAD which may carry old divergent history. Rebasing onto origin/develop then replays 100+ commits and hits conflicts. Since this is always a fresh session with no prior work, a hard reset to origin/develop is the correct approach.

## What

<!-- Brief description of the change -->

## Why

<!-- Link to issue: Closes #XX -->

## How

<!-- Key implementation decisions -->

## Checklist

- [ ] `just lint` passes
- [ ] `just test` passes
- [ ] Public API has type hints + docstrings
- [ ] Tests cover new/changed behavior
- [ ] CHANGELOG.md updated (if user-facing)
- [ ] No backward-compatibility breaks (or documented in migration guide)
