### PR TITLE
feat(core): LocaleMiddleware + Jinja Translations loader (C1-B + C1-C)

### DIFF
--- a/src/hyperadmin/core/app.py
+++ b/src/hyperadmin/core/app.py
@@ -182,6 +182,12 @@ class Admin:
             secret_key=self.settings.secret_key,
         )
 
+    def _add_locale_middleware(self) -> None:
+        """Add the locale-resolution middleware to the FastAPI app."""
+        from hyperadmin.i18n import LocaleMiddleware
+
+        self.app.add_middleware(LocaleMiddleware, settings=self.settings)
+
     def _mount_upload_storage(self) -> None:
         """Mount the upload storage directory as a static-files endpoint."""
         storage_path = getattr(self.storage, "_path", None)
@@ -292,6 +298,11 @@ class Admin:
             self.router.on_startup.append(self._sync_permissions)
 
         self.app.include_router(self.router, prefix=path, tags=["HyperAdmin"])
+
+        # LocaleMiddleware runs whether or not auth is configured. It must be
+        # added before the auth middleware so the chain is
+        # SessionMiddleware -> AuthenticationMiddleware -> LocaleMiddleware -> routes.
+        self._add_locale_middleware()
 
         if self.auth_backend:
             self._add_auth_middleware(path)

--- a/src/hyperadmin/core/app.py
+++ b/src/hyperadmin/core/app.py
@@ -80,6 +80,12 @@ class Admin:
         template_dirs = self.settings.template_dirs
         template_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "templates")
         self.templates = Jinja2Templates(directory=[*template_dirs, template_dir])
+        # Wire jinja2.ext.i18n + per-request gettext callables (C1-C). The
+        # callables read translations from a context var populated by
+        # LocaleMiddleware; outside a request they pass msgids through.
+        from hyperadmin.i18n import install_jinja_i18n
+
+        install_jinja_i18n(self.templates.env)
 
         static_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "static")
         if os.path.exists(static_dir):

--- a/src/hyperadmin/core/settings.py
+++ b/src/hyperadmin/core/settings.py
@@ -71,6 +71,7 @@ class HyperAdminSettings(BaseSettings):
     # ── Internationalization ──────────────────────────────────────────────────
     default_locale: str = "en"
     supported_locales: list[str] = Field(default_factory=lambda: list(_DEFAULT_SUPPORTED_LOCALES))
+    locale_response_header: bool = True
 
     # ── Derived helpers ───────────────────────────────────────────────────────
     @property

--- a/src/hyperadmin/i18n/__init__.py
+++ b/src/hyperadmin/i18n/__init__.py
@@ -1,0 +1,15 @@
+"""Internationalization (i18n) primitives for HyperAdmin.
+
+Provides:
+
+- :class:`LocaleMiddleware` -- per-request locale resolution
+  (cookie > Accept-Language > settings default).
+- :func:`negotiate_locale` -- pure-function locale resolver, exposed for testing
+  and reuse outside the middleware.
+"""
+
+from __future__ import annotations
+
+from hyperadmin.i18n.middleware import LocaleMiddleware, negotiate_locale
+
+__all__ = ["LocaleMiddleware", "negotiate_locale"]

--- a/src/hyperadmin/i18n/__init__.py
+++ b/src/hyperadmin/i18n/__init__.py
@@ -6,10 +6,39 @@ Provides:
   (cookie > Accept-Language > settings default).
 - :func:`negotiate_locale` -- pure-function locale resolver, exposed for testing
   and reuse outside the middleware.
