### PR TITLE
chore(pm): create v0.4.1 i18n SDD and epic backlog

### DIFF
--- a/.meta/epics/epic-i18n/epic.md
+++ b/.meta/epics/epic-i18n/epic.md
@@ -1,0 +1,130 @@
+---
+type: epic
+id: I18nMain_01
+title: "epic(i18n): Internationalization -- gettext + Babel + RTL + 7 locales"
+status: in_progress
+priority: high
+owner: null
+labels:
+  - i18n
+  - backend
+  - frontend
+  - css
+milestone_ref:
+  id: ulcysRt0fus6
+github: null
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+---
+
+## Epic: Internationalization -- gettext + Babel + RTL
+
+Part of milestone: **v0.4.1 -- i18n** (target: 2026-07-30)
+
+**Spec:** `docs/specs/i18n.md`
+
+### Goal
+
+Make HyperAdmin localizable end-to-end: every UI string is translatable via gettext,
+runtime locale is detected per-request (cookie > Accept-Language > settings default),
+users can switch locale from the navbar, the layout supports RTL via logical CSS
+properties, and 7 seed locales (en, es, fr, de, zh_CN, ja, uk) ship with empty catalogs
+ready for community translation. English remains the only fully-translated locale at
+release; other catalogs are scaffolded for follow-up.
+
+### Principles
+
+1. **Babel + jinja2.ext.i18n** -- canonical Python i18n stack, no custom invention.
+2. **Cookie-driven locale** -- no URL-prefix routing changes; mirrors the auth-cookie pattern.
+3. **Logical CSS only** -- physical properties (`margin-right`, `text-align: left`) become
+   logical (`margin-inline-end`, `text-align: start`); RTL is structural, not bolted on.
+4. **Backward compatible** -- existing apps default to `en` and render identically.
+5. **Bottom-up** -- deps + settings -> middleware -> Jinja loader -> wrap strings ->
+   switcher -> RTL -> catalogs -> tests.
+
+### 3-Cycle Delivery Plan (zero file conflict per cycle)
+
+#### Cycle 0 -- SDD (1 chore-pm, human gate)
+
+| Slot | Story | Size |
+|------|-------|------|
+| C0   | chore(pm): create i18n SDD + epic | S |
+
+Human gate: `review(spec): approve SDD for i18n` -- blocks all C1+ stories.
+
+#### Cycle 1 -- Foundations
+
+| Slot | Story | Size | Files |
+|------|-------|------|-------|
+| C1-A | feat(core): add Babel + locale settings to HyperAdminSettings | S | `pyproject.toml`, `src/hyperadmin/core/settings.py` |
+| C1-B | feat(core): LocaleMiddleware (cookie > Accept-Language > default) | M | `src/hyperadmin/i18n/__init__.py` (new), `src/hyperadmin/i18n/middleware.py` (new), `src/hyperadmin/core/app.py` (wire) |
+| C1-C | feat(core): wire jinja2.ext.i18n + per-request Translations | M | `src/hyperadmin/i18n/loader.py` (new), `src/hyperadmin/core/app.py` (extend Jinja env) |
+
+Conflict check: A+B disjoint -> parallel. C touches `app.py` near the same Jinja init
+block as B, sequence C after B merges.
+
+#### Cycle 2 -- Strings + switcher
+
+| Slot | Story | Size | Files |
+|------|-------|------|-------|
+| C2-A | refactor(ui): wrap login/navbar/sidebar/messages in `_()` | S | `templates/login.html`, `_navbar.html`, `_sidebar.html`, `_messages.html` |
+| C2-B | refactor(ui): wrap list/detail/form/pagination/components | M | `templates/list_layout.html`, `detail.html`, `create.html`, `update.html`, `form_layout.html`, `pagination.html`, `components/*` |
+| C2-C | feat(views): structured flash + translatable validation messages | M | `src/hyperadmin/views/static.py`, `src/hyperadmin/views/forms.py` |
+| C2-D | feat(ui): locale switcher in navbar + POST endpoint sets cookie | M | `templates/_navbar.html` (rebase on C2-A), `static/css/_navbar.css`, `src/hyperadmin/views/locale.py` (new) |
+| C2-E | feat(core): translatable model verbose names + field labels | M | `src/hyperadmin/core/options.py`, `src/hyperadmin/core/registry.py` |
+
+Conflict check: A/B/C/E disjoint -> parallel. C2-D rebases on C2-A (both touch
+`_navbar.html`).
+
+#### Cycle 3 -- RTL + catalogs + tests
+
+| Slot | Story | Size | Files |
+|------|-------|------|-------|
+| C3-A | refactor(ui): physical -> logical CSS properties | M | all `src/hyperadmin/static/css/*.css` |
+| C3-B | feat(ui): `<html dir>` from locale + `_rtl.css` overrides | S | `templates/_base.html`, `static/css/_rtl.css` (new), `static/css/main.css` (import) |
+| C3-C | feat(build): Babel extraction + 7 locale catalogs + poe targets | M | `babel.cfg` (new), `src/hyperadmin/locale/<locale>/LC_MESSAGES/messages.po` x 7, `pyproject.toml` |
+| C3-D | test(unit): LocaleMiddleware + Translations loader | M | `tests/unit/test_i18n_middleware.py`, `tests/unit/test_i18n_loader.py` |
+| C3-E | test(e2e): locale switcher + RTL layout snapshot | M | `tests/e2e/test_i18n.py` |
+
+Conflict check: C3-A/C3-B both touch CSS -- A finishes the logical-property refactor,
+B layers RTL-specific overrides; sequence A -> B. C3-C/D/E parallel after C3-A.
+
+### Sub-issues (14 stories: 1 chore-pm + 13 feat/test)
+
+| Cycle | Story | Size | Depends on |
+|-------|-------|------|-----------|
+| C0    | chorepm-create-i18n-sdd | S | none |
+| C1-A  | feat-core-babel-locale-settings | S | SDD approved |
+| C1-B  | feat-core-locale-middleware | M | SDD approved |
+| C1-C  | feat-core-jinja-i18n-loader | M | C1-B |
+| C2-A  | refactorui-wrap-login-navbar-sidebar | S | C1-C |
+| C2-B  | refactorui-wrap-list-detail-form | M | C1-C |
+| C2-C  | featviews-translatable-validation | M | C1-C |
+| C2-D  | featui-locale-switcher | M | C2-A |
+| C2-E  | featcore-translatable-model-verbose | M | C1-C |
+| C3-A  | refactorui-logical-css-properties | M | none (independent) |
+| C3-B  | featui-html-dir-rtl-overrides | S | C3-A, C2-D |
+| C3-C  | featbuild-babel-extract-7-catalogs | M | all C2 wrap-string stories |
+| C3-D  | testunit-i18n-middleware-loader | M | C1-B, C1-C |
+| C3-E  | teste2e-locale-switcher-rtl | M | all C3 |
+
+### Critical Path
+
+```
+C1-B (middleware, M) -> C1-C (loader, M) -> C2-D (switcher, M) -> C3-B (RTL, S) -> C3-E (e2e, M)
+```
+
+### Acceptance Criteria
+
+- [ ] SDD at `docs/specs/i18n.md` reviewed and approved
+- [ ] Babel + locale settings wired into `HyperAdminSettings`
+- [ ] LocaleMiddleware resolves locale per request (cookie > Accept-Language > default)
+- [ ] Jinja templates render via `jinja2.ext.i18n` with per-request `Translations`
+- [ ] All 38 hardcoded UI strings wrapped in `_()` / `{% trans %}`
+- [ ] Locale switcher in navbar sets `hyperadmin_locale` cookie
+- [ ] Model verbose names and field labels translatable
+- [ ] All CSS uses logical properties; `_rtl.css` overrides where needed
+- [ ] `<html dir>` driven by locale; RTL layout mirrors LTR at all breakpoints
+- [ ] 7 locale catalogs scaffolded under `src/hyperadmin/locale/`
+- [ ] `poe i18n:extract` and `poe i18n:compile` targets work
+- [ ] Unit + E2E tests cover middleware, loader, switcher, and RTL

