### PR TITLE
feat(ui): responsive data table with stacked card layout (C1-C, #461)

### DIFF
--- a/src/hyperadmin/static/css/_table.css
+++ b/src/hyperadmin/static/css/_table.css
@@ -122,3 +122,109 @@
   color: var(--ha-color-danger-hover);
   background-color: var(--ha-color-danger-light);
 }
+
+/* ==========================================================================
+   Responsive — Stacked card layout on mobile (< 768px)
+
+   Self-contained: this block uses its own @media query and does not depend
+   on _responsive.css, so this story can ship independently of C1-B.
+
+   Below 768px each row renders as a card with field labels inline:
+     - <thead> is visually hidden but kept in the accessibility tree (clip
+       technique, not display:none)
+     - Each <tr> becomes a bordered card with stacked cells
+     - Each <td> shows its data-label as bold text before the value
+     - Action buttons get min-height 44px to meet touch-target guidance
+   ========================================================================== */
+
+@media (max-width: 767px) {
+  .ha-table-wrapper {
+    border: none;
+    box-shadow: none;
+    background-color: transparent;
+    overflow-x: visible;
+    margin: var(--ha-space-4) 0;
+  }
+
+  /* Visually hide the header but keep it accessible to screen readers. */
+  .ha-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* Card layout for each row. */
+  .ha-table,
+  .ha-table-body,
+  .ha-table-row,
+  .ha-table-cell {
+    display: block;
+    width: 100%;
+  }
+
+  .ha-table-row {
+    background-color: var(--ha-surface-raised);
+    border: var(--ha-border-width) solid var(--ha-color-border-light);
+    border-radius: var(--ha-radius-lg);
+    box-shadow: var(--ha-shadow-xs);
+    margin-bottom: var(--ha-space-4);
+    padding: var(--ha-space-3) var(--ha-space-4);
+  }
+
+  .ha-table-row:hover {
+    background-color: var(--ha-surface-raised);
+  }
+
+  .ha-table-row:last-child {
+    margin-bottom: 0;
+  }
+
+  .ha-table-cell {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--ha-space-4);
+    padding: var(--ha-space-2) 0;
+    border-bottom: var(--ha-border-width) solid var(--ha-color-border-light);
+    white-space: normal;
+    text-align: right;
+  }
+
+  .ha-table-cell:last-child {
+    border-bottom: none;
+  }
+
+  .ha-table-cell::before {
+    content: attr(data-label);
+    font-weight: var(--ha-font-semibold);
+    color: var(--ha-color-text-muted);
+    font-size: var(--ha-font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    text-align: left;
+    flex-shrink: 0;
+  }
+
+  /* Actions cell stacks horizontally with wrap, ensuring 44px touch targets. */
+  .ha-table-cell-center[data-label="Actions"] {
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: var(--ha-space-2);
+    text-align: right;
+  }
+
+  .ha-action-link,
+  .ha-action-delete {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    padding: var(--ha-space-2) var(--ha-space-3);
+  }
+}
+

--- a/src/hyperadmin/templates/components/table.html
+++ b/src/hyperadmin/templates/components/table.html
@@ -12,9 +12,10 @@
             {%- for item in items -%}
             <tr class="ha-table-row" data-testid="list-row">
                 {%- for field in fields -%}
-                    <td class="ha-table-cell">{{- item[field] -}}</td>
+                    {%- set cell_label = model_name if field == '__str__' else (field_labels[field] if field_labels is defined and field in field_labels else field.replace('_', ' ').title()) -%}
+                    <td class="ha-table-cell" data-label="{{ cell_label }}">{{- item[field] -}}</td>
                 {%- endfor -%}
-                <td class="ha-table-cell ha-table-cell-center">
+                <td class="ha-table-cell ha-table-cell-center" data-label="Actions">
                     {%- if can_detail is not defined or can_detail -%}
                     <a href="{{- url_for(model_name|lower ~ '-detail', item_id=item.id) -}}" class="ha-action-link" data-testid="row-view-link">View</a>
                     {%- endif -%}

--- a/tests/e2e/test_list_view.py
+++ b/tests/e2e/test_list_view.py
@@ -291,15 +291,46 @@ def test_filter_functionality(page: Page, demo_base_url: str) -> None:
     expect(page.get_by_test_id("list-row")).to_have_count(initial_count)
 
 
