### PR TITLE
fix(e2e): move Page import into TYPE_CHECKING block

### DIFF
--- a/tests/e2e/test_visual_regression.py
+++ b/tests/e2e/test_visual_regression.py
@@ -23,10 +23,13 @@ from __future__ import annotations
 import io
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from PIL import Image, ImageChops
-from playwright.sync_api import Page
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
 
 SNAPSHOT_DIR = Path(__file__).parent / "snapshots" / "responsive"
 SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Develop CI is red on a TC002 ruff violation in `tests/e2e/test_visual_regression.py:29`. `Page` is only used in type annotations, so it belongs behind `TYPE_CHECKING`. Introduced by C3-D visual regression baseline (PR #515) -- the local pre-commit ruff version evidently lagged the CI version.

## Failing CI run

https://github.com/yevheniidehtiar/hyper-admin/actions/runs/25277294544 (all four matrix legs fail with the same TC002 error).

## Fix

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from playwright.sync_api import Page
```

`Page` is consumed only as a function-parameter type annotation, and `from __future__ import annotations` is already in place, so the runtime no longer needs the import at all.

## Manual test

- [x] `uv run ruff check tests/e2e/test_visual_regression.py` -- All checks passed
- [ ] CI matrix turns green on Py 3.10/3.12/3.13 across ubuntu/macos