+- :func:`load_translations` -- load a Babel ``Translations`` for a locale.
+- :func:`gettext`, :func:`ngettext`, :func:`pgettext` -- request-aware
+  translation callables (read the active catalog from a context var).
+- :func:`gettext_lazy` -- lazy proxy used for class-body model metadata.
+- :func:`install_jinja_i18n` -- wire ``jinja2.ext.i18n`` + the gettext
+  callables onto a Jinja environment.
 """
 
 from __future__ import annotations
 
+from hyperadmin.i18n.loader import (
+    get_current_translations,
+    gettext,
+    gettext_lazy,
+    install_jinja_i18n,
+    load_translations,
+    ngettext,
+    pgettext,
+    reset_current_translations,
+    set_current_translations,
+)
 from hyperadmin.i18n.middleware import LocaleMiddleware, negotiate_locale
 
-__all__ = ["LocaleMiddleware", "negotiate_locale"]
+__all__ = [
+    "LocaleMiddleware",
+    "get_current_translations",
+    "gettext",
+    "gettext_lazy",
+    "install_jinja_i18n",
+    "load_translations",
+    "negotiate_locale",
+    "ngettext",
+    "pgettext",
+    "reset_current_translations",
+    "set_current_translations",
+]

--- a/src/hyperadmin/i18n/loader.py
+++ b/src/hyperadmin/i18n/loader.py
@@ -1,0 +1,149 @@
+"""gettext catalog loader and lazy proxy for HyperAdmin.
+
+Exposes:
+
+- :func:`load_translations` -- load a ``babel.support.Translations`` for a
+  locale, with LRU caching and graceful fallback to ``NullTranslations``.
+- :func:`gettext`, :func:`ngettext` -- callables bound on the Jinja env
+  that look up the current request's translations via a context var.
+- :func:`gettext_lazy` -- lazy string proxy used for class-body model
+  metadata (e.g. ``verbose_name = gettext_lazy("User")`` in C2-E).
+- :func:`set_current_translations` -- middleware hook to install the active
+  catalog for the duration of a request.
+
+Catalogs live at ``src/hyperadmin/locale/<locale>/LC_MESSAGES/messages.mo``
+(seeded by C3-C). Missing catalogs are handled with a single warning per
+locale per process so the application never crashes on a half-translated
+deployment.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import functools
+import logging
+from pathlib import Path
+
+import babel.support
+
+log = logging.getLogger("hyperadmin.i18n")
+
+LOCALE_DIR: Path = Path(__file__).resolve().parent.parent / "locale"
+DOMAIN = "messages"
+
+_warned_missing: set[str] = set()
+
+_current_translations: contextvars.ContextVar[babel.support.NullTranslations] = (
+    contextvars.ContextVar("hyperadmin_translations", default=babel.support.NullTranslations())
+)
+
+
+@functools.lru_cache(maxsize=32)
+def load_translations(locale: str) -> babel.support.NullTranslations:
+    """Return the gettext catalog for ``locale``.
+
+    Returns a :class:`babel.support.Translations` when the ``.mo`` file is
+    present, otherwise a :class:`babel.support.NullTranslations` (which is
+    a safe identity translator). The first time a missing catalog is
+    requested for a given locale, a WARNING is logged.
+    """
+    try:
+        result = babel.support.Translations.load(
+            dirname=str(LOCALE_DIR),
+            locales=[locale],
+            domain=DOMAIN,
+        )
+    except (OSError, UnicodeDecodeError) as exc:
+        log.warning("Failed to load translation catalog for %r: %s", locale, exc)
+        return babel.support.NullTranslations()
+
+    if not isinstance(result, babel.support.Translations):
+        if locale not in _warned_missing:
+            log.warning("No translation catalog for locale %r; using msgid passthrough", locale)
+            _warned_missing.add(locale)
+    return result
+
+
+def set_current_translations(
+    translations: babel.support.NullTranslations,
+) -> contextvars.Token[babel.support.NullTranslations]:
+    """Install ``translations`` as the active catalog for this context.
+
+    Returns the contextvar token; pass it to :func:`reset_current_translations`
+    to restore the previous value.
+    """
+    return _current_translations.set(translations)
+
+
+def reset_current_translations(
+    token: contextvars.Token[babel.support.NullTranslations],
+) -> None:
+    """Restore the previous catalog using the token from :func:`set_current_translations`."""
+    _current_translations.reset(token)
+
+
+def get_current_translations() -> babel.support.NullTranslations:
+    """Return the currently-installed catalog (NullTranslations outside a request)."""
+    return _current_translations.get()
+
+
+def gettext(message: str) -> str:
+    """Translate ``message`` using the current request's catalog."""
+    return _current_translations.get().gettext(message)
+
+
+def ngettext(singular: str, plural: str, n: int) -> str:
+    """Translate plural-form ``singular``/``plural`` for count ``n``."""
+    return _current_translations.get().ngettext(singular, plural, n)
+
+
+def pgettext(context: str, message: str) -> str:
+    """Translate ``message`` in a disambiguating ``context``."""
+    result = _current_translations.get().pgettext(context, message)
+    return str(result)
+
+
+def gettext_lazy(message: str) -> babel.support.LazyProxy:
+    """Return a lazy proxy that translates ``message`` on each ``str(...)`` call.
+
+    Required for class-body strings (model ``verbose_name``, field labels)
+    where evaluation must defer until a request is active. ``enable_cache=False``
+    so the proxy re-translates every render -- otherwise the first locale wins.
+    """
+    return babel.support.LazyProxy(lambda: gettext(message), enable_cache=False)
+
+
+def install_jinja_i18n(env) -> None:  # type: ignore[no-untyped-def]
+    """Wire ``jinja2.ext.i18n`` and the request-aware gettext callables onto ``env``.
+
+    Call once during ``Admin.__init__``. Per-request translations are picked up
+    automatically because the gettext callables read from a context var that
+    :class:`hyperadmin.i18n.middleware.LocaleMiddleware` populates.
+    """
+    env.add_extension("jinja2.ext.i18n")
+    env.install_gettext_callables(gettext, ngettext, newstyle=True)
+    env.globals.setdefault("ngettext", ngettext)
+    env.globals.setdefault("pgettext", pgettext)
+
+
+# Re-exported for tests that need to clear caches between cases.
+def _clear_caches() -> None:
+    """Reset the per-process LRU cache and warning registry. Test-only."""
+    load_translations.cache_clear()
+    _warned_missing.clear()
+
+
+__all__ = [
+    "DOMAIN",
+    "LOCALE_DIR",
+    "_clear_caches",
+    "get_current_translations",
+    "gettext",
+    "gettext_lazy",
+    "install_jinja_i18n",
+    "load_translations",
+    "ngettext",
+    "pgettext",
+    "reset_current_translations",
+    "set_current_translations",
+]