--- a/.meta/epics/epic-i18n/stories/chorepm-create-i18n-sdd.md
+++ b/.meta/epics/epic-i18n/stories/chorepm-create-i18n-sdd.md
@@ -1,0 +1,80 @@
+---
+type: story
+id: I18nMain_C0PM
+title: "chore(pm): create i18n SDD and epic backlog for v0.4.1"
+status: in_progress
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - i18n
+  - cycle:0
+estimate: null
+epic_ref:
+  id: I18nMain_01
+github: null
+created_at: 2026-05-03T00:00:00Z
+updated_at: 2026-05-03T00:00:00Z
+---
+
+## Summary
+
+Author the v0.4.1 i18n design document and seed the epic backlog so Cycle 1+ stories
+can be dispatched in parallel after human approval.
+
+This is the Cycle 0 / human-gate task per `.claude/rules/sdd-conventions.md`. It does
+not modify production code -- only `docs/specs/i18n.md` and `.meta/`.
+
+## Scenarios
+
+**Scenario: SDD draft exists at the canonical path**
+  Given the v0.4.1 milestone is `in_progress`
+  When  this task completes
+  Then  `docs/specs/i18n.md` exists with status **Draft**
+  And   the file follows `docs/specs/TEMPLATE.md` section structure
+
+**Scenario: epic file references the SDD**
+  Given the i18n epic is created
+  When  inspecting `.meta/epics/epic-i18n/epic.md`
+  Then  the body contains `**Spec:** docs/specs/i18n.md`
+  And   `milestone_ref.id` is `ulcysRt0fus6` (v0.4.1)
+
+**Scenario: human approves the SDD before C1 starts**
+  Given the SDD is in **Draft** status
+  When  a human reviewer marks it **Approved**
+  Then  Cycle 1 stories (C1-A, C1-B) become unblocked
+  And   the SDD frontmatter `Status` field is updated
+
+## Tasks
+
+- [x] Create `.meta/epics/epic-i18n/epic.md` linking milestone v0.4.1
+- [x] Create `.meta/epics/epic-i18n/stories/chorepm-create-i18n-sdd.md` (this file)
+- [x] Write `docs/specs/i18n.md` from `docs/specs/TEMPLATE.md` (status: Draft)
+- [ ] Open PR and request human review of the SDD
+- [ ] On approval, flip SDD `Status` -> `Approved` and dispatch C1-A + C1-B
+
+## Acceptance criteria
+
+- [ ] `docs/specs/i18n.md` exists, status: Draft
+- [ ] Epic at `.meta/epics/epic-i18n/epic.md` exists and links the SDD
+- [ ] `./scripts/gitpm.sh validate` exits 0
+- [ ] PR opened with the SDD + epic + this story
+- [ ] Human-approval comment on the PR flips SDD status to Approved before C1 dispatch
+
+## Files to modify
+
+- `docs/specs/i18n.md` (new) -- SDD draft
+- `.meta/epics/epic-i18n/epic.md` (new) -- epic descriptor
+- `.meta/epics/epic-i18n/stories/chorepm-create-i18n-sdd.md` (new) -- this story
+
+## Demo checkpoint
+
+`./scripts/gitpm.sh validate` exits 0 and `docs/specs/i18n.md` renders cleanly in
+a markdown preview. Human review on the PR is the gate.
+
+## Agent
+
+- **Size:** S
+- **Tier:** Sonnet (planning)
+- **blocked_by:** none (this is the Cycle 0 gate)

