### PR TITLE
feat(views): structured flash + translatable validation messages (C2-C)

### DIFF
--- a/src/hyperadmin/views/forms.py
+++ b/src/hyperadmin/views/forms.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, ValidationError
 from pydantic.fields import FieldInfo
 
 from hyperadmin.core.choices import ChoiceItem
+from hyperadmin.i18n import gettext_lazy
 
 try:
     from hyperadmin.core.fields import classify_field as _classify_field
@@ -29,6 +30,10 @@ if TYPE_CHECKING:
     from hyperadmin.core.fieldsets import FieldsetSpec
     from hyperadmin.core.inlines import InlineModelSpec
     from hyperadmin.core.layouts import FormLayout
+
+# Type alias: errors can be lazy-translated proxies or plain strings.
+# ``babel.support.LazyProxy`` satisfies the string protocol via ``__str__``.
+ErrorList = list[Any]
 
 
 @dataclass(slots=True)
@@ -219,7 +224,7 @@ class FormField:
     model_field: FieldInfo
     widget: HtmxWidget
     value: Any | None = None
-    errors: list[str] | None = None
+    errors: ErrorList | None = None
 
     @property
     def label(self) -> str:
@@ -286,7 +291,7 @@ class PydanticForm:
         self.exclude = set(exclude or [])
         self.initial = initial or {}
         self.choices_base_url = choices_base_url
-        self.errors: dict[str, list[str]] = {}
+        self.errors: dict[str, ErrorList] = {}
         self._fields: list[FormField] = []
         self._fieldset_specs: list[FieldsetSpec] = fieldsets or []
         self._form_layout: FormLayout | None = form_layout
@@ -471,7 +476,7 @@ class PydanticForm:
         for f in self.fields:
             f.value = data.get(f.name)
 
-    def validate(self, data: dict[str, Any]) -> tuple[BaseModel | None, dict[str, list[str]]]:
+    def validate(self, data: dict[str, Any]) -> tuple[BaseModel | None, dict[str, ErrorList]]:
         cleaned_data = data.copy()
         for f in self.fields:
             if not f.required and cleaned_data.get(f.name) == "":
@@ -482,11 +487,11 @@ class PydanticForm:
             self.errors = {}
             return instance, {}
         except ValidationError as e:
-            errs: dict[str, list[str]] = {}
+            errs: dict[str, ErrorList] = {}
             for error in e.errors():
                 loc = error["loc"][0]
                 key = str(loc)
-                errs.setdefault(key, []).append(error["msg"])
+                errs.setdefault(key, []).append(gettext_lazy(error["msg"]))
             self.errors = errs
             for f in self.fields:
                 f.errors = errs.get(f.name)
@@ -543,7 +548,7 @@ class InlineFormset:
 
     spec: InlineModelSpec
     rows: list[InlineFormRow] = dc_field(default_factory=list)
-    errors: dict[int, dict[str, list[str]]] = dc_field(default_factory=dict)
+    errors: dict[int, dict[str, ErrorList]] = dc_field(default_factory=dict)
     add_row_url: str = ""
 
     @property
@@ -666,7 +671,7 @@ class InlineFormset:
         self,
         rows_data: list[dict[str, Any]],
         parent_pk: int | None = None,
-    ) -> tuple[list[dict[str, Any]], dict[int, dict[str, list[str]]]]:
+    ) -> tuple[list[dict[str, Any]], dict[int, dict[str, ErrorList]]]:
         """Validate each row's data against the inline model.
 
         Returns:
@@ -674,7 +679,7 @@ class InlineFormset:
             Each valid row is a dict ready for adapter.create/update.
         """
         valid: list[dict[str, Any]] = []
-        errors: dict[int, dict[str, list[str]]] = {}
+        errors: dict[int, dict[str, ErrorList]] = {}
 
         for i, row in enumerate(rows_data):
             if row.get("_delete"):
@@ -700,10 +705,10 @@ class InlineFormset:
                     result["_pk"] = row["_pk"]
                 valid.append(result)
             except ValidationError as e:
-                row_errors: dict[str, list[str]] = {}
+                row_errors: dict[str, ErrorList] = {}
                 for error in e.errors():
                     loc = str(error["loc"][0])