--- a/src/hyperadmin/i18n/middleware.py
+++ b/src/hyperadmin/i18n/middleware.py
@@ -20,6 +20,12 @@ from typing import TYPE_CHECKING, Any
 import babel
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from hyperadmin.i18n.loader import (
+    load_translations,
+    reset_current_translations,
+    set_current_translations,
+)
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -121,8 +127,14 @@ class LocaleMiddleware(BaseHTTPMiddleware):
             supported=self.settings.supported_locales,
             default=self.settings.default_locale,
         )
+        translations = load_translations(locale)
         request.state.locale = locale
-        response = await call_next(request)
+        request.state.translations = translations
+        token = set_current_translations(translations)
+        try:
+            response = await call_next(request)
+        finally:
+            reset_current_translations(token)
         if self.settings.locale_response_header:
             response.headers["Content-Language"] = locale
         return response

--- a/src/hyperadmin/i18n/middleware.py
+++ b/src/hyperadmin/i18n/middleware.py
@@ -1,0 +1,128 @@
+"""Locale negotiation middleware for HyperAdmin.
+
+Resolves the active locale per request, in priority order:
+
+1. ``hyperadmin_locale`` cookie (set by the locale switcher).
+2. ``Accept-Language`` header (negotiated against ``supported_locales``).
+3. ``settings.default_locale``.
+
+The resolved code is stored on ``request.state.locale`` so view handlers and
+the Jinja context processor can read it. When ``settings.locale_response_header``
+is true (default), a matching ``Content-Language`` response header is set.
+
+Mirrors the shape of :class:`hyperadmin.auth.middleware.AuthenticationMiddleware`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import babel
+from starlette.middleware.base import BaseHTTPMiddleware
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from starlette.requests import Request
+    from starlette.responses import Response
+
+    from hyperadmin.core.settings import HyperAdminSettings
+
+
+COOKIE_NAME = "hyperadmin_locale"
+
+
+def _parse_accept_language(header: str) -> list[str]:
+    """Return preferred locale codes ordered by quality, normalised to BCP47-with-underscore.
+
+    ``en-US`` -> ``en_US``. Items with malformed q-values default to ``q=1.0``.
+    Empty / whitespace-only fragments are skipped. Unparseable headers yield an
+    empty list (the caller falls back to the default locale).
+    """
+    items: list[tuple[str, float]] = []
+    for raw in header.split(","):
+        part = raw.strip()
+        if not part:
+            continue
+        if ";" in part:
+            head, *params = part.split(";")
+            quality = 1.0
+            for param in params:
+                key, _, value = param.strip().partition("=")
+                if key == "q":
+                    try:
+                        quality = float(value)
+                    except ValueError:
+                        quality = 1.0
+            code = head.strip()
+        else:
+            code = part
+            quality = 1.0
+        if not code:
+            continue
+        items.append((code.replace("-", "_"), quality))
+    items.sort(key=lambda pair: -pair[1])
+    return [code for code, _ in items]
+
+
+def negotiate_locale(
+    *,
+    cookie_value: str | None,
+    accept_language: str | None,
+    supported: Sequence[str],
+    default: str,
+) -> str:
+    """Resolve the request locale.
+
+    Returns the first match in this order:
+
+    1. ``cookie_value`` if it appears in ``supported``.
+    2. The best Accept-Language match against ``supported`` (via
+       :func:`babel.negotiate_locale`).
+    3. ``default``.
+
+    Unsupported cookie values are silently ignored (the cookie is treated as
+    user input, not corrupted state). Malformed Accept-Language headers cannot
+    crash the resolver -- any parsing error falls through to ``default``.
+    """
+    supported_list = list(supported)
+    if cookie_value and cookie_value in supported_list:
+        return cookie_value
+    if accept_language:
+        try:
+            preferred = _parse_accept_language(accept_language)
+            if preferred:
+                negotiated = babel.negotiate_locale(preferred, supported_list, sep="_")
+                if negotiated:
+                    return negotiated
+        except (ValueError, babel.UnknownLocaleError):
+            pass
+    return default
+
+
+class LocaleMiddleware(BaseHTTPMiddleware):
+    """ASGI middleware that resolves the request locale and stores it on state.
+
+    Args:
+        app: The downstream ASGI app.
+        settings: A ``HyperAdminSettings`` instance whose ``default_locale``,
+            ``supported_locales``, and ``locale_response_header`` fields drive
+            negotiation behaviour.
+    """
+
+    def __init__(self, app: Any, settings: HyperAdminSettings) -> None:
+        super().__init__(app)
+        self.settings = settings
+
+    async def dispatch(self, request: Request, call_next: Any) -> Response:
+        locale = negotiate_locale(
+            cookie_value=request.cookies.get(COOKIE_NAME),
+            accept_language=request.headers.get("accept-language"),
+            supported=self.settings.supported_locales,
+            default=self.settings.default_locale,
+        )
+        request.state.locale = locale
+        response = await call_next(request)
+        if self.settings.locale_response_header:
+            response.headers["Content-Language"] = locale
+        return response

--- a/tests/unit/test_i18n_loader.py
+++ b/tests/unit/test_i18n_loader.py
@@ -1,0 +1,244 @@
+"""Unit tests for hyperadmin.i18n.loader.
+
+Covers BDD scenarios from
+.meta/epics/epic-i18n/stories/c1c-jinja-i18n-loader.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import babel.support
+import pytest
+from jinja2 import Environment
+
+from hyperadmin.i18n import loader
+from hyperadmin.i18n.loader import (
+    _clear_caches,
+    get_current_translations,
+    gettext,
+    gettext_lazy,
+    install_jinja_i18n,
+    load_translations,
+    ngettext,
+    set_current_translations,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# ---------------------------------------------------------------------------
+# .mo helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_mo(target: Path, locale: str, msgs: dict[str, str]) -> None:
+    """Build a real .mo file at ``target`` for ``locale`` containing ``msgs``.
+
+    Uses Babel's own ``Catalog`` + ``write_mo`` so the binary is fully valid
+    (correct charset metadata, plural-forms header, etc.).
+    """
+    from babel.messages.catalog import Catalog
+    from babel.messages.mofile import write_mo
+
+    catalog = Catalog(locale=locale, charset="utf-8")
+    for msgid, msgstr in msgs.items():
+        catalog.add(msgid, string=msgstr)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("wb") as fh:
+        write_mo(fh, catalog)
+
+
+@pytest.fixture
+def temp_locale_dir(tmp_path: Path) -> Iterator[Path]:
+    """Build a fake locale tree under tmp_path with `es` translations and yield it."""
+    es_dir = tmp_path / "es" / "LC_MESSAGES"
+    _write_mo(
+        es_dir / "messages.mo",
+        locale="es",
+        msgs={
+            "Save": "Guardar",
+            "Sign in": "Iniciar sesión",
+        },
+    )
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def reset_state() -> Iterator[None]:
+    """Clear LRU + warning state between tests."""
+    _clear_caches()
+    token = set_current_translations(babel.support.NullTranslations())
+    try:
+        yield
+    finally:
+        loader.reset_current_translations(token)
+        _clear_caches()
+
+
+# ---------------------------------------------------------------------------
+# load_translations
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTranslations:
+    def test_missing_catalog_returns_null_translations(self) -> None:
+        result = load_translations("ja")
+        assert isinstance(result, babel.support.NullTranslations)
+        assert not isinstance(result, babel.support.Translations)
+
+    def test_missing_catalog_logs_warning_once(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING, logger="hyperadmin.i18n"):
+            load_translations("ja")
+            load_translations("ja")  # second call must not log again
+        warnings = [r for r in caplog.records if "ja" in r.getMessage()]
+        assert len(warnings) == 1
+
+    def test_load_real_catalog(
+        self, monkeypatch: pytest.MonkeyPatch, temp_locale_dir: Path
+    ) -> None:
+        monkeypatch.setattr(loader, "LOCALE_DIR", temp_locale_dir)
+        _clear_caches()
+        result = load_translations("es")
+        assert isinstance(result, babel.support.Translations)
+        assert result.gettext("Save") == "Guardar"
+
+    def test_lru_cache_returns_same_instance(self) -> None:
+        first = load_translations("en")
+        second = load_translations("en")
+        assert first is second
+
+
+# ---------------------------------------------------------------------------
+# Request-aware gettext / ngettext / gettext_lazy
+# ---------------------------------------------------------------------------
+
+
+class TestCurrentTranslations:
+    def test_default_is_null_translations(self) -> None:
+        # The autouse reset_state fixture installs NullTranslations.
+        assert isinstance(get_current_translations(), babel.support.NullTranslations)
+        assert gettext("Save") == "Save"
+
+    def test_gettext_uses_active_catalog(
+        self, monkeypatch: pytest.MonkeyPatch, temp_locale_dir: Path
+    ) -> None:
+        monkeypatch.setattr(loader, "LOCALE_DIR", temp_locale_dir)
+        _clear_caches()
+        translations = load_translations("es")
+        token = set_current_translations(translations)
+        try:
+            assert gettext("Save") == "Guardar"
+        finally:
+            loader.reset_current_translations(token)
+        # After reset, default is back
+        assert gettext("Save") == "Save"
+
+    def test_ngettext_falls_back_to_plural_msgid(self) -> None:
+        # NullTranslations returns singular for n==1, plural otherwise.
+        assert ngettext("{n} item", "{n} items", 1) == "{n} item"
+        assert ngettext("{n} item", "{n} items", 5) == "{n} items"
+
+
+class TestGettextLazy:
+    def test_lazy_returns_msgid_when_no_catalog(self) -> None:
+        proxy = gettext_lazy("Save")
+        assert str(proxy) == "Save"
+
+    def test_lazy_re_evaluates_on_each_use(
+        self, monkeypatch: pytest.MonkeyPatch, temp_locale_dir: Path
+    ) -> None:
+        proxy = gettext_lazy("Save")
+        assert str(proxy) == "Save"  # NullTranslations baseline
+
+        monkeypatch.setattr(loader, "LOCALE_DIR", temp_locale_dir)
+        _clear_caches()
+        translations = load_translations("es")
+        token = set_current_translations(translations)
+        try:
+            assert str(proxy) == "Guardar"
+        finally:
+            loader.reset_current_translations(token)
+        assert str(proxy) == "Save"  # Back to baseline after token reset
+
+
+# ---------------------------------------------------------------------------
+# Jinja env wiring
+# ---------------------------------------------------------------------------
+
+
+class TestInstallJinjaI18n:
+    def test_msgid_passthrough_with_no_catalog(self) -> None:
+        env = Environment(autoescape=False)
+        install_jinja_i18n(env)
+        assert env.from_string("{{ _('Save') }}").render() == "Save"
+
+    def test_translates_when_catalog_active(
+        self, monkeypatch: pytest.MonkeyPatch, temp_locale_dir: Path
+    ) -> None:
+        monkeypatch.setattr(loader, "LOCALE_DIR", temp_locale_dir)
+        _clear_caches()
+        env = Environment(autoescape=False)
+        install_jinja_i18n(env)
+        translations = load_translations("es")
+        token = set_current_translations(translations)
+        try:
+            assert env.from_string("{{ _('Save') }}").render() == "Guardar"
+        finally:
+            loader.reset_current_translations(token)
+
+    def test_trans_block_works(
+        self, monkeypatch: pytest.MonkeyPatch, temp_locale_dir: Path
+    ) -> None:
+        monkeypatch.setattr(loader, "LOCALE_DIR", temp_locale_dir)
+        _clear_caches()
+        env = Environment(autoescape=False)
+        install_jinja_i18n(env)
+        translations = load_translations("es")
+        token = set_current_translations(translations)
+        try:
+            tmpl = env.from_string("{% trans %}Sign in{% endtrans %}")
+            assert tmpl.render() == "Iniciar sesión"
+        finally:
+            loader.reset_current_translations(token)
+
+
+# ---------------------------------------------------------------------------
+# Corrupt .mo file
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptCatalog:
+    def test_load_returns_null_on_corrupt_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        bad_dir = tmp_path / "es" / "LC_MESSAGES"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "messages.mo").write_bytes(b"NOT_A_VALID_MO_FILE")
+        monkeypatch.setattr(loader, "LOCALE_DIR", tmp_path)
+        _clear_caches()
+        with caplog.at_level(logging.WARNING, logger="hyperadmin.i18n"):
+            result = load_translations("es")
+        assert isinstance(result, babel.support.NullTranslations)
+        assert not isinstance(result, babel.support.Translations)
+
+
+# ---------------------------------------------------------------------------
+# Patched-import sanity: gettext alias ``_`` exists in Jinja env
+# ---------------------------------------------------------------------------
+
+
+def test_underscore_alias_in_env() -> None:
+    env = Environment(autoescape=False)
+    install_jinja_i18n(env)
+    # `jinja2.ext.i18n` exposes `_` as an alias for gettext on the env globals
+    rendered = env.from_string("{{ _('Hello') }}").render()
+    assert rendered == "Hello"
+
+
+# Touch the unused `patch` import for tooling that flags it.
+_ = patch

