### PR TITLE
refactor(ui): wrap login/navbar/sidebar/messages in _() (C2-A)

### DIFF
--- a/src/hyperadmin/templates/_messages.html
+++ b/src/hyperadmin/templates/_messages.html
@@ -1,9 +1,9 @@
 <div class="ha-toast-container" aria-live="polite" aria-atomic="true">
     <div x-data="{ show: false }" x-show="show" x-init="setTimeout(() => show = false, 5000)" class="ha-toast ha-alert-success" role="alert">
-        <strong class="ha-alert-title">Success!</strong>
-        <span>Your action was successful.</span>
-        <button @click="show = false" class="ha-toast-close" aria-label="Close">
-            <svg class="ha-icon" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>Close</title><path fill="currentColor" d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
+        <strong class="ha-alert-title">{{ _("Success!") }}</strong>
+        <span>{{ _("Your action was successful.") }}</span>
+        <button @click="show = false" class="ha-toast-close" aria-label="{{ _('Close') }}">
+            <svg class="ha-icon" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><title>{{ _("Close") }}</title><path fill="currentColor" d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 3.029a1.2 1.2 0 1 1-1.697-1.697l2.758-3.15-2.759-3.152a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-3.031a1.2 1.2 0 1 1 1.697 1.697l-2.758 3.152 2.758 3.15a1.2 1.2 0 0 1 0 1.698z"/></svg>
         </button>
     </div>
 </div>

--- a/src/hyperadmin/templates/_navbar.html
+++ b/src/hyperadmin/templates/_navbar.html
@@ -1,11 +1,11 @@
-<nav class="ha-navbar" aria-label="Main navigation">
+<nav class="ha-navbar" aria-label="{{ _('Main navigation') }}">
     <div class="ha-navbar-inner">
         <button type="button"
                 class="ha-sidebar-toggle"
                 @click="sidebarOpen = !sidebarOpen"
                 :aria-expanded="sidebarOpen ? 'true' : 'false'"
                 aria-controls="sidebar"
-                aria-label="Toggle navigation menu"
+                aria-label="{{ _('Toggle navigation menu') }}"
                 data-testid="sidebar-toggle">
             <svg class="ha-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
@@ -16,7 +16,7 @@
         <button type="button"
                 class="ha-theme-toggle"
                 onclick="haToggleTheme()"
-                aria-label="Toggle dark mode"
+                aria-label="{{ _('Toggle dark mode') }}"
                 data-testid="theme-toggle">
             <svg class="ha-icon-sun" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m8.66-13.66l-.71.71M4.05 19.95l-.71.71M21 12h-1M4 12H3m16.66 7.66l-.71-.71M4.05 4.05l-.71-.71M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
@@ -38,7 +38,7 @@
             </button>
             <div x-show="open" @click.away="open = false" @keydown.escape="open = false" x-cloak class="ha-dropdown" role="menu">
                 <form method="post" action="{{ admin_prefix }}/logout">
-                    <button type="submit" class="ha-dropdown-item" data-testid="logout-btn" role="menuitem">Logout</button>
+                    <button type="submit" class="ha-dropdown-item" data-testid="logout-btn" role="menuitem">{{ _("Logout") }}</button>
                 </form>
             </div>
             {% else %}
@@ -46,14 +46,14 @@
                 <svg class="ha-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0z"></path>
                 </svg>
-                <span>Admin</span>
+                <span>{{ _("Admin") }}</span>
                 <svg class="ha-icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
                 </svg>
             </button>
             <div x-show="open" @click.away="open = false" @keydown.escape="open = false" x-cloak class="ha-dropdown" role="menu">
-                <a href="#" class="ha-dropdown-item" role="menuitem">Profile</a>
-                <a href="#" class="ha-dropdown-item" role="menuitem">Settings</a>
+                <a href="#" class="ha-dropdown-item" role="menuitem">{{ _("Profile") }}</a>
+                <a href="#" class="ha-dropdown-item" role="menuitem">{{ _("Settings") }}</a>
             </div>
             {% endif %}
         </div>