-                    row_errors.setdefault(loc, []).append(error["msg"])
+                    row_errors.setdefault(loc, []).append(gettext_lazy(error["msg"]))
                 errors[i] = row_errors
 
         self.errors = errors

--- a/src/hyperadmin/views/static.py
+++ b/src/hyperadmin/views/static.py
@@ -4,6 +4,14 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.templating import Jinja2Templates
 
 from hyperadmin.core.adapters import BaseAdapter
+from hyperadmin.i18n import gettext_lazy as _
+
+# Translatable status / flash messages constructed at module load time.
+# ``gettext_lazy`` defers translation to render time so the correct locale
+# is active when ``str(msg)`` is first evaluated in a template.
+_MSG_ITEM_NOT_FOUND = _("Item not found")
+_MSG_ITEM_CREATED = _("Item created successfully")
+_MSG_ITEM_UPDATED = _("Item updated successfully")
 
 # The templates are now in src/hyperadmin/templates
 template_dir = os.path.join(os.path.dirname(__file__), "templates")
@@ -59,7 +67,7 @@ class ModelView:
         """Deletes an item."""
         item = await self.adapter.get(pk=item_id)
         if not item:
-            raise HTTPException(status_code=404, detail="Item not found")
+            raise HTTPException(status_code=404, detail=str(_MSG_ITEM_NOT_FOUND))
 
         await self.adapter.delete(pk=item_id)
 
@@ -70,13 +78,13 @@ class ModelView:
         """Renders the update view and handles form submission for updating an item."""
         item = await self.adapter.get(pk=item_id)
         if not item:
-            raise HTTPException(status_code=404, detail="Item not found")
+            raise HTTPException(status_code=404, detail=str(_MSG_ITEM_NOT_FOUND))
 
         if request.method == "POST":
             form_data = await request.form()
             await self.adapter.update(pk=item_id, data=dict(form_data))
             # For now, let's redirect to the list view. HTMX will be added later.