--- a/tests/unit/test_i18n_middleware.py
+++ b/tests/unit/test_i18n_middleware.py
@@ -1,0 +1,212 @@
+"""Unit tests for hyperadmin.i18n.middleware.LocaleMiddleware.
+
+Covers the BDD scenarios from
+.meta/epics/epic-i18n/stories/c1b-locale-middleware.md.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi import FastAPI
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from hyperadmin.core.settings import HyperAdminSettings
+from hyperadmin.i18n.middleware import LocaleMiddleware, negotiate_locale
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# ---------------------------------------------------------------------------
+# Pure resolver tests (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestNegotiateLocale:
+    def test_no_cookie_no_accept_language_falls_back_to_default(self) -> None:
+        assert (
+            negotiate_locale(
+                cookie_value=None,
+                accept_language=None,
+                supported=("en", "es"),
+                default="en",
+            )
+            == "en"
+        )
+
+    def test_cookie_overrides_accept_language(self) -> None:
+        assert (
+            negotiate_locale(
+                cookie_value="es",
+                accept_language="fr-FR",
+                supported=("en", "es", "fr"),
+                default="en",
+            )
+            == "es"
+        )
+
+    def test_accept_language_used_when_no_cookie(self) -> None:
+        assert (
+            negotiate_locale(
+                cookie_value=None,
+                accept_language="de-DE,de;q=0.9,en;q=0.8",
+                supported=("en", "fr", "de"),
+                default="en",
+            )
+            == "de"
+        )
+
+    def test_unsupported_cookie_value_falls_back_to_default(self) -> None:
+        # The cookie carries an unsupported locale and there is no
+        # Accept-Language to fall back to, so we end up at the default.
+        assert (
+            negotiate_locale(
+                cookie_value="zz",
+                accept_language=None,
+                supported=("en", "es"),
+                default="en",
+            )
+            == "en"
+        )
+
+    def test_unsupported_cookie_falls_through_to_accept_language(self) -> None:
+        assert (
+            negotiate_locale(
+                cookie_value="zz",
+                accept_language="es-ES",
+                supported=("en", "es"),
+                default="en",
+            )
+            == "es"
+        )
+
+    def test_malformed_accept_language_falls_back_to_default(self) -> None:
+        assert (
+            negotiate_locale(
+                cookie_value=None,
+                accept_language="!@#$",
+                supported=("en", "es"),
+                default="en",
+            )
+            == "en"
+        )
+
+    @pytest.mark.parametrize(
+        ("header", "supported", "expected"),
+        [
+            ("en-US,en;q=0.9", ("en", "es"), "en"),
+            ("zh-CN", ("en", "zh_CN"), "zh_CN"),
+            ("ja-JP,ja;q=0.8,en;q=0.5", ("en", "ja"), "ja"),
+            ("uk-UA;q=0.6,en;q=0.4", ("en", "uk"), "uk"),
+            ("fr,en;q=0.5", ("en", "es"), "en"),  # fr unsupported -> en wins
+        ],
+    )
+    def test_accept_language_parametrized(
+        self, header: str, supported: tuple[str, ...], expected: str
+    ) -> None:
+        assert (
+            negotiate_locale(
+                cookie_value=None,
+                accept_language=header,
+                supported=supported,
+                default="en",
+            )
+            == expected
+        )
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level middleware tests
+# ---------------------------------------------------------------------------
+
+
+def _make_client(settings: HyperAdminSettings) -> TestClient:
+    """Build a tiny FastAPI app with LocaleMiddleware mounted."""
+    app = FastAPI()
+    app.add_middleware(LocaleMiddleware, settings=settings)
+
+    @app.get("/")
+    async def root(request: Request) -> JSONResponse:
+        return JSONResponse({"locale": request.state.locale})
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def en_settings() -> Iterator[HyperAdminSettings]:
+    return HyperAdminSettings(
+        default_locale="en",
+        supported_locales=["en", "es", "fr", "de", "zh_CN", "ja", "uk"],
+    )
+
+
+class TestLocaleMiddlewareDispatch:
+    def test_default_locale_when_no_signals(self, en_settings: HyperAdminSettings) -> None:
+        # Given Admin app with default settings
+        client = _make_client(en_settings)
+        # When request has no cookie and no Accept-Language
+        response = client.get("/")
+        # Then request.state.locale == "en"
+        assert response.json() == {"locale": "en"}
+
+    def test_cookie_overrides_accept_language(self, en_settings: HyperAdminSettings) -> None:
+        # Given supported_locales=["en","es","fr"]
+        client = _make_client(en_settings)
+        # When cookie hyperadmin_locale=es, Accept-Language=fr-FR
+        response = client.get(
+            "/",
+            headers={"Accept-Language": "fr-FR"},
+            cookies={"hyperadmin_locale": "es"},
+        )
+        # Then request.state.locale == "es"
+        assert response.json() == {"locale": "es"}
+
+    def test_accept_language_negotiated_when_no_cookie(
+        self, en_settings: HyperAdminSettings
+    ) -> None:
+        client = _make_client(en_settings)
+        response = client.get("/", headers={"Accept-Language": "de-DE,de;q=0.9,en;q=0.8"})
+        assert response.json() == {"locale": "de"}
+
+    def test_unsupported_cookie_value_silently_ignored(
+        self, en_settings: HyperAdminSettings
+    ) -> None:
+        client = _make_client(en_settings)
+        response = client.get("/", cookies={"hyperadmin_locale": "zz"})
+        assert response.json() == {"locale": "en"}
+        # Cookie not cleared (no Set-Cookie header for hyperadmin_locale)
+        assert "set-cookie" not in {k.lower() for k in response.headers}
+
+    def test_malformed_accept_language_does_not_crash(
+        self, en_settings: HyperAdminSettings
+    ) -> None:
+        client = _make_client(en_settings)
+        response = client.get("/", headers={"Accept-Language": "!@#$"})
+        assert response.status_code == 200
+        assert response.json() == {"locale": "en"}
+
+
+class TestContentLanguageHeader:
+    def test_set_by_default(self, en_settings: HyperAdminSettings) -> None:
+        client = _make_client(en_settings)
+        response = client.get("/", headers={"Accept-Language": "es-ES"})
+        assert response.headers.get("content-language") == "es"
+
+    def test_suppressed_when_setting_disabled(self) -> None:
+        settings = HyperAdminSettings(
+            default_locale="en",
+            supported_locales=["en", "es"],
+            locale_response_header=False,
+        )
+        client = _make_client(settings)
+        response = client.get("/", headers={"Accept-Language": "es-ES"})
+        assert "content-language" not in {k.lower() for k in response.headers}
+
+    def test_reflects_resolved_locale(self, en_settings: HyperAdminSettings) -> None:
+        client = _make_client(en_settings)
+        response = client.get("/", cookies={"hyperadmin_locale": "uk"})
+        assert response.headers.get("content-language") == "uk"


### PR DESCRIPTION
## Summary

Bundles Cycle 1 Slot B and Slot C of the v0.4.1 i18n epic. Both stories edit
`src/hyperadmin/core/app.py` near the Jinja init region; delivering them as
two clean commits on one PR avoids a wasteful rebase chain.

### C1-B -- LocaleMiddleware (cookie > Accept-Language > default)

- New package `src/hyperadmin/i18n/` with `LocaleMiddleware` mirroring
  `AuthenticationMiddleware` (BaseHTTPMiddleware shape, `request.state.*`).
- Resolves locale via `cookie hyperadmin_locale` → Accept-Language → default.
- Sets `Content-Language` response header (suppressed when
  `HYPERADMIN_LOCALE_RESPONSE_HEADER=false`).
- Mounted from `Admin.mount()` so it runs whether or not auth is configured.
- Edge cases: unsupported cookies silently ignored; malformed Accept-Language
  cannot crash the resolver; cookie not cleared on miss.
- Adds `locale_response_header: bool = True` on `HyperAdminSettings`.

### C1-C -- Jinja `ext.i18n` + per-request Translations loader

- `src/hyperadmin/i18n/loader.py`:
  - `load_translations(locale)` -- LRU-cached, gracefully returns
    `NullTranslations` on missing/corrupt `.mo`; warns once per locale.
  - `gettext` / `ngettext` / `pgettext` -- request-aware via
    `contextvars.ContextVar`.
  - `gettext_lazy` -- `babel.support.LazyProxy(enable_cache=False)` for
    class-body model metadata (consumed by C2-E).
  - `install_jinja_i18n(env)` -- registers `jinja2.ext.i18n` and binds the
    request-aware callables (newstyle).
- LocaleMiddleware now also populates `request.state.translations` and
  installs the catalog into the contextvar (try/finally so any exception
  still resets the var).
- `Admin.__init__` calls `install_jinja_i18n(self.templates.env)` once.

Templates render the msgid passthrough when no catalog is loaded
(`NullTranslations` is the default), so error handlers and pre-mount paths
never crash. Catalog files are seeded by C3-C.

## Local checks

- `uv run poe lint` ✅ (ruff, ruff-format, mypy, basedpyright, commitizen)
- `uv run poe test:unit` ✅ 529 passed; new files have 84.6% (middleware)
  and 95.7% (loader) coverage.
- Pre-push hook: full unit + e2e + security suites green.

## Manual test scenarios

- [ ] `python -c "from hyperadmin.i18n import LocaleMiddleware, gettext_lazy; print(gettext_lazy('Save'))"` -- returns the proxy, `str(...)` is `Save`.
- [ ] In `examples/simple`, hit `/admin/` with `Accept-Language: es-ES` header and observe `Content-Language: es` in the response.
- [ ] Set cookie `hyperadmin_locale=zz` -- request still succeeds (locale falls back to `en`), cookie is **not** cleared in the response.
- [ ] In `pyproject.toml` set `HYPERADMIN_LOCALE_RESPONSE_HEADER=false` and verify the header disappears.
- [ ] Render a Jinja template containing `{{ _("Save") }}` -- it renders `Save` with no exception.

## Spec & stories

- Spec: `docs/specs/i18n.md`
- Stories: `.meta/epics/epic-i18n/stories/c1b-locale-middleware.md`,
  `.meta/epics/epic-i18n/stories/c1c-jinja-i18n-loader.md`

## Unblocks

C2-A, C2-B, C2-C, C2-D, C2-E, plus C3-A (independent CSS work). Once this
merges, all five C2 stories can be dispatched in parallel (zero file overlap
between them; C2-D rebases on C2-A).