### PR TITLE
feat(ui): responsive cycle 2 stagger + cycle 3 polish (C3-A, C2-D, C3-B)

### DIFF
--- a/src/hyperadmin/static/css/_accessibility.css
+++ b/src/hyperadmin/static/css/_accessibility.css
@@ -58,7 +58,11 @@
   .ha-select,
   .ha-textarea,
   .ha-inline-add-btn,
-  .ha-inline-remove-btn {
+  .ha-inline-remove-btn,
+  .ha-theme-toggle,
+  .ha-navbar-user-btn,
+  .ha-sidebar-toggle,
+  .ha-sidebar-close {
     min-height: 44px;
     min-width: 44px;
     display: inline-flex;

--- a/src/hyperadmin/static/css/_filter.css
+++ b/src/hyperadmin/static/css/_filter.css
@@ -55,3 +55,28 @@
 .ha-filter-toggle .ha-icon {
   transition: transform 0.2s var(--ha-ease-default);
 }
+
+/* ==========================================================================
+   Mobile (< 768px) — stack filter controls full-width
+   ========================================================================== */
+
+@media (max-width: 767px) {
+  .ha-filter-container {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--ha-space-3);
+  }
+
+  .ha-filter-group {
+    width: 100%;
+  }
+
+  .ha-filter-clear {
+    width: 100%;
+    text-align: center;
+  }
+
+  .ha-filter-toggle {
+    min-height: 44px;
+  }
+}

--- a/src/hyperadmin/static/css/_login.css
+++ b/src/hyperadmin/static/css/_login.css
@@ -7,17 +7,27 @@
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  padding: var(--ha-space-4);
+  padding: var(--ha-space-3);
 }
 
 .ha-login-card {
   width: 100%;
   max-width: 24rem;
-  padding: var(--ha-space-8);
+  padding: var(--ha-space-5);
   background-color: var(--ha-surface-raised);
   border: var(--ha-border-width) solid var(--ha-color-border-light);
   border-radius: var(--ha-radius-xl);
   box-shadow: var(--ha-shadow-lg);
+}
+
+@media (min-width: 768px) {
+  .ha-login-container {
+    padding: var(--ha-space-4);
+  }
+
+  .ha-login-card {
+    padding: var(--ha-space-8);
+  }
 }
 
 .ha-login-title {

--- a/src/hyperadmin/static/css/_navbar.css
+++ b/src/hyperadmin/static/css/_navbar.css
@@ -14,21 +14,39 @@
 .ha-navbar-inner {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 0 var(--ha-space-6);
+  padding: 0 var(--ha-space-3);
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: var(--ha-space-2);
   height: var(--ha-navbar-height);
 }
 
+@media (min-width: 768px) {
+  .ha-navbar-inner {
+    padding: 0 var(--ha-space-6);
+    gap: var(--ha-space-3);
+  }
+}
+
 .ha-navbar-brand {
-  font-size: var(--ha-font-size-xl);
+  font-size: var(--ha-font-size-lg);
   font-weight: var(--ha-font-extrabold);
   color: var(--ha-color-primary-700);
   text-decoration: none;
   letter-spacing: -0.025em;
   transition: color var(--ha-transition);
   margin-right: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (min-width: 768px) {
+  .ha-navbar-brand {
+    font-size: var(--ha-font-size-xl);
+  }
 }
 
 /* ==========================================================================
@@ -85,6 +103,7 @@
   display: flex;
   align-items: center;
   gap: var(--ha-space-2);
+  min-height: 44px;
   color: var(--ha-color-text-muted);
   background: none;
   border: var(--ha-border-width) solid transparent;
@@ -94,6 +113,16 @@
   font-weight: var(--ha-font-medium);
   padding: var(--ha-space-1-5) var(--ha-space-3);
   transition: all var(--ha-transition);
+  flex-shrink: 0;
+}
+
+/* Hide the username label on very small screens — icon + chevron remain.
+   The dropdown still labels the user clearly; this keeps the navbar from
+   overflowing at 320px. */
+@media (max-width: 374px) {
+  .ha-navbar-user-btn span:not(.ha-navbar-user-btn-chevron) {
+    display: none;
+  }
 }
 
 .ha-navbar-user-btn:hover {

--- a/src/hyperadmin/static/css/_pagination.css
+++ b/src/hyperadmin/static/css/_pagination.css
@@ -44,3 +44,42 @@
   font-size: var(--ha-font-size-sm);
   font-weight: var(--ha-font-semibold);
 }
+
+/* ==========================================================================
+   Mobile (< 768px) — stack pagination vertically with centered controls
+   ========================================================================== */
+
+@media (max-width: 767px) {
+  .ha-pagination {
+    flex-direction: column;
+    align-items: center;
+    gap: var(--ha-space-3);
+    padding: var(--ha-space-4);
+  }
+
+  .ha-pagination-info {
+    text-align: center;
+    word-wrap: break-word;
+  }
+
+  .ha-pagination-controls {
+    gap: var(--ha-space-2);
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .ha-pagination-btn {
+    min-height: 44px;
+    padding: var(--ha-space-2) var(--ha-space-4);
+    font-size: var(--ha-font-size-base);
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .ha-pagination-page {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    font-size: var(--ha-font-size-base);
+  }
+}

--- a/src/hyperadmin/static/css/_search.css
+++ b/src/hyperadmin/static/css/_search.css
@@ -32,3 +32,20 @@
   font-size: var(--ha-font-size-sm);
   color: var(--ha-color-text-muted);
 }
+
+/* ==========================================================================
+   Mobile (< 768px) — full-width search with touch-friendly height
+
+   The base .ha-search-input already has width: 100% so it takes the
+   container width on mobile; here we just bump font-size to 1rem
+   (matching the form input rule in C2-B — prevents iOS Safari auto-zoom)
+   and increase padding to meet the 44px touch target.
+   ========================================================================== */
+
+@media (max-width: 767px) {
+  .ha-search-input {
+    padding: var(--ha-space-3);
+    font-size: 1rem;
+    min-height: 44px;
+  }
+}

--- a/src/hyperadmin/static/css/_theme-toggle.css
+++ b/src/hyperadmin/static/css/_theme-toggle.css
@@ -6,8 +6,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
+  width: 44px;
+  height: 44px;
   background: none;
   border: var(--ha-border-width) solid var(--ha-color-border);
   border-radius: var(--ha-radius);
@@ -16,6 +16,14 @@
   transition: color var(--ha-transition), border-color var(--ha-transition);
   padding: 0;
   margin-right: var(--ha-space-2);
+  flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+  .ha-theme-toggle {
+    width: 2rem;
+    height: 2rem;
+  }
 }
 
 .ha-theme-toggle:hover {

--- a/src/hyperadmin/templates/login.html
+++ b/src/hyperadmin/templates/login.html
@@ -9,16 +9,16 @@
 {%- block content -%}
 <div class="ha-login-container">
     <div class="ha-login-card">
-        <h1 class="ha-login-title">HyperAdmin</h1>
+        <h1 id="login-title" class="ha-login-title">HyperAdmin</h1>
         <p class="ha-text-muted">Sign in to your account</p>
 
         {%- if error -%}
-        <div class="ha-alert ha-alert-error" data-testid="login-error">
+        <div class="ha-alert ha-alert-error" data-testid="login-error" role="alert">
             {{ error }}
         </div>
         {%- endif -%}
 
-        <form method="post" action="{{ admin_prefix }}/login" data-testid="login-form">
+        <form method="post" action="{{ admin_prefix }}/login" data-testid="login-form" aria-labelledby="login-title">
             <div class="ha-form-group">
                 <label for="username" class="ha-label">Username</label>
                 <input


### PR DESCRIPTION
## Summary

Consolidates three small responsive polish stories into one PR with one commit per story:

1. **C3-A** (Cycle 3 navbar polish) — closes #465
2. **C2-D** (Cycle 2 stagger: pagination + filter + search mobile rules) — closes #464
3. **C3-B** (Cycle 3 login + detail + dashboard polish) — closes #470

All three are file-disjoint apart from `_accessibility.css` (extended in C3-A only).

## Commits

| Commit | Story | Closes |
|---|---|---|
| `9eef63b` | feat(ui): responsive navbar with mobile optimizations (C3-A) | #465 |
| `a743ec1` | feat(ui): mobile-optimized pagination and filter bar (C2-D) | #464 |
| `c88d1a3` | feat(ui): responsive login, detail, and dashboard polish (C3-B) | #470 |

## C3-A — Responsive navbar

| File | Change |
|---|---|
| `_navbar.css` | Tighter inner padding (space-3 mobile, space-6 desktop). Brand drops to font-size-lg with overflow ellipsis on mobile, restored at 768px. User button gains 44px min-height + flex-shrink:0. At < 375px the username label hides (icon + chevron remain). |
| `_theme-toggle.css` | Toggle bumped to 44×44 on mobile (from 2rem), restored to 2rem at >= 768px. flex-shrink:0 to prevent squashing. |
| `_accessibility.css` | Coarse-pointer touch target rule extended to `.ha-theme-toggle`, `.ha-navbar-user-btn`, `.ha-sidebar-toggle`, `.ha-sidebar-close`. |

## C2-D — Mobile-optimized pagination/filter/search

| File | Change |
|---|---|
| `_pagination.css` | At < 768px: `.ha-pagination` stacks vertically with centered controls; info text wraps; Prev/Next get 44px min-height and base font-size; controls flex-wrap. |
| `_filter.css` | At < 768px: `.ha-filter-container` stacks; `.ha-filter-group` and clear button full-width; toggle gets 44px min-height. |
| `_search.css` | At < 768px: search input gets 16px font-size (prevents iOS auto-zoom), 44px min-height, finger-friendly padding. Width already 100% in base. |

## C3-B — Login + detail + dashboard

| File | Change |
|---|---|
| `_login.css` | Container padding tightened to space-3 (was space-4) on mobile; card padding to space-5 (was space-8). Restored at >= 768px. |
| `login.html` | Title gets `id=\"login-title\"`; form gets `aria-labelledby=\"login-title\"` so screen readers announce \"HyperAdmin\" as the form name. Error alert gets `role=\"alert\"` for immediate announcement. |

Detail and dashboard views were already covered by upstream cycle work (forms via C2-B, action buttons via C2-C), so this commit is login-focused.

## BDD scenarios covered

**C3-A:**
- ✅ navbar adjusts spacing on mobile (reduced padding)
- ✅ navbar actions remain accessible at 320px (theme toggle 44px, user button 44px, hamburger 44px)
- ✅ navbar buttons have accessible aria-label names (already present from prior cycles)

**C2-D:**
- ✅ pagination stacks vertically on mobile with centered controls
- ✅ pagination info wraps gracefully
- ✅ filter controls stack full-width on mobile
- ✅ search input is full-width on mobile

**C3-B:**
- ✅ login page is centered and usable on mobile
- ✅ inputs full-width with adequate touch targets (from C2-B)
- ✅ Sign In button full-width (existing `.ha-btn-block`)
- ✅ login form accessible to screen readers (`aria-labelledby` + label associations)
- ✅ detail view fields stack vertically (existing `.ha-form-group`)
- ✅ detail action buttons wrap on mobile (from C2-C `flex-wrap`)

## Manual test scenarios

At 375px viewport on `examples/simple`:

1. **Navbar**: brand + hamburger + theme toggle + user dropdown all fit without overflow; tap targets all >= 44px
2. **At 320px**: same as above; username label hidden, icon + chevron visible
3. **List pagination**: scroll to bottom of a list with multiple pages → controls stack vertically and center; Prev/Next buttons large enough to tap
4. **Filter bar**: open filter panel on a filterable list → each filter is full-width and stacks vertically
5. **Search**: search input spans full width, 16px font (no iOS zoom on focus)
6. **Login** at 375px and 320px: card centered, comfortable padding, all inputs comfortable to tap, Sign In full-width

## Acceptance criteria

- [x] All three stories' acceptance criteria covered
- [x] poe lint passes
- [x] poe test:unit passes (493 tests)
- [x] No new ha-* class names in test selectors

## Epic context

- **Epic:** \`.meta/epics/epic-responsive-design/epic.md\`
- **SDD:** \`docs/specs/responsive-design.md\`
- **Cycle:** 2 stagger (C2-D) + 3 (C3-A, C3-B)
- **Remaining:** C3-C E2E test suite (#471), C3-D visual regression baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)