-            return {"message": "Item updated successfully"}
+            return {"message": str(_MSG_ITEM_UPDATED)}
 
         context = {
             "request": request,
@@ -92,7 +100,7 @@ class ModelView:
             form_data = await request.form()
             await self.adapter.create(data=dict(form_data))
             # For now, let's redirect to the list view. HTMX will be added later.
-            return {"message": "Item created successfully"}  # This will be improved later
+            return {"message": str(_MSG_ITEM_CREATED)}
 
         context = {
             "request": request,
@@ -120,7 +128,7 @@ class ModelView:
         item = await self.adapter.get(pk=item_id)
 
         if not item:
-            raise HTTPException(status_code=404, detail="Item not found")
+            raise HTTPException(status_code=404, detail=str(_MSG_ITEM_NOT_FOUND))
 
         context = {
             "request": request,

--- a/tests/unit/test_i18n_validation.py
+++ b/tests/unit/test_i18n_validation.py
@@ -1,0 +1,245 @@
+"""Unit tests for C2-C: structured flash + translatable validation messages.
+
+BDD scenarios from .meta/epics/epic-i18n/stories/c2c-translatable-validation.md:
+
+Scenario: validation error message is a lazy string
+  Given a form field with min_length=3
+  When  views/forms.py constructs the error message
+  Then  the message is wrapped in gettext_lazy (returns msgid before translation)
+  And   str(msg) returns the English msgid
+
+Scenario: flash message is a lazy string
+  Given views/static.py emits a "Saved successfully" flash
+  When  the flash is constructed
+  Then  it is wrapped in gettext_lazy
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import babel.support
+import pytest
+from pydantic import BaseModel, Field
+
+from hyperadmin.i18n import loader
+from hyperadmin.i18n.loader import (
+    _clear_caches,
+    set_current_translations,
+)
+from hyperadmin.views.forms import PydanticForm
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_mo(target: Path, locale: str, msgs: dict[str, str]) -> None:
+    """Write a real Babel .mo file at *target* containing *msgs*."""
+    from babel.messages.catalog import Catalog
+    from babel.messages.mofile import write_mo
+
+    catalog = Catalog(locale=locale, charset="utf-8")
+    for msgid, msgstr in msgs.items():
+        catalog.add(msgid, string=msgstr)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("wb") as fh:
+        write_mo(fh, catalog)
+
+
+@pytest.fixture(autouse=True)
+def reset_i18n_state() -> Iterator[None]:
+    """Restore i18n context var and caches between tests."""
+    _clear_caches()
+    token = set_current_translations(babel.support.NullTranslations())
+    try:
+        yield
+    finally:
+        loader.reset_current_translations(token)
+        _clear_caches()
+
+
+# ---------------------------------------------------------------------------
+# Scenario: flash message is a lazy string
+# ---------------------------------------------------------------------------
+
+
+class TestFlashMessagesAreLazy:
+    def test_item_not_found_is_lazy_proxy(self) -> None:
+        """
+        Scenario: flash message is a lazy string
+          Given views/static.py defines _MSG_ITEM_NOT_FOUND
+          When  the module is imported
+          Then  the message is a LazyProxy instance
+        """
+        # Given views/static.py emits a flash message
+        import hyperadmin.views.static as static_mod
+
+        # When the module constant is inspected
+        msg = static_mod._MSG_ITEM_NOT_FOUND
+
+        # Then it is a LazyProxy (gettext_lazy wraps it)
+        assert isinstance(msg, babel.support.LazyProxy)
+
+    def test_item_created_is_lazy_proxy(self) -> None:
+        """
+        Scenario: flash message is a lazy string
+          Given views/static.py defines _MSG_ITEM_CREATED
+          When  the module is imported
+          Then  the message is a LazyProxy instance
+        """
+        import hyperadmin.views.static as static_mod
+
+        msg = static_mod._MSG_ITEM_CREATED
+
+        assert isinstance(msg, babel.support.LazyProxy)
+
+    def test_item_updated_is_lazy_proxy(self) -> None:
+        """
+        Scenario: flash message is a lazy string
+          Given views/static.py defines _MSG_ITEM_UPDATED
+          When  the module is imported
+          Then  the message is a LazyProxy instance
+        """
+        import hyperadmin.views.static as static_mod
+
+        msg = static_mod._MSG_ITEM_UPDATED
+
+        assert isinstance(msg, babel.support.LazyProxy)
+
+    def test_flash_str_returns_english_msgid_without_catalog(self) -> None:
+        """str(lazy_proxy) returns the msgid when no translation catalog is active."""
+        import hyperadmin.views.static as static_mod
+
+        # Given no catalog is installed (NullTranslations from fixture)
+        # When str() is called on the lazy proxy
+        result = str(static_mod._MSG_ITEM_NOT_FOUND)
+
+        # Then it returns the English msgid
+        assert result == "Item not found"
+
+    def test_flash_translates_when_catalog_active(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """str(lazy_proxy) returns translated text when a catalog is active."""
+        # Given a Spanish catalog that maps our msgids
+        _write_mo(
+            tmp_path / "es" / "LC_MESSAGES" / "messages.mo",
+            locale="es",
+            msgs={"Item not found": "Elemento no encontrado"},
+        )
+        monkeypatch.setattr(loader, "LOCALE_DIR", tmp_path)
+        _clear_caches()
+        translations = loader.load_translations("es")
+        token = set_current_translations(translations)
+
+        import hyperadmin.views.static as static_mod
+
+        try:
+            # When the locale is Spanish
+            # Then str() returns the Spanish translation
+            assert str(static_mod._MSG_ITEM_NOT_FOUND) == "Elemento no encontrado"
+        finally:
+            loader.reset_current_translations(token)
+
+
+# ---------------------------------------------------------------------------
+# Scenario: validation error message is a lazy string
+# ---------------------------------------------------------------------------
+
+
+class ShortNameModel(BaseModel):
+    """Minimal model with a min_length constraint for testing."""
+
+    name: str = Field(min_length=3)
+
+
+class TestValidationErrorsAreLazy:
+    def test_validation_error_is_lazy_proxy(self) -> None:
+        """
+        Scenario: validation error message is a lazy string
+          Given a form field with min_length=3
+          When  views/forms.py constructs the error message
+          Then  the message is wrapped in gettext_lazy (a LazyProxy)
+          And   str(msg) returns the English msgid
+        """
+        # Given a PydanticForm backed by ShortNameModel
+        form = PydanticForm(ShortNameModel)
+
+        # When validation fails (name too short)
+        _instance, errs = form.validate({"name": "ab"})
+
+        # Then errs["name"] contains a LazyProxy
+        assert errs, "Expected validation errors but got none"
+        name_errors = errs.get("name", [])
+        assert name_errors, "Expected errors on 'name' field"
+        first_error = name_errors[0]
+        assert isinstance(first_error, babel.support.LazyProxy)
+
+    def test_validation_error_str_returns_msgid(self) -> None:
+        """str(proxy) returns the English msgid before any catalog is installed."""
+        form = PydanticForm(ShortNameModel)
+        _instance, errs = form.validate({"name": "ab"})
+
+        name_errors = errs.get("name", [])
+        assert name_errors
+
+        # str() should return the English pydantic error message
+        msg_str = str(name_errors[0])
+        assert len(msg_str) > 0
+        assert isinstance(msg_str, str)
+
+    def test_field_errors_are_lazy_proxies(self) -> None:
+        """FormField.errors are also LazyProxy after validate()."""
+        form = PydanticForm(ShortNameModel)
+        form.validate({"name": "x"})
+
+        name_field = next((f for f in form.fields if f.name == "name"), None)
+        assert name_field is not None
+        assert name_field.errors is not None and len(name_field.errors) > 0
+        assert isinstance(name_field.errors[0], babel.support.LazyProxy)
+
+    def test_validation_error_translates_when_catalog_active(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """LazyProxy re-evaluates when locale changes, returning translated text."""
+        # Build form and trigger validation error to capture the proxy
+        form = PydanticForm(ShortNameModel)
+        _instance, errs = form.validate({"name": "ab"})
+        name_errors = errs.get("name", [])
+        assert name_errors
+        proxy = name_errors[0]
+        msgid = str(proxy)  # English baseline
+
+        # Given a catalog that translates the Pydantic error msgid
+        translated = "El valor es demasiado corto"
+        _write_mo(
+            tmp_path / "es" / "LC_MESSAGES" / "messages.mo",
+            locale="es",
+            msgs={msgid: translated},
+        )
+        monkeypatch.setattr(loader, "LOCALE_DIR", tmp_path)
+        _clear_caches()
+        translations = loader.load_translations("es")
+        token = set_current_translations(translations)
+
+        try:
+            # When the locale is Spanish, the proxy re-evaluates
+            assert str(proxy) == translated
+        finally:
+            loader.reset_current_translations(token)
+        # After locale reset, proxy returns the English msgid again
+        assert str(proxy) == msgid
+
+    def test_valid_form_has_empty_errors(self) -> None:
+        """A passing validation produces no errors."""
+        form = PydanticForm(ShortNameModel)
+        instance, errs = form.validate({"name": "abc"})
+
+        assert instance is not None
+        assert errs == {}


### PR DESCRIPTION
## Summary

Cycle 2 Slot C of the v0.4.1 i18n epic. Wraps user-facing flash and
validation messages in \`gettext_lazy\` so they translate at render time.

- \`src/hyperadmin/views/static.py\`: three module-level \`LazyProxy\` constants
  (\`_MSG_ITEM_NOT_FOUND\`, \`_MSG_ITEM_CREATED\`, \`_MSG_ITEM_UPDATED\`) created via
  \`gettext_lazy\`, consumed with \`str()\` at call sites.
- \`src/hyperadmin/views/forms.py\`: \`PydanticForm.validate()\` and
  \`InlineFormset.validate_rows()\` now wrap each Pydantic error \`msg\` in
  \`gettext_lazy\`; introduces \`ErrorList = list[Any]\` type alias and updates
  all type annotations accordingly.
- \`tests/unit/test_i18n_validation.py\`: 10 new unit tests covering both BDD scenarios.

## Spec & story

- \`docs/specs/i18n.md\`
- \`.meta/epics/epic-i18n/stories/c2c-translatable-validation.md\`

## Manual test scenarios

- [ ] Submit a form with invalid input (e.g. a too-short field). The error
      list renders English with no exception.
- [ ] \`from hyperadmin.i18n import gettext_lazy; from babel.support import LazyProxy; ...\` — assert validation error strings are \`LazyProxy\` instances.
- [ ] \`uv run poe test:unit\` green; \`uv run poe lint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)