### PR TITLE
refactor(ui): wrap list/detail/form/pagination/components in _() (C2-B)

### DIFF
--- a/src/hyperadmin/templates/components/filter_bar.html
+++ b/src/hyperadmin/templates/components/filter_bar.html
@@ -8,7 +8,7 @@
         <svg class="ha-icon ha-icon-sm" :class="filtersOpen ? 'ha-rotate--180' : 'ha-rotate--0'" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M19 9l-7 7-7-7" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
-        Filters
+        {{ _("Filters") }}
     </button>
 
     <div id="filter-content" class="ha-filter-content" x-show="filtersOpen" x-cloak>
@@ -24,7 +24,7 @@
                         hx-target="#model-list"
                         hx-push-url="true"
                         hx-include="[name^='filter_'], [name='search'], [name='sort_by'], [name='sort_direction']">
-                    <option value="">Any</option>
+                    <option value="">{{ _("Any") }}</option>
                     {%- for choice in filter.choices -%}
                     <option value="{{ choice.value }}" {% if active_filters.get(filter.name) == choice.value|string %}selected{% endif %}>
                         {{- choice.label -}}
@@ -40,7 +40,7 @@
                    hx-get="{{- url_for(model_name|lower ~ '-list') }}?search={{ search_query }}&sort_by={{ sort_by }}&sort_direction={{ sort_direction -}}"
                    hx-target="#model-list"
                    hx-push-url="true">
-                    Clear all filters
+                    {{ _("Clear all filters") }}
                 </a>
             </div>
         </div>

--- a/src/hyperadmin/templates/components/inline_row.html
+++ b/src/hyperadmin/templates/components/inline_row.html
@@ -28,12 +28,12 @@
         {%- endif -%}
     </td>
     {%- endfor -%}
-    <td class="ha-inline-actions" data-label="Actions">
+    <td class="ha-inline-actions" data-label="{{ _('Actions') }}">
         <button type="button"
                 class="ha-btn ha-btn-danger ha-btn-sm ha-inline-remove-btn"
                 data-testid="inline-{{ inline.prefix }}-remove-{{ row.index }}"
                 onclick="this.closest('tr').querySelector('[name$=DELETE]').value='1'; this.closest('tr').classList.add('ha-inline-row-deleted'); this.closest('tr').style.display='none';">
-            Remove
+            {{ _("Remove") }}
         </button>
         <input type="hidden" name="{{ inline.prefix }}-{{ row.index }}-DELETE" value="" />
     </td>

--- a/src/hyperadmin/templates/components/pagination.html
+++ b/src/hyperadmin/templates/components/pagination.html
@@ -1,7 +1,7 @@
-<nav aria-label="Pagination">
+<nav aria-label="{{ _('Pagination') }}">
 <div class="ha-pagination">
     <div class="ha-pagination-info" data-testid="pagination-info">
-        Showing {{- pagination.start_index }} to {{ pagination.end_index }} of {{ pagination.total_items }} results
+        {% trans start=pagination.start_index, end=pagination.end_index, total=pagination.total_items %}Showing {{ start }} to {{ end }} of {{ total }} results{% endtrans %}
     </div>
     <div class="ha-pagination-controls">
         {%- set filter_params -%}
@@ -14,12 +14,12 @@
            hx-swap="outerHTML"
            class="ha-pagination-btn"
            data-testid="pagination-prev">
-            Previous
+            {{ _("Previous") }}
         </a>
         {%- endif -%}
 
         <div class="ha-pagination-page" data-testid="pagination-page" aria-current="page">
-            Page {{ pagination.page }} of {{ pagination.total_pages }}
+            {% trans page=pagination.page, total_pages=pagination.total_pages %}Page {{ page }} of {{ total_pages }}{% endtrans %}
         </div>
 
         {%- if pagination.page < pagination.total_pages -%}
@@ -29,7 +29,7 @@
            hx-swap="outerHTML"
            class="ha-pagination-btn"
            data-testid="pagination-next">
-            Next
+            {{ _("Next") }}
         </a>
         {%- endif -%}
     </div>

--- a/src/hyperadmin/templates/components/search_input.html
+++ b/src/hyperadmin/templates/components/search_input.html
@@ -2,14 +2,14 @@
     <input type="search"
            name="search"
            value="{{- search_query -}}"
-           placeholder="Search..."
+           placeholder="{{ _('Search...') }}"
            class="ha-search-input"
            data-testid="search-input"
-           aria-label="Search"
+           aria-label="{{ _('Search') }}"
            hx-get="{{- url_for(model_name|lower ~ '-list') -}}"
            hx-trigger="keyup changed delay:500ms, search"
            hx-target="#model-list"
            hx-swap="outerHTML"
            hx-indicator="#search-indicator">