--- a/src/hyperadmin/templates/_sidebar.html
+++ b/src/hyperadmin/templates/_sidebar.html
@@ -2,25 +2,25 @@
        class="ha-sidebar"
        :class="{ 'ha-sidebar-mobile-open': sidebarOpen }"
        data-testid="sidebar"
-       aria-label="Model navigation"
+       aria-label="{{ _('Model navigation') }}"
        :role="sidebarOpen ? 'dialog' : 'complementary'"
        :aria-modal="sidebarOpen ? 'true' : null"
        x-trap.inert.noscroll="sidebarOpen"
        @keydown.escape.window="sidebarOpen = false">
     <div class="ha-sidebar-inner">
         <div class="ha-sidebar-header">
-            <h2 class="ha-sidebar-title">Menu</h2>
+            <h2 class="ha-sidebar-title">{{ _("Menu") }}</h2>
             <button type="button"
                     class="ha-sidebar-close"
                     @click="sidebarOpen = false"
-                    aria-label="Close navigation menu"
+                    aria-label="{{ _('Close navigation menu') }}"
                     data-testid="sidebar-close">
                 <svg class="ha-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                 </svg>
             </button>
         </div>
-        <nav aria-label="Sidebar">
+        <nav aria-label="{{ _('Sidebar') }}">
         <ul class="ha-sidebar-nav">
             {%- for item in nav_items -%}
             {%- if not auth_enabled or not request.state.user or item.get('visible', true) -%}

--- a/src/hyperadmin/templates/login.html
+++ b/src/hyperadmin/templates/login.html
@@ -1,6 +1,6 @@
 {%- extends "_base.html" -%}
 
-{%- block title -%}Login — HyperAdmin{%- endblock -%}
+{%- block title -%}{{ _("Login") }} — HyperAdmin{%- endblock -%}
 
 {%- block messages -%}{%- endblock -%}
 {%- block navbar -%}{%- endblock -%}
@@ -10,7 +10,7 @@
 <div class="ha-login-container">
     <div class="ha-login-card">
         <h1 id="login-title" class="ha-login-title">HyperAdmin</h1>
-        <p class="ha-text-muted">Sign in to your account</p>
+        <p class="ha-text-muted">{{ _("Sign in to your account") }}</p>
 
         {%- if error -%}
         <div class="ha-alert ha-alert-error" data-testid="login-error" role="alert">
@@ -20,7 +20,7 @@
 
         <form method="post" action="{{ admin_prefix }}/login" data-testid="login-form" aria-labelledby="login-title">
             <div class="ha-form-group">
-                <label for="username" class="ha-label">Username</label>
+                <label for="username" class="ha-label">{{ _("Username") }}</label>
                 <input
                     type="text"
                     id="username"
@@ -32,7 +32,7 @@
                 >
             </div>
             <div class="ha-form-group">
-                <label for="password" class="ha-label">Password</label>
+                <label for="password" class="ha-label">{{ _("Password") }}</label>
                 <input
                     type="password"
                     id="password"
@@ -43,7 +43,7 @@
                 >
             </div>
             <button type="submit" class="ha-btn ha-btn-primary ha-btn-block" data-testid="login-submit">
-                Sign in
+                {{ _("Sign in") }}
             </button>
         </form>
     </div>

--- a/tests/unit/test_dynamic_view_htmx.py
+++ b/tests/unit/test_dynamic_view_htmx.py
@@ -116,7 +116,10 @@ def view(tmp_path):
     # _get_template_name resolves create/update.html present in the repo.
     from fastapi.templating import Jinja2Templates
 
+    from hyperadmin.i18n.loader import install_jinja_i18n
+
     templates = Jinja2Templates(directory="src/hyperadmin/templates")
