### PR TITLE
refactor(ui): add breakpoint design tokens to _tokens.css (C1-A)

### DIFF
--- a/src/hyperadmin/static/css/_tokens.css
+++ b/src/hyperadmin/static/css/_tokens.css
@@ -143,5 +143,12 @@
 
   /* ---- Layout ---- */
   --ha-sidebar-width: 16rem;
+  --ha-sidebar-width-tablet: 12rem;
   --ha-navbar-height: 3.5rem;
+
+  /* ---- Breakpoints ---- */
+  --ha-bp-sm: 640px;
+  --ha-bp-md: 768px;
+  --ha-bp-lg: 1024px;
+  --ha-bp-xl: 1280px;
 }


### PR DESCRIPTION
## Summary

C1-A of v0.4.0 Responsive Design epic. Adds breakpoint custom properties to `_tokens.css` so all subsequent responsive stories share a single vocabulary.

Purely additive — no existing styles modified. Zero regression risk.

## Changes

`src/hyperadmin/static/css/_tokens.css` — adds:
- `--ha-bp-sm: 640px`
- `--ha-bp-md: 768px`
- `--ha-bp-lg: 1024px`
- `--ha-bp-xl: 1280px`
- `--ha-sidebar-width-tablet: 12rem`

## Manual test scenarios

1. Open any admin page in `examples/simple` (e.g. `uv run python examples/simple/main.py` → http://localhost:8000/admin/)
2. Open DevTools → Elements → `:root`
3. Confirm the 5 new custom properties are present under `:root`

## Acceptance criteria

- [x] Tokens `--ha-bp-sm`, `--ha-bp-md`, `--ha-bp-lg`, `--ha-bp-xl` defined in `:root`
- [x] `--ha-sidebar-width-tablet` token defined
- [x] `poe lint` passes
- [x] `poe test:unit` passes (493 tests)

## Epic context

- **Epic:** `.meta/epics/epic-responsive-design/epic.md`
- **SDD:** `docs/specs/responsive-design.md`
- **Cycle:** 1 / 3 (Slot A — runs parallel with C1-B and C1-C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)