### PR TITLE
chore: ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,4 +92,5 @@ gha-creds-*.json
 
 # git worktrees
 /.worktrees/
+.claude/worktrees/
 


### PR DESCRIPTION
## Summary

- Adds `.claude/worktrees/` to `.gitignore`.
- The existing `/.worktrees/` rule only covers root-level worktree dirs; the `/wt` skill places worktrees under `.claude/worktrees/agent-*`, which were leaking into commits.

## Test plan

- [x] `git check-ignore -v .claude/worktrees/agent-foo/anyfile` resolves to the new rule
- [x] `git status` no longer surfaces files under `.claude/worktrees/`