### PR TITLE
refactor(ui): physical → logical CSS properties (C3-A)

### DIFF
--- a/src/hyperadmin/static/css/_accessibility.css
+++ b/src/hyperadmin/static/css/_accessibility.css
@@ -4,7 +4,7 @@
 
 .ha-skip-link {
   position: absolute;
-  left: -9999px;
+  inset-inline-start: -9999px;
   top: auto;
   width: 1px;
   height: 1px;
@@ -23,7 +23,7 @@
 .ha-skip-link:focus-visible {
   position: fixed;
   top: var(--ha-space-2);
-  left: var(--ha-space-2);
+  inset-inline-start: var(--ha-space-2);
   width: auto;
   height: auto;
   min-height: 44px;

--- a/src/hyperadmin/static/css/_alerts.css
+++ b/src/hyperadmin/static/css/_alerts.css
@@ -43,7 +43,7 @@
 .ha-toast-container {
   position: fixed;
   top: var(--ha-space-4);
-  right: var(--ha-space-4);
+  inset-inline-end: var(--ha-space-4);
   width: 100%;
   max-width: 22rem;
   z-index: 60;
@@ -64,7 +64,7 @@
 .ha-toast-close {
   position: absolute;
   top: var(--ha-space-2);
-  right: var(--ha-space-2);
+  inset-inline-end: var(--ha-space-2);
   padding: var(--ha-space-1);
   background: none;
   border: none;

--- a/src/hyperadmin/static/css/_fieldsets.css
+++ b/src/hyperadmin/static/css/_fieldsets.css
@@ -37,7 +37,7 @@
   cursor: pointer;
   padding: var(--ha-space-1) 0;
   width: 100%;
-  text-align: left;
+  text-align: start;
 }
 
 .ha-fieldset-toggle:hover {

--- a/src/hyperadmin/static/css/_forms.css
+++ b/src/hyperadmin/static/css/_forms.css
@@ -16,7 +16,7 @@
 
 .ha-required {
   color: var(--ha-color-danger);
-  margin-left: var(--ha-space-0-5);
+  margin-inline-start: var(--ha-space-0-5);
 }
 
 .ha-input {

--- a/src/hyperadmin/static/css/_inlines.css
+++ b/src/hyperadmin/static/css/_inlines.css
@@ -21,7 +21,7 @@
 
 .ha-inline-table th {
   padding: var(--ha-space-2) var(--ha-space-3);
-  text-align: left;
+  text-align: start;
   font-weight: var(--ha-font-semibold);
   color: var(--ha-color-text-muted);
   background-color: var(--ha-color-bg);
@@ -116,7 +116,7 @@
   }
 
   .ha-inline-actions {
-    text-align: right;
+    text-align: end;
   }
 
   .ha-inline-remove-btn {

--- a/src/hyperadmin/static/css/_layout.css
+++ b/src/hyperadmin/static/css/_layout.css
@@ -9,8 +9,7 @@
 
 .ha-container {
   max-width: 1280px;
-  margin-left: auto;
-  margin-right: auto;
+  margin-inline: auto;
   padding: 0;
 }
 

--- a/src/hyperadmin/static/css/_navbar.css
+++ b/src/hyperadmin/static/css/_navbar.css
@@ -36,7 +36,7 @@
   text-decoration: none;
   letter-spacing: -0.025em;
   transition: color var(--ha-transition);
-  margin-right: auto;
+  margin-inline-end: auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -59,7 +59,7 @@
   justify-content: center;
   min-width: 44px;
   min-height: 44px;
-  margin-right: var(--ha-space-2);
+  margin-inline-end: var(--ha-space-2);
   padding: 0;
   color: var(--ha-color-text);
   background: none;
@@ -141,7 +141,7 @@
 
 .ha-dropdown {
   position: absolute;
-  right: 0;
+  inset-inline-end: 0;
   margin-top: var(--ha-space-1);
   width: 12rem;
   background-color: var(--ha-color-surface);
@@ -160,7 +160,7 @@
 .ha-dropdown-item {
   display: block;
   width: 100%;
-  text-align: left;
+  text-align: start;
   padding: var(--ha-space-2) var(--ha-space-4);
   font-size: var(--ha-font-size-sm);
   font-weight: var(--ha-font-medium);

--- a/src/hyperadmin/static/css/_sidebar.css
+++ b/src/hyperadmin/static/css/_sidebar.css
@@ -6,7 +6,7 @@
   display: none;
   width: var(--ha-sidebar-width);
   background-color: var(--ha-color-surface);
-  border-right: var(--ha-border-width) solid var(--ha-color-border-light);
+  border-inline-end: var(--ha-border-width) solid var(--ha-color-border-light);
   min-height: calc(100vh - var(--ha-navbar-height));
   flex-shrink: 0;
 }
@@ -109,12 +109,12 @@
     flex-direction: column;
     position: fixed;
     top: 0;
-    left: 0;
+    inset-inline-start: 0;
     width: 85%;
     max-width: 20rem;
     height: 100vh;
     background-color: var(--ha-color-surface);
-    border-right: var(--ha-border-width) solid var(--ha-color-border-light);
+    border-inline-end: var(--ha-border-width) solid var(--ha-color-border-light);
     box-shadow: var(--ha-shadow-xl);
     z-index: 40;
     transform: translateX(-100%);

--- a/src/hyperadmin/static/css/_table.css
+++ b/src/hyperadmin/static/css/_table.css
@@ -25,7 +25,7 @@
 
 .ha-table-th {
   padding: var(--ha-space-3) var(--ha-space-4);
-  text-align: left;
+  text-align: start;
   font-size: var(--ha-font-size-xs);
   font-weight: var(--ha-font-semibold);
   color: var(--ha-color-text-muted);
@@ -58,7 +58,7 @@
 
 .ha-table-cell {
   padding: var(--ha-space-3) var(--ha-space-4);
-  text-align: left;
+  text-align: start;
   white-space: nowrap;
   color: var(--ha-color-text);
 }
@@ -102,7 +102,7 @@
 .ha-action-link + .ha-action-link,
 .ha-action-link + .ha-action-delete,
 .ha-action-delete + .ha-action-link {
-  margin-left: var(--ha-space-1);
+  margin-inline-start: var(--ha-space-1);
 }
 
 .ha-action-delete {
@@ -193,7 +193,7 @@
     padding: var(--ha-space-2) 0;
     border-bottom: var(--ha-border-width) solid var(--ha-color-border-light);
     white-space: normal;
-    text-align: right;
+    text-align: end;
   }
 
   .ha-table-cell:last-child {
@@ -207,7 +207,7 @@
     font-size: var(--ha-font-size-xs);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    text-align: left;
+    text-align: start;
     flex-shrink: 0;
   }
 
@@ -216,7 +216,7 @@
     justify-content: flex-end;
     flex-wrap: wrap;
     gap: var(--ha-space-2);
-    text-align: right;
+    text-align: end;
   }
 
   .ha-action-link,

--- a/src/hyperadmin/static/css/_theme-toggle.css
+++ b/src/hyperadmin/static/css/_theme-toggle.css
@@ -15,7 +15,7 @@
   color: var(--ha-color-text-muted);
   transition: color var(--ha-transition), border-color var(--ha-transition);
   padding: 0;
-  margin-right: var(--ha-space-2);
+  margin-inline-end: var(--ha-space-2);
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary

Mechanically replaces physical CSS directional properties with logical equivalents across all files in `src/hyperadmin/static/css/`. Required so RTL locales can flip layout via `dir="rtl"` without per-rule overrides.

| Physical | Logical |
|---|---|
| `margin-left` / `margin-right` | `margin-inline-start` / `margin-inline-end` (or `margin-inline: auto` for centering) |
| `padding-left` / `padding-right` | `padding-inline-start` / `padding-inline-end` |
| `border-right` | `border-inline-end` |
| `text-align: left` / `right` | `text-align: start` / `end` |
| `left:` / `right:` (positioning) | `inset-inline-start:` / `inset-inline-end:` |

10 files touched, 23/-24 lines. Block axis (`top`/`bottom`/`margin-top`/etc.), non-directional sizing (`width`/`height`), and `transform: translateX(...)` were intentionally left physical per the dispatch brief.

This is **C3-A only** — no `_rtl.css` overrides (that's C3-B). Pure CSS change, no Python or template edits.

## Test plan

- [x] `uv run poe lint` — all checks pass (ruff, mypy, basedpyright, commitizen)
- [x] `uv run poe test:unit` — 529 passed
- [x] `grep -rE "margin-(left |right)|padding-(left|right)|border-(left|right)|text-align: (left|right)|^\s*(left|right):" src/hyperadmin/static/css/` returns no matches

## Manual test scenarios

**Scenario: desktop layout unchanged at 1280px (LTR)**
  Given default locale `en`
  When admin loads at 1280px viewport
  Then sidebar, navbar, table, forms, dropdowns are pixel-identical to develop
  And no horizontal scrollbar appears

**Scenario: mobile layout unchanged (< 768px)**
  Given default locale `en`
  When admin loads at 375px viewport
  Then sidebar slides in from the start edge as before
  And table card layout, inline formsets, and toast positioning are unchanged

**Scenario: full E2E suite green**
  Given the refactor is applied
  When `uv run poe test:e2e` is executed
  Then all existing tests pass with no regressions

## Notes

- Unblocks: **C3-B** (RTL overrides will sit on top of this refactor)
- Browser support: logical properties are supported in all modern browsers; no fallbacks needed.