--- a/docs/specs/i18n.md
+++ b/docs/specs/i18n.md
@@ -1,0 +1,249 @@
+# SDD: Internationalization (i18n) -- gettext + Babel + RTL
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD (epic issue to be created via gitpm push) |
+| Milestone | v0.4.1 -- i18n |
+| Created | 2026-05-03 |
+| Last updated | 2026-05-03 |
+
+---
+
+## Problem
+
+HyperAdmin is English-only and LTR-only. Inventory of the current code:
+
+- ~38 hardcoded UI strings across 13 Jinja2 templates (login, navbar, sidebar, list,
+  detail, form, pagination, components).
+- Dynamic strings from SQLModel `verbose_name`, Pydantic field labels, and Pydantic
+  validation messages are emitted unwrapped.
+- `HyperAdminSettings` (`src/hyperadmin/core/settings.py`) has no locale fields.
+- `Admin.__init__` (`src/hyperadmin/core/app.py:82`) constructs a Jinja2 environment
+  without `jinja2.ext.i18n`.
+- No Babel / gettext dependency in `pyproject.toml`.
+- CSS uses **physical** properties throughout (`margin-right`, `text-align: left`,
+  `padding-left`). RTL is structurally broken until refactored to logical properties
+  (`margin-inline-end`, `text-align: start`, `padding-inline-start`).
+
+This blocks adoption by non-English-speaking teams and prevents shipping admin
+dashboards in markets that require Arabic/Hebrew (RTL) or East Asian locales.
+
+## Goals
+
+- gettext-based string extraction and message catalogs for 7 locales: `en`, `es`,
+  `fr`, `de`, `zh_CN`, `ja`, `uk`.
+- Runtime per-request locale detection (cookie `hyperadmin_locale` >
+  `Accept-Language` header > settings default).
+- Locale switcher rendered in the navbar; switching sets the cookie and reloads.
+- Full RTL support via logical CSS properties. `<html dir>` driven by the resolved
+  locale.
+- Translatable model verbose names and field labels via an i18n hook.
+- `poe i18n:extract` / `poe i18n:compile` workflow targets.
+- Backward compatible -- existing apps default to `en` and render identically.
+
+## Non-Goals
+
+- Plural form authoring beyond gettext `ngettext` -- callers are responsible for the
+  plural form expression.
+- Date / number / currency format overrides beyond Babel defaults.
+- Translation of user-supplied content (model row data, custom messages).
+- An in-admin catalog editor.
+- URL-prefix locale routing (`/en/admin/`, `/es/admin/`). Cookie-driven only.
+- Shipping translated catalogs for non-English locales -- catalogs are scaffolded
+  empty; community PRs fill them.
+
+## BDD Scenarios
+
+Representative scenarios per cycle. Full set lives in individual story files.
+
+```
+Scenario: default locale falls back to English
+  Given an Admin app with default settings
+  When  a request arrives with no cookie and no Accept-Language
+  Then  request.state.locale == "en"
+  And   templates render English strings
+
+Scenario: cookie overrides Accept-Language
+  Given an Admin app with supported_locales=["en","es","fr"]
+  When  a request arrives with cookie hyperadmin_locale=es and Accept-Language=fr-FR
+  Then  request.state.locale == "es"
+  And   templates render the Spanish catalog
+
+Scenario: Accept-Language is parsed when no cookie is present
+  Given an Admin app with supported_locales=["en","fr","de"]
+  When  a request arrives with Accept-Language="de-DE,de;q=0.9,en;q=0.8" and no cookie
+  Then  request.state.locale == "de"
+
+Scenario: unsupported cookie value is ignored
+  Given an Admin app with supported_locales=["en","es"]
+  When  a request arrives with cookie hyperadmin_locale=zz
+  Then  request.state.locale falls back to settings.default_locale
+  And   the cookie is NOT cleared (treated as user input, not corrupted state)
+
+Scenario: missing catalog falls back without error
+  Given supported_locales includes "ja" but its .mo file is missing
+  When  a request resolves to locale "ja"
+  Then  templates render the English msgid as the translation
+  And   no exception is raised
+
+Scenario: locale switcher sets cookie and redirects
+  Given a logged-in user on the dashboard
+  When  the user POSTs to /admin/locale with locale=es
+  Then  the response is 302 to the Referer (or /admin/ if absent)
+  And   the response sets cookie hyperadmin_locale=es with Path=/admin and HttpOnly
+
+Scenario: switcher rejects unsupported locale
+  Given supported_locales=["en","es"]
+  When  the user POSTs to /admin/locale with locale=zz
+  Then  the response is 400
+  And   no cookie is set
+
+Scenario: <html dir> reflects RTL locale
+  Given supported_locales includes "ar"
+  When  request.state.locale == "ar"
+  Then  the rendered <html> tag has dir="rtl"
+  And   _rtl.css overrides apply
+
+Scenario: model verbose_name is translated
+  Given a SQLModel User with __verbose_name__ = _("User")
+  When  the list page renders for locale "es"
+  Then  the page heading shows "Usuario" (from the catalog)
+
+Scenario: validation error message is translated
+  Given a form field with min_length=3
+  When  the user submits "ab" and the page renders for locale "es"
+  Then  the error list shows the Spanish translation of "Field too short"
+```
+
+## Design
+
+### Architecture
+
+```
+HTTP request
+    |
+    v
+LocaleMiddleware  ----------> request.state.locale = "es"
+    |                        request.state.translations = babel.support.Translations
+    v
+View handler
+    |
+    v
+Jinja2 env (ext.i18n) ------> _, gettext, ngettext bound to request.state.translations
+    |
+    v
+Template renders {{ _("Save") }} -> "Guardar"
+```
+
+Affected modules:
+
+- `src/hyperadmin/i18n/` (new package)
+  - `__init__.py` -- public exports: `LocaleMiddleware`, `gettext_lazy`, `Translations`.
+  - `middleware.py` -- `LocaleMiddleware` (mirror of `auth/middleware.py:AuthenticationMiddleware`).
+  - `loader.py` -- `load_translations(locale: str) -> babel.support.Translations` with
+    in-memory LRU cache and graceful fallback to `NullTranslations`.
+- `src/hyperadmin/core/settings.py` -- new fields `default_locale`, `supported_locales`.
+- `src/hyperadmin/core/app.py` -- `Admin.__init__` mounts `LocaleMiddleware`, registers
+  `jinja2.ext.i18n`, installs Translations via context processor.
+- `src/hyperadmin/views/locale.py` (new) -- `POST /admin/locale` switcher endpoint.
+- `src/hyperadmin/core/options.py` / `registry.py` -- thread `gettext_lazy` through
+  `verbose_name` and field labels.
+- `src/hyperadmin/templates/*.html` -- wrap strings in `_()` / `{% trans %}`.
+- `src/hyperadmin/static/css/*.css` -- physical -> logical properties; new `_rtl.css`.
+- `src/hyperadmin/locale/<locale>/LC_MESSAGES/messages.{po,mo}` -- 7 locales.
+- `babel.cfg` (new) -- extraction config for Babel CLI.
+
+### Data Model Changes
+
+No data model changes.
+
+### API / Protocol Changes
+
+`HyperAdminSettings` gains:
+
+```python
+default_locale: str = "en"
+supported_locales: list[str] = ["en", "es", "fr", "de", "zh_CN", "ja", "uk"]
+```
+
+`Admin(...)` gains an optional `locales: Sequence[str] | None = None` override that
+takes precedence over settings when provided.
+
+Public exports added to `hyperadmin.__init__`:
+
+```python
+from hyperadmin.i18n import LocaleMiddleware, gettext_lazy
+```
+
+Jinja globals exposed: `_`, `gettext`, `ngettext` (via `jinja2.ext.i18n`).
+
+New endpoint: `POST /admin/locale` -- form body `locale=<code>`, sets cookie and 302s
+to Referer (or `/admin/` fallback). Read-only `GET` is not exposed.
+
+### Configuration Changes
+
+| Variable | Default | Description |
+|---|---|---|
+| `HYPERADMIN_DEFAULT_LOCALE` | `"en"` | Locale used when no cookie / Accept-Language match |
+| `HYPERADMIN_SUPPORTED_LOCALES` | `["en","es","fr","de","zh_CN","ja","uk"]` | Allowed locale codes |
+
+Cookie `hyperadmin_locale` -- `Path=/admin`, `HttpOnly`, `SameSite=Lax`,
+`Max-Age=31536000` (1 year), no `Secure` flag in dev (set in production via
+existing cookie-secure settings hook).
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Missing `.mo` file for a supported locale | `loader.load_translations` returns `NullTranslations`; templates render English msgid; warning logged once |
+| Cookie value not in `supported_locales` | Ignored; fall back to Accept-Language / default. Cookie not cleared (user may set it back from another tab) |
+| Accept-Language header malformed | `babel.Locale.parse` raises -> caught; fall back to default |
+| Translations file corrupted | `load_translations` catches `OSError` / `UnicodeDecodeError`; returns `NullTranslations`; logged at WARNING |
+| Locale switcher receives unsupported locale | 400 response, no cookie set |
+| Locale switcher CSRF | POST + same-origin cookie + 302 to Referer; relies on existing CSRF middleware |
+| RTL + dark-mode interaction | RTL overrides live in `_rtl.css`, loaded after dark-mode tokens; logical properties carry both |
+| RTL + responsive sidebar (v0.4.0) | Sidebar already uses `inset-inline-start` via logical refactor in C3-A; `dir="rtl"` flips it automatically |
+| `gettext_lazy` evaluated outside a request | Returns the msgid; no exception |
+| Templates rendered in error handlers (no LocaleMiddleware run) | Context processor checks `getattr(request.state, "translations", None)`; falls back to `NullTranslations` |
+
+## Migration & Backward Compatibility
+
+Backward compatible -- no migration required.
+
+- Existing apps default to `default_locale="en"` and render identically.
+- No public API removals or signature changes; only additive fields and exports.
+- Templates wrapped in `_()` render the msgid verbatim when no catalog is loaded,
+  matching current behavior for all English deployments.
+- Catalogs ship empty for non-English locales; existing users do not opt in by
+  default.
+
+## Open Questions
+
+- [x] Babel vs python-fluent? -> **Babel.** Mature ecosystem, `jinja2.ext.i18n` is a
+  drop-in extension, xgettext extraction works out of the box.
+- [x] Cookie vs URL-prefix locale routing? -> **Cookie.** No routing changes, aligns
+  with the existing auth-cookie pattern (`auth/middleware.py`), zero impact on link
+  generation.
+- [x] Where does the locale switcher live? -> **Navbar.** Most discoverable; rebases
+  on the responsive navbar from v0.4.0 (C2-A).
+- [x] Ship full translations or empty catalogs? -> **Empty.** 6 non-English catalogs
+  are scaffolded with msgids only; community PRs translate. English ships fully.
+- [x] How are model `verbose_name`s wrapped? -> `gettext_lazy` so class-body
+  evaluation does not require an active request.
+- [ ] Should `LocaleMiddleware` set `Content-Language` response header? -> Default
+  yes; can be disabled via `HYPERADMIN_LOCALE_RESPONSE_HEADER=false`. Final decision
+  during C1-B implementation.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Babel + `jinja2.ext.i18n` | Mature, canonical, integrates with `xgettext` extraction | python-fluent (less ecosystem); custom Jinja filter (no `{% trans %}` block, harder extraction) |
+| Cookie-driven locale | No URL changes; mirrors existing auth-cookie pattern | URL-prefix (`/en/admin/`) -- breaks all reverse-URL helpers; `Accept-Language`-only -- no user override |
+| Logical CSS first, RTL overrides second | Most layout works automatically once physical -> logical refactor is done; `_rtl.css` carries the few exceptions | Two parallel CSS bundles (`ltr.css` / `rtl.css`) -- doubles maintenance |
+| 7 locales seeded empty | Translations are a community concern; empty catalogs prove the pipeline without taking on translation responsibility | Ship 7 fully translated -- out of scope for v0.4.1; ship only `en` -- no proof RTL or non-Latin scripts work |
+| `gettext_lazy` for model metadata | `verbose_name` is evaluated at class-body time, before any request -- lazy proxies are mandatory | `gettext` directly -- fails with no active translations |
+| `LocaleMiddleware` mirrors `AuthenticationMiddleware` | Existing pattern, well-understood, sets `request.state.*` | Custom ASGI middleware -- reinvents the wheel |
+| Split RTL CSS (C3-A logical, C3-B overrides) | Logical-property refactor is large enough to merit its own story; overrides are small and locale-gated | One mega-story -- harder to review, mixes mechanical refactor with new RTL logic |