+    install_jinja_i18n(templates.env)
 
     view = dynamic_module.DynamicModelView(
         adapter=DummyAdapter(User),
@@ -249,7 +252,10 @@ async def test_delete_action_not_found(request_factory, view):
 async def test_admin_dashboard(request_factory, view):
     from fastapi.templating import Jinja2Templates
 
+    from hyperadmin.i18n.loader import install_jinja_i18n
+
     templates = Jinja2Templates(directory="src/hyperadmin/templates")
+    install_jinja_i18n(templates.env)
     req = request_factory()
     resp = await dynamic_module.admin_dashboard(req, templates)
     assert resp.template.name == "dashboard.html"


### PR DESCRIPTION
## Summary

C2-A of the v0.4.1 i18n epic — wraps all hardcoded UI strings in the four shared/global templates so Babel can extract them and the gettext catalog can translate them at request time.

Touched templates:
- `src/hyperadmin/templates/login.html` — `Login`, `Sign in to your account`, `Username`, `Password`, `Sign in`
- `src/hyperadmin/templates/_navbar.html` — `Main navigation`, `Toggle navigation menu`, `Toggle dark mode`, `Logout`, `Admin`, `Profile`, `Settings`
- `src/hyperadmin/templates/_sidebar.html` — `Model navigation`, `Menu`, `Close navigation menu`, `Sidebar`
- `src/hyperadmin/templates/_messages.html` — `Success!`, `Your action was successful.`, `Close`

19 unique msgids extracted (verified locally with `babel.messages.extract`). The product brand `HyperAdmin` and dynamic content (`{{ item.name }}`, `{{ request.state.user.username }}`, `{{ error }}`) are intentionally **not** wrapped.

No `data-testid`, CSS class, or layout changes — pure string wrapping.

### Test fixture fix
`tests/unit/test_dynamic_view_htmx.py` constructed a bare `Jinja2Templates(...)` that bypassed the `Admin` initialization path where `install_jinja_i18n` is called. Both call sites now wire i18n on the env, otherwise the dashboard render exploded with `'_' is undefined`. Strictly a test-side fix; no production code touched.

## Manual test scenarios

- [ ] **Login renders in English by default**
  Start the example app, visit `/admin/login` with no locale cookie. Expect: page title `Login — HyperAdmin`, h1 `HyperAdmin`, muted text `Sign in to your account`, labels `Username` / `Password`, button `Sign in`. No `UnicodeError` / `TemplateSyntaxError` in logs.
- [ ] **Authenticated dashboard renders navbar + sidebar**
  Log in. Expect navbar to show `Logout` in the user dropdown and `Toggle dark mode` aria-label on the theme button. Sidebar `<aside>` aria-label is `Model navigation`, header text is `Menu`, close-button aria-label is `Close navigation menu`.
- [ ] **Toast/messages partial renders**
  Trigger any flash message; toast contains `Success!` and `Your action was successful.`, close button has aria-label `Close`.
- [ ] **Babel extraction**
  ```bash
  uv run python -c "from babel.messages.extract import extract_from_dir; \
    print(sorted({r[2] for r in extract_from_dir('src/hyperadmin/templates', \
    method_map=[('**.html','jinja2.ext:babel_extract')], \
    options_map={'**.html':{'extensions':'jinja2.ext.i18n'}})}))"
  ```
  Expect the 19 wrapped msgids to appear in the output (`Login`, `Username`, `Password`, `Sign in`, `Sign in to your account`, `Logout`, `Admin`, `Profile`, `Settings`, `Main navigation`, `Toggle navigation menu`, `Toggle dark mode`, `Menu`, `Close navigation menu`, `Sidebar`, `Model navigation`, `Success!`, `Your action was successful.`, `Close`).

## References

- SDD: `docs/specs/i18n.md`
- Story: `.meta/epics/epic-i18n/stories/c2a-wrap-login-navbar-sidebar.md`

## Notes for downstream stories

**C2-D (locale switcher) rebases on this PR** — the switcher lives in `_navbar.html`, so it must merge after this one to avoid trivial conflicts.