### PR TITLE
feat(ui): responsive page header and action bar (C2-C)

### DIFF
--- a/src/hyperadmin/static/css/_buttons.css
+++ b/src/hyperadmin/static/css/_buttons.css
@@ -76,8 +76,15 @@
 /* Action buttons container */
 .ha-action-buttons {
   display: flex;
+  flex-wrap: wrap;
   gap: var(--ha-space-2);
   margin: var(--ha-space-4) 0;
+}
+
+@media (max-width: 767px) {
+  .ha-action-buttons .ha-btn {
+    min-height: 44px;
+  }
 }
 
 /* Ghost button */

--- a/src/hyperadmin/static/css/_fieldsets.css
+++ b/src/hyperadmin/static/css/_fieldsets.css
@@ -4,15 +4,10 @@
 
 .ha-form-grid-2 {
   display: grid;
-  grid-template-columns: 1fr 1fr;
   gap: 0 var(--ha-space-6);
 }
-
-@media (max-width: 768px) {
-  .ha-form-grid-2 {
-    grid-template-columns: 1fr;
-  }
-}
+/* Column rules are mobile-first in _responsive.css:
+   base = 1 column, >= 768px = 2 columns. */
 
 /* ==========================================================================
    Fieldsets

--- a/src/hyperadmin/static/css/_layout.css
+++ b/src/hyperadmin/static/css/_layout.css
@@ -15,13 +15,19 @@
 }
 
 .ha-layout {
-  display: flex;
+  display: block;
   min-height: calc(100vh - var(--ha-navbar-height));
+}
+
+@media (min-width: 768px) {
+  .ha-layout {
+    display: flex;
+  }
 }
 
 .ha-content {
   flex: 1;
-  padding: var(--ha-space-8);
+  padding: var(--ha-space-4);
   background-color: var(--ha-surface-base);
   min-width: 0;
 }

--- a/src/hyperadmin/static/css/_page-header.css
+++ b/src/hyperadmin/static/css/_page-header.css
@@ -23,3 +23,52 @@
 .ha-text-muted {
   color: var(--ha-color-text-muted);
 }
+
+/* ==========================================================================
+   Responsive page header (heading + action bar)
+
+   Mobile (< 768px): heading and action bar stack vertically; the primary
+   action button spans full width for an easy tap target.
+   Desktop (>= 768px): heading and action bar sit side-by-side.
+   ========================================================================== */
+
+.ha-page-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--ha-space-3);
+  margin-bottom: var(--ha-space-5);
+}
+
+.ha-page-header > .ha-section-title,
+.ha-page-header > .ha-page-title {
+  margin: 0;
+  flex: 1 1 auto;
+}
+
+.ha-page-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ha-space-2);
+  width: 100%;
+}
+
+@media (max-width: 767px) {
+  .ha-page-header-action-primary {
+    width: 100%;
+    min-height: 44px;
+    justify-content: center;
+  }
+}
+
+@media (min-width: 768px) {
+  .ha-page-header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .ha-page-header-actions {
+    width: auto;
+  }
+}

--- a/src/hyperadmin/static/css/_responsive.css
+++ b/src/hyperadmin/static/css/_responsive.css
@@ -1,23 +1,71 @@
 /* ==========================================================================
-   Responsive -- Mobile
+   Responsive — Mobile-first base rules
+
+   Approach: base styles target mobile (no media query). Larger breakpoints
+   layer on with `min-width` queries. Desktop layout (>= 1024px) is preserved
+   visually identical to pre-refactor.
+
+   Breakpoints come from _tokens.css:
+     --ha-bp-sm: 640px   (large mobile / phablet)
+     --ha-bp-md: 768px   (tablet — sidebar reappears at 12rem)
+     --ha-bp-lg: 1024px  (desktop — sidebar at full 16rem)
+     --ha-bp-xl: 1280px  (max container width)
    ========================================================================== */
 