### PR DESCRIPTION
## Summary

Cycle 0 / human-gate task for milestone **v0.4.1 -- i18n** (#20).

- New SDD at `docs/specs/i18n.md` (Status: **Draft**) covering Babel + `jinja2.ext.i18n`, cookie-driven locale detection, logical-CSS RTL strategy, locale switcher, translatable model metadata.
- New epic `.meta/epics/epic-i18n/` with 14-story backlog (1 chore-pm + 13 feat/test) across 3 cycles.
- File-target zero-conflict map ready for parallel agent dispatch once the SDD is approved.

## Spec

`docs/specs/i18n.md`

## Backlog (3 cycles)

- **C1 (Foundations)** -- Babel + locale settings, `LocaleMiddleware`, Jinja `ext.i18n` + per-request `Translations` loader.
- **C2 (Strings + switcher)** -- wrap all 38 hardcoded UI strings, translatable validation messages, locale switcher endpoint, translatable model verbose names.
- **C3 (RTL + catalogs + tests)** -- physical -> logical CSS refactor, `<html dir>` + `_rtl.css`, Babel extraction + 7 locale catalogs, unit + E2E tests.

Critical path: C1-B -> C1-C -> C2-D -> C3-B -> C3-E.

## Manual test scenarios

This PR is documentation + planning only -- no code paths exercised.

- [ ] Reviewer reads `docs/specs/i18n.md` end-to-end and resolves the one open question (Content-Language response header)
- [ ] Reviewer confirms the 7 locales (en, es, fr, de, zh_CN, ja, uk) match the milestone description
- [ ] Reviewer confirms cookie-driven approach is acceptable (vs URL-prefix)
- [ ] On approval, flip SDD frontmatter `Status` from **Draft** to **Approved** in a follow-up commit
- [ ] `./scripts/gitpm.sh validate` exits 0 (CI verifies)

## Blocks

C1+ stories are blocked until a human flips the SDD status to Approved per `.claude/rules/sdd-conventions.md`.