### PR TITLE
feat(ui): skip-to-content and landmark enhancements for mobile (C2-F)

### DIFF
--- a/src/hyperadmin/static/css/_accessibility.css
+++ b/src/hyperadmin/static/css/_accessibility.css
@@ -19,13 +19,19 @@
   box-shadow: var(--ha-shadow-lg);
 }
 
-.ha-skip-link:focus {
+.ha-skip-link:focus,
+.ha-skip-link:focus-visible {
   position: fixed;
   top: var(--ha-space-2);
   left: var(--ha-space-2);
   width: auto;
   height: auto;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
   overflow: visible;
+  outline: 2px solid var(--ha-color-primary-200);
+  outline-offset: 2px;
 }
 
 /* ==========================================================================

--- a/src/hyperadmin/templates/_base.html
+++ b/src/hyperadmin/templates/_base.html
@@ -95,13 +95,18 @@
     </script>
 </head>
 <body class="ha-page" x-data="{ sidebarOpen: false }" :class="{ 'ha-has-sidebar-open': sidebarOpen }">
-    <a href="#main-content" class="ha-skip-link">Skip to main content</a>
+    <a href="#main-content"
+       class="ha-skip-link"
+       @click="sidebarOpen = false"
+       data-testid="skip-link">Skip to main content</a>
     <div class="ha-container">
         {% block messages %}{% include "_messages.html" %}{% endblock %}
-        {% block navbar %}{% include "_navbar.html" %}{% endblock %}
+        <header role="banner">
+            {% block navbar %}{% include "_navbar.html" %}{% endblock %}
+        </header>
         <div class="ha-layout">
             {% block sidebar %}{% include "_sidebar.html" %}{% endblock %}
-            <main id="main-content" role="main" class="ha-content">
+            <main id="main-content" role="main" tabindex="-1" class="ha-content">
                 {% block content %}{% endblock %}
             </main>
         </div>

--- a/src/hyperadmin/templates/_sidebar.html
+++ b/src/hyperadmin/templates/_sidebar.html
@@ -2,8 +2,8 @@
        class="ha-sidebar"
        :class="{ 'ha-sidebar-mobile-open': sidebarOpen }"
        data-testid="sidebar"
-       aria-label="Sidebar navigation"
-       :role="sidebarOpen ? 'dialog' : null"
+       aria-label="Model navigation"
+       :role="sidebarOpen ? 'dialog' : 'complementary'"
        :aria-modal="sidebarOpen ? 'true' : null"
        x-trap.inert.noscroll="sidebarOpen"
        @keydown.escape.window="sidebarOpen = false">


### PR DESCRIPTION
## Summary

C2-F of v0.4.0 Responsive Design epic (Cycle 2 stagger). Enhances the existing skip-to-content link so it actually works on mobile when the sidebar overlay is open, and labels page regions as ARIA landmarks for screen reader navigation.

Cherry-picked from Gamma PPU experiment.

## Changes

| File | Change |
|---|---|
| `_base.html` | Wrap navbar include in \`<header role=\"banner\">\` landmark. Skip link gains \`@click=\"sidebarOpen = false\"\` so it closes the sidebar before jumping (otherwise focus would land behind the open overlay on mobile). \`<main>\` gets \`tabindex=\"-1\"\` so it accepts programmatic focus from the skip link. Added \`data-testid=\"skip-link\"\` for E2E tests. |
| `_sidebar.html` | aria-label changed from \"Sidebar navigation\" to \"Model navigation\" (more descriptive of contents). Conditional role: \`dialog\` when overlay is open, \`complementary\` otherwise (the landmark on desktop). |
| `_accessibility.css` | Skip link on focus gains 44px min-height for touch and a high-contrast focus outline. \`focus-visible\` selector added alongside \`:focus\`. |

## BDD scenarios covered

- ✅ skip-to-content link bypasses sidebar overlay on mobile (closes sidebar via Alpine handler, then anchor scroll moves focus to \`#main-content\`)
- ✅ landmarks are labeled for screen reader navigation:
  - navbar wrapped in \`<header role=\"banner\">\` ✓
  - sidebar exposes \`role=\"complementary\"\` with \`aria-label=\"Model navigation\"\` ✓
  - main content has \`role=\"main\"\` (already present) ✓

## Manual test scenarios

1. Press Tab on any admin page — skip link appears top-left with high-contrast outline
2. At 375px, open sidebar overlay → press Tab → activate skip link → sidebar closes AND focus moves to main content
3. With VoiceOver/NVDA, page exposes 3 landmarks (banner, complementary, main) and they're navigable via shortcut keys

## Acceptance criteria

- [x] Skip-to-content link bypasses sidebar and closes overlay on mobile
- [x] All major page regions have appropriate ARIA landmarks and labels
- [x] Skip link is visually hidden but accessible via keyboard Tab
- [x] poe lint passes
- [x] poe test:unit passes (493 tests)

## Epic context

- **Epic:** \`.meta/epics/epic-responsive-design/epic.md\`
- **SDD:** \`docs/specs/responsive-design.md\`
- **Cycle:** 2 / 3 (stagger pickup — runs after main slots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)