-    <span id="search-indicator" class="htmx-indicator ha-search-indicator">Searching...</span>
+    <span id="search-indicator" class="htmx-indicator ha-search-indicator">{{ _("Searching...") }}</span>
 </div>

--- a/src/hyperadmin/templates/components/table.html
+++ b/src/hyperadmin/templates/components/table.html
@@ -1,11 +1,11 @@
 <div id="model-list" class="ha-table-wrapper">
-    <table class="ha-table" data-testid="list-table" aria-label="{{ model_name }} list">
+    <table class="ha-table" data-testid="list-table" aria-label="{% trans model_name=model_name %}{{ model_name }} list{% endtrans %}">
         <thead>
             <tr class="ha-table-header">
                 {%- for field in fields -%}
                     {%- include "components/sortable_header.html" -%}
                 {%- endfor -%}
-                <th class="ha-table-th ha-table-th-center" scope="col">Actions</th>
+                <th class="ha-table-th ha-table-th-center" scope="col">{{ _("Actions") }}</th>
             </tr>
         </thead>
         <tbody class="ha-table-body">
@@ -15,21 +15,21 @@
                     {%- set cell_label = model_name if field == '__str__' else (field_labels[field] if field_labels is defined and field in field_labels else field.replace('_', ' ').title()) -%}
                     <td class="ha-table-cell" data-label="{{ cell_label }}">{{- item[field] -}}</td>
                 {%- endfor -%}
-                <td class="ha-table-cell ha-table-cell-center" data-label="Actions">
+                <td class="ha-table-cell ha-table-cell-center" data-label="{{ _('Actions') }}">
                     {%- if can_detail is not defined or can_detail -%}
-                    <a href="{{- url_for(model_name|lower ~ '-detail', item_id=item.id) -}}" class="ha-action-link" data-testid="row-view-link">View</a>
+                    <a href="{{- url_for(model_name|lower ~ '-detail', item_id=item.id) -}}" class="ha-action-link" data-testid="row-view-link">{{ _("View") }}</a>
                     {%- endif -%}
                     {%- if can_edit is not defined or can_edit -%}
-                    <a href="{{- url_for(model_name|lower ~ '-update-form', item_id=item.id) -}}" class="ha-action-link" data-testid="row-edit-link">Edit</a>
+                    <a href="{{- url_for(model_name|lower ~ '-update-form', item_id=item.id) -}}" class="ha-action-link" data-testid="row-edit-link">{{ _("Edit") }}</a>
                     {%- endif -%}
                     {%- if can_delete is not defined or can_delete -%}
                     <button hx-delete="{{- url_for(model_name|lower ~ '-delete', item_id=item.id) -}}"
-                            hx-confirm="Are you sure you want to delete this item?"
+                            hx-confirm="{{ _('Are you sure you want to delete this item?') }}"
                             hx-target="closest tr"
                             hx-swap="outerHTML"
                             class="ha-action-delete"
                             data-testid="row-delete-btn">
-                        Delete
+                        {{ _("Delete") }}
                     </button>
                     {%- endif -%}
                 </td>

--- a/src/hyperadmin/templates/create.html
+++ b/src/hyperadmin/templates/create.html
@@ -1,7 +1,7 @@
 {%- extends "form_layout.html" -%}
 
 {%- block form_title -%}
-    Create {{ model_name }}
+    {% trans model_name=model_name %}Create {{ model_name }}{% endtrans %}
 {%- endblock -%}
 
 {%- block form_attributes -%}
@@ -33,10 +33,10 @@
 {%- block form_actions -%}
     <div class="ha-form-actions">
         <button type="submit" class="ha-btn ha-btn-primary">
-            Create
+            {{ _("Create") }}
         </button>
         <a href="{{- url_for(model_name|lower ~ '-list') -}}" class="ha-cancel-link">
-            Cancel
+            {{ _("Cancel") }}
         </a>
     </div>
 {%- endblock -%}

--- a/src/hyperadmin/templates/detail.html
+++ b/src/hyperadmin/templates/detail.html
@@ -27,11 +27,11 @@
         <button
             data-testid="action-{{ act.name }}-btn"
             hx-post="{{- url_for(model_name_lower ~ '-action', item_id=item.id, action_name=act.name) -}}"
-            hx-confirm="Run action '{{ act.label }}'?"
+            hx-confirm="{% trans label=act.label %}Run action '{{ label }}'?{% endtrans %}"
             class="ha-btn ha-btn-action"
         >{{ act.label }}</button>
         {%- endfor -%}
     </div>
     {%- endif -%}
-    <a href="../" class="ha-text-link">Back to list</a>
+    <a href="../" class="ha-text-link">{{ _("Back to list") }}</a>
 {%- endblock -%}

