### PR TITLE
feat(core): add Babel + locale settings to HyperAdminSettings (C1-A)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,8 @@ type = "simple"
   # GHSA-4xh5-x5gv-qwph is a false positive for this project, as it's a vulnerability in pypy-3.11, and this project uses CPython.
   # CVE-2026-4539: pygments vulnerability; pygments is a dev-only dep (rich, mkdocs-material, pytest) — not a runtime dep of this library. No fix available yet.
   # CVE-2026-25645: requests vulnerability; requests is a dev-only transitive dep (mkdocs, pip-audit, pytest-base-url). Fix: requests>=2.33.0.
-  cmd = "pip-audit --format markdown --ignore-vuln GHSA-4xh5-x5gv-qwph --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645"
+  # CVE-2026-3219: pip vulnerability in pip itself (the package manager, not a runtime dep of this library). Tracked upstream; no action required by this project.
+  cmd = "pip-audit --format markdown --ignore-vuln GHSA-4xh5-x5gv-qwph --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219"
 
   [tool.poe.tasks.license-check]
   help = "Check this package's dependencies for license issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
   "typer>=0.12",
   "argon2-cffi",
   "itsdangerous>=2.0",
-  "python-multipart>=0.0.26"
+  "python-multipart>=0.0.26",
+  "babel>=2.13"
 ]
 
 [project.scripts]

--- a/src/hyperadmin/core/settings.py
+++ b/src/hyperadmin/core/settings.py
@@ -7,6 +7,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _DEFAULT_SECRET_KEY = "hyperadmin-default-secret"  # noqa: S105
 _DEFAULT_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+_DEFAULT_SUPPORTED_LOCALES = ["en", "es", "fr", "de", "zh_CN", "ja", "uk"]
 
 ThemeLiteral = Literal["auto", "light", "dark"]
 
@@ -66,6 +67,10 @@ class HyperAdminSettings(BaseSettings):
     # ── Formatting ────────────────────────────────────────────────────────────
     date_format: str = "%Y-%m-%d"
     datetime_format: str = "%Y-%m-%d %H:%M:%S"
+
+    # ── Internationalization ──────────────────────────────────────────────────
+    default_locale: str = "en"
+    supported_locales: list[str] = Field(default_factory=lambda: list(_DEFAULT_SUPPORTED_LOCALES))
 
     # ── Derived helpers ───────────────────────────────────────────────────────
     @property

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -25,6 +25,8 @@ class TestDefaults:
         assert settings.items_per_page == 20
         assert settings.date_format == "%Y-%m-%d"
         assert settings.datetime_format == "%Y-%m-%d %H:%M:%S"
+        assert settings.default_locale == "en"
+        assert settings.supported_locales == ["en", "es", "fr", "de", "zh_CN", "ja", "uk"]
 
     def test_is_default_secret_key_true_when_using_default(self) -> None:
         settings = HyperAdminSettings()
@@ -81,6 +83,23 @@ class TestEnvVarLoading:
         monkeypatch.setenv("HYPERADMIN_SECRET_KEY", "env-value")
         settings = HyperAdminSettings(secret_key="explicit")
         assert settings.secret_key == "explicit"
+
+    def test_default_locale_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_DEFAULT_LOCALE", "es")
+        settings = HyperAdminSettings()
+        assert settings.default_locale == "es"
+
+    def test_supported_locales_from_env_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYPERADMIN_SUPPORTED_LOCALES", '["en", "es", "uk"]')
+        settings = HyperAdminSettings()
+        assert settings.supported_locales == ["en", "es", "uk"]
+
+
+class TestBabelImportable:
+    def test_babel_importable(self) -> None:
+        import babel
+
+        assert babel.__version__ >= "2.13"
 
 
 class TestValidation:


### PR DESCRIPTION
## Summary

Cycle 1, Slot A of v0.4.1 i18n epic. Pure additive change -- no existing behavior modified.

- Adds `babel>=2.13` to `[project.dependencies]`.
- Adds `default_locale: str = "en"` and `supported_locales: list[str] = ["en","es","fr","de","zh_CN","ja","uk"]` to `HyperAdminSettings`.
- Both fields env-bound via existing `HYPERADMIN_` prefix (`HYPERADMIN_DEFAULT_LOCALE`, `HYPERADMIN_SUPPORTED_LOCALES`).
- Unit tests cover defaults + env overrides + babel importability (4 new tests).
- Bundles a small build fix: ignore CVE-2026-3219 in `pip-audit` (pip self-vuln, dev-tool only -- same pattern as existing pygments/requests ignores).

Provides the configuration surface that C1-B (LocaleMiddleware) and C1-C (Jinja Translations loader) consume.

## Spec

`docs/specs/i18n.md`

## Story

`.meta/epics/epic-i18n/stories/c1a-babel-locale-settings.md`

## Manual test scenarios

- [ ] `uv sync --extra dev` succeeds; `babel` is installed at >= 2.13
- [ ] `python -c "from hyperadmin.core.settings import HyperAdminSettings; print(HyperAdminSettings().default_locale)"` prints `en`
- [ ] `HYPERADMIN_DEFAULT_LOCALE=es python -c "..."` prints `es`
- [ ] `HYPERADMIN_SUPPORTED_LOCALES='["en","es","uk"]' python -c "..."` prints `['en', 'es', 'uk']`
- [ ] `poe test:unit tests/unit/test_settings.py` -- all 21 tests green
- [ ] No CSS / template / endpoint changes (CI E2E still green)

## Unblocks

- C1-B feat(core): LocaleMiddleware
- C1-C feat(core): wire jinja2.ext.i18n + Translations loader (also blocked by C1-B)