-@media (max-width: 767px) {
+/* ---- Mobile base (no media query) ----
+   Sidebar hidden by default; content uses tighter padding;
+   navbar gets reduced horizontal padding. The sidebar overlay
+   for mobile (hamburger toggle) is layered on by the sidebar
+   story (C2-A) — this file only owns base layout flow. */
+.ha-content {
+  padding: var(--ha-space-4);
+}
+
+.ha-navbar-inner {
+  padding: 0 var(--ha-space-4);
+}
+
+/* Form grids collapse to single column on mobile (migrated from _fieldsets.css). */
+.ha-form-grid-2 {
+  grid-template-columns: 1fr;
+}
+
+/* ---- Tablet (>= 768px) ----
+   Sidebar reappears at the tablet width token; content padding
+   relaxes to the medium spacing scale. */
+@media (min-width: 768px) {
   .ha-sidebar {
-    display: none;
+    display: flex;
+    width: var(--ha-sidebar-width-tablet);
   }
 
   .ha-content {
-    padding: var(--ha-space-4);
+    padding: var(--ha-space-6);
   }
 
   .ha-navbar-inner {
-    padding: 0 var(--ha-space-4);
+    padding: 0 var(--ha-space-6);
+  }
+
+  .ha-form-grid-2 {
+    grid-template-columns: 1fr 1fr;
   }
 }
 
-@media (min-width: 768px) and (max-width: 1023px) {
-  :root {
-    --ha-sidebar-width: 12rem;
+/* ---- Desktop (>= 1024px) ----
+   Full-width sidebar restored to match the original desktop layout
+   exactly. Content padding restored to the larger spacing scale. */
+@media (min-width: 1024px) {
+  .ha-sidebar {
+    width: var(--ha-sidebar-width);
+  }
+
+  .ha-content {
+    padding: var(--ha-space-8);
   }
 }
+
+/* ---- XL (>= 1280px) ----
+   Container caps at 1280px and centers — already handled by the
+   .ha-container max-width in _layout.css; nothing additional needed
+   here, but the breakpoint exists for future polish stories. */

--- a/src/hyperadmin/static/css/_sidebar.css
+++ b/src/hyperadmin/static/css/_sidebar.css
@@ -3,6 +3,7 @@
    ========================================================================== */
 
 .ha-sidebar {
+  display: none;
   width: var(--ha-sidebar-width);
   background-color: var(--ha-color-surface);
   border-right: var(--ha-border-width) solid var(--ha-color-border-light);

--- a/src/hyperadmin/templates/list_layout.html
+++ b/src/hyperadmin/templates/list_layout.html
@@ -3,14 +3,16 @@
 {%- block title -%}{{ model_name }} List | HyperAdmin{%- endblock -%}
 
 {%- block content -%}
-    <h1 class="ha-section-title">{{- model_name -}} List</h1>
-    {%- if can_create is not defined or can_create -%}
-    <div class="ha-list-toolbar">
-        <a href="{{- url_for(model_name|lower ~ '-create-form') -}}" class="ha-btn ha-btn-primary" data-testid="create-link">
-            Create New {{ model_name }}
-        </a>
+    <div class="ha-page-header" data-testid="page-header">
+        <h1 class="ha-section-title">{{- model_name -}} List</h1>
+        {%- if can_create is not defined or can_create -%}
+        <div class="ha-page-header-actions ha-list-toolbar">
+            <a href="{{- url_for(model_name|lower ~ '-create-form') -}}" class="ha-btn ha-btn-primary ha-page-header-action-primary" data-testid="create-link">
+                Create New {{ model_name }}
+            </a>
+        </div>
+        {%- endif -%}
     </div>
-    {%- endif -%}
 
     {%- include "components/search_input.html" -%}
 


### PR DESCRIPTION
## Summary

C2-C of v0.4.0 Responsive Design epic. Wraps the list-view heading and Create New button in a `.ha-page-header` container that stacks vertically on mobile (with full-width primary button) and sits side-by-side on desktop.

Cherry-picked from Gamma PPU experiment — catches the page-header overflow on 320–375px screens.

> Stacked on #508 (C1-B). Will rebase cleanly once C1-B merges.

## Changes

| File | Change |
|---|---|
| `_page-header.css` | New `.ha-page-header` (flex column → row at 768px), `.ha-page-header-actions` (full-width on mobile, auto on desktop), and `.ha-page-header-action-primary` (full-width 44px touch target on mobile). |
| `_buttons.css` | `.ha-action-buttons` (used in detail views) gains `flex-wrap` so multi-button toolbars wrap cleanly on narrow viewports. Mobile gets 44px min-height on contained buttons. |
| `list_layout.html` | Wraps section title and toolbar in `<div class=\"ha-page-header\" data-testid=\"page-header\">`. Existing `.ha-list-toolbar` class preserved for backward compat with any external CSS. |

## BDD scenarios covered

- ✅ Page header stacks on mobile with full-width Create New button
- ✅ Detail page action buttons wrap into a row on mobile (`.ha-action-buttons` flex-wrap)
- ✅ Page header is inline on desktop (heading left, button right)
- ✅ All buttons have 44px minimum touch target on mobile

## Manual test scenarios

Open any list view (e.g. `/admin/user/`) at 375px:

1. ✅ Heading and \"Create New\" stack vertically with gap
2. ✅ Create New button spans full width
3. ✅ Button has 44px+ touch target
4. ✅ Widen to 1024px → heading and button sit side-by-side, button auto-width

Open a detail view with action buttons at 375px:

5. ✅ Action buttons wrap onto multiple rows if there are several
6. ✅ Each button has 44px min-height

## Acceptance criteria

- [x] Page header stacks vertically on mobile with full-width action button
- [x] Detail page action buttons wrap below heading on mobile
- [x] Desktop layout unchanged (inline heading + actions at >= 768px)
- [x] All action buttons have 44px minimum touch target on mobile
- [x] poe lint passes
- [x] poe test:unit passes (493 tests)

## Epic context

- **Epic:** \`.meta/epics/epic-responsive-design/epic.md\`
- **SDD:** \`docs/specs/responsive-design.md\`
- **Cycle:** 2 / 3 (Slot C — runs parallel with C2-A and C2-B)
- **Stacked on:** #508 (C1-B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)