--- a/src/hyperadmin/templates/form_layout.html
+++ b/src/hyperadmin/templates/form_layout.html
@@ -9,7 +9,7 @@
             </div>
             <div class="ha-form-actions">
                 {%- block form_actions -%}
-                <button type="submit" class="ha-btn ha-btn-primary">Save</button>
+                <button type="submit" class="ha-btn ha-btn-primary">{{ _("Save") }}</button>
                 {%- endblock -%}
             </div>
         </form>

--- a/src/hyperadmin/templates/list_layout.html
+++ b/src/hyperadmin/templates/list_layout.html
@@ -1,14 +1,14 @@
 {%- extends "base.html" -%}
 
-{%- block title -%}{{ model_name }} List | HyperAdmin{%- endblock -%}
+{%- block title -%}{% trans model_name=model_name %}{{ model_name }} List | HyperAdmin{% endtrans %}{%- endblock -%}
 
 {%- block content -%}
     <div class="ha-page-header" data-testid="page-header">
-        <h1 class="ha-section-title">{{- model_name -}} List</h1>
+        <h1 class="ha-section-title">{{- model_name -}}{{ _("List") }}</h1>
         {%- if can_create is not defined or can_create -%}
         <div class="ha-page-header-actions ha-list-toolbar">
             <a href="{{- url_for(model_name|lower ~ '-create-form') -}}" class="ha-btn ha-btn-primary ha-page-header-action-primary" data-testid="create-link">
-                Create New {{ model_name }}
+                {% trans model_name=model_name %}Create New {{ model_name }}{% endtrans %}
             </a>
         </div>
         {%- endif -%}

--- a/src/hyperadmin/templates/update.html
+++ b/src/hyperadmin/templates/update.html
@@ -1,7 +1,7 @@
 {%- extends "form_layout.html" -%}
 
 {%- block form_title -%}
-    Update {{ item_name }}
+    {% trans item_name=item_name %}Update {{ item_name }}{% endtrans %}
 {%- endblock -%}
 
 {%- block form_attributes -%}
@@ -33,10 +33,10 @@
 {%- block form_actions -%}
     <div class="ha-form-actions">
         <button type="submit" class="ha-btn ha-btn-primary">
-            Update
+            {{ _("Update") }}
         </button>
         <a href="{{- url_for(model_name|lower ~ '-list') -}}" class="ha-cancel-link">
-            Cancel
+            {{ _("Cancel") }}
         </a>
     </div>
 {%- endblock -%}


### PR DESCRIPTION
## Summary

Story C2-B of the v0.4.1 i18n epic: wrap hardcoded UI strings in list,
detail, form, pagination, and component templates with `_()` / `{% trans %}`.

Files touched:
- `templates/list_layout.html`
- `templates/detail.html`
- `templates/create.html`, `templates/update.html`, `templates/form_layout.html`
- `templates/components/pagination.html`
- `templates/components/{table,search_input,filter_bar,inline_row}.html`

No layout, CSS, `data-testid`, or Python changes. Whitespace-stripping in
`list_layout.html` h1 (`{{- model_name -}}List`) is preserved by translating
just the bare word `_("List")` rather than the full title.

**Note on `{% trans %}` syntax:** Jinja's newstyle gettext requires Jinja
placeholders (`{{ var }}`) inside the trans body, NOT printf-style
`%(var)s`. Initial draft used the latter and rendered the literal
placeholder; fixed in the same commit before push.

**Spec:** `docs/specs/i18n.md`
**Story:** `.meta/epics/epic-i18n/stories/c2b-wrap-list-detail-form.md`

## Manual test scenarios

- [ ] Open `/admin/user` with no `hyperadmin_locale` cookie — heading reads `UserList`,
      page title `User List | HyperAdmin`, search placeholder `Search...`, filter
      button `Filters`, "Create New User" link visible. No errors in dev console.
- [ ] Open `/admin/user/{id}` — detail view renders with `Back to list` link;
      action buttons (if any) confirm with `Run action '<label>'?`.
- [ ] Open `/admin/user/create` — h2 reads `Create User`, buttons `Create` / `Cancel`.
- [ ] Open `/admin/user/{id}/edit` — h2 reads `Update <item>`, buttons `Update` / `Cancel`.
- [ ] List with > 1 page — pagination shows `Showing 1 to N of M results`,
      `Page 1 of K`, `Previous` / `Next` buttons.
- [ ] Filter bar — `Any` placeholder, `Clear all filters` link.
- [ ] Inline formset — `Remove` button on each row.
- [ ] Verify table headers include translated `Actions` column with `View` /
      `Edit` / `Delete` action labels.