-def test_table_overflow_scroll(page: Page, demo_base_url: str) -> None:
+def test_table_renders_as_stacked_cards_on_mobile(page: Page, demo_base_url: str) -> None:
+    """
+    Scenario: table displays as stacked cards on mobile.
+
+      Given viewport width is 375px
+      When  the list view loads with data
+      Then  each row renders as a block-level card
+      And   no horizontal scrollbar is needed
+    """
+    # Given a mobile viewport
+    page.set_viewport_size({"width": 375, "height": 600})
     page.goto(demo_base_url + "/admin/user")
 
-    # Set a very narrow viewport
-    page.set_viewport_size({"width": 300, "height": 600})
+    # When the list view loads
+    expect(page.get_by_test_id("list-table")).to_be_visible()
 
-    wrapper = page.locator(".ha-table-wrapper")
-    expect(wrapper).to_be_visible()
+    # Then rows render as block-level cards (table-row in desktop becomes block on mobile)
+    first_row = page.get_by_test_id("list-row").first
+    expect(first_row).to_be_visible()
+    row_display = first_row.evaluate("el => window.getComputedStyle(el).display")
+    assert row_display == "block"
 
-    # Check that overflow-x is auto
-    overflow_x = wrapper.evaluate("el => window.getComputedStyle(el).overflowX")
-    assert overflow_x == "auto"
+
+def test_table_renders_as_horizontal_table_on_desktop(page: Page, demo_base_url: str) -> None:
+    """
+    Scenario: table displays as normal horizontal table on desktop.
+
+      Given viewport width is 1024px
+      When  the list view loads with data
+      Then  rows render as table rows (not blocks)
+    """
+    # Given a desktop viewport
+    page.set_viewport_size({"width": 1024, "height": 768})
+    page.goto(demo_base_url + "/admin/user")
+
+    # When the list view loads
+    expect(page.get_by_test_id("list-table")).to_be_visible()
+
+    # Then rows render as standard table rows
+    first_row = page.get_by_test_id("list-row").first
+    expect(first_row).to_be_visible()
+    row_display = first_row.evaluate("el => window.getComputedStyle(el).display")
+    assert row_display == "table-row"


### PR DESCRIPTION
## Summary

C1-C of v0.4.0 Responsive Design epic. **First demoable mobile feature.**

Below 768px viewport, transforms the data table from a horizontal overflow-scroll table into stacked cards with field labels inline. Each `<td>` carries a `data-label` attribute that CSS renders as bold text via `::before` on mobile.

Closes #461.

## Changes

| File | Change |
|---|---|
| `src/hyperadmin/templates/components/table.html` | Adds `data-label="{{ display_name }}"` to each body `<td>` and to the Actions column. Display name uses the same logic as `sortable_header.html` (model name for `__str__`, label override map, or title-cased field name). |
| `src/hyperadmin/static/css/_table.css` | Adds a self-contained `@media (max-width: 767px)` block: `<thead>` clipped from view but accessible to screen readers; rows become bordered cards; cells become flex rows with `data-label` shown via `::before`; action buttons get `min-height: 44px` for WCAG 2.1 AA touch targets. |
| `tests/e2e/test_list_view.py` | Replaces the now-obsolete `test_table_overflow_scroll` (which asserted desktop-first horizontal scroll) with two BDD-shaped scenarios: mobile renders rows as `display: block` cards; desktop renders rows as `display: table-row`. Uses `data-testid` locators per testing rules. |

## Self-contained — does not depend on C1-A or C1-B

`_table.css` uses its own `@media` query rather than reading from the new `_responsive.css`. This was an explicit design decision in the SDD (decision log) so this story can run in true parallel with C1-A and C1-B in Cycle 1.

## Manual test scenarios

Open any list view (e.g. `/admin/user/`) at 375px viewport:

1. ✅ Each row renders as a card with label:value pairs
2. ✅ Column headers visually hidden but DOM-present (screen readers can read them)
3. ✅ View / Edit / Delete buttons appear at card bottom with 44px touch targets
4. ✅ Widen to 1024px — standard horizontal table layout restored

## Acceptance criteria

- [x] Table displays as stacked cards on mobile
- [x] Table displays as normal horizontal table on desktop
- [x] Action buttons in card footer with min 44px touch targets
- [x] `data-label` attributes provide inline column labels
- [x] Table header accessible to screen readers when visually hidden
- [x] `poe lint` passes
- [x] `poe test:unit` passes (493 tests)
- [x] Updated E2E table tests pass

## Epic context

- **Epic:** `.meta/epics/epic-responsive-design/epic.md`
- **SDD:** `docs/specs/responsive-design.md`
- **Cycle:** 1 / 3 (Slot C — runs parallel with C1-A and C1-B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)