### PR TITLE
feat(ui): <html dir> from locale + _rtl.css overrides (C3-B)

### DIFF
--- a/src/hyperadmin/core/app.py
+++ b/src/hyperadmin/core/app.py
@@ -321,6 +321,9 @@ class Admin:
         self.templates.env.globals["site_title"] = self.settings.site_title
         self.templates.env.globals["site_header"] = self.settings.site_header
         self.templates.env.globals["supported_locales"] = self.settings.supported_locales
+        from hyperadmin.i18n import RTL_LOCALES
+
+        self.templates.env.globals["rtl_locales"] = RTL_LOCALES
 
         if self.auth_backend:
             self.router.on_startup.append(self._sync_permissions)

--- a/src/hyperadmin/i18n/__init__.py
+++ b/src/hyperadmin/i18n/__init__.py
@@ -27,9 +27,10 @@ from hyperadmin.i18n.loader import (
     reset_current_translations,
     set_current_translations,
 )
-from hyperadmin.i18n.middleware import LocaleMiddleware, negotiate_locale
+from hyperadmin.i18n.middleware import RTL_LOCALES, LocaleMiddleware, negotiate_locale
 
 __all__ = [
+    "RTL_LOCALES",
     "LocaleMiddleware",
     "get_current_translations",
     "gettext",

--- a/src/hyperadmin/i18n/middleware.py
+++ b/src/hyperadmin/i18n/middleware.py
@@ -37,6 +37,14 @@ if TYPE_CHECKING:
 
 COOKIE_NAME = "hyperadmin_locale"
 
+#: Locale codes whose natural reading direction is right-to-left.
+#:
+#: Used by :func:`hyperadmin.core.app.Admin.mount` to expose ``rtl_locales``
+#: as a Jinja2 global so ``_base.html`` can render ``<html dir="rtl">``.
+#: None of the seeded locales (en, es, fr, de, zh_CN, ja, uk) are RTL by
+#: default; RTL locales remain opt-in via ``HYPERADMIN_SUPPORTED_LOCALES``.
+RTL_LOCALES: frozenset[str] = frozenset({"ar", "he", "fa", "ur"})
+
 
 def _parse_accept_language(header: str) -> list[str]:
     """Return preferred locale codes ordered by quality, normalised to BCP47-with-underscore.

--- a/src/hyperadmin/static/css/_rtl.css
+++ b/src/hyperadmin/static/css/_rtl.css
@@ -1,0 +1,59 @@
+/* ==========================================================================
+   RTL (Right-to-Left) Overrides
+   ========================================================================== */
+
+/*
+ * All rules here are scoped under [dir="rtl"] so they are completely inert
+ * for LTR layouts.  Most layout mirroring is handled automatically by the
+ * logical CSS properties introduced in C3-A (_layout.css, _sidebar.css, …).
+ * Only the few physical properties that cannot be expressed as logical ones
+ * are listed here.
+ *
+ * C3-B — <html dir> from locale + RTL overrides.
+ */
+
+/* --------------------------------------------------------------------------
+   Mobile sidebar: flip the slide-in direction.
+
+   LTR default:  starts off-screen to the LEFT  (translateX(-100%))
+                 slides to   translateX(0) when open.
+   RTL override: starts off-screen to the RIGHT (translateX(100%))
+                 slides to   translateX(0) when open.
+   ----------------------------------------------------------------------- */
+
+@media (max-width: 767px) {
+  [dir="rtl"] .ha-sidebar {
+    transform: translateX(100%);
+  }
+
+  [dir="rtl"] .ha-sidebar.ha-sidebar-mobile-open {
+    transform: translateX(0);
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Directional icon rotations.
+
+   SVG arrows and chevrons that point left / right carry physical meaning.
+   In RTL the "forward" direction is to the left, so we mirror them.
+   Only icons that are already rotated or used as prev/next indicators need
+   explicit treatment — stroke-based icons that are symmetric (X, ✓, ⓘ)
+   do NOT need mirroring.
+   ----------------------------------------------------------------------- */
+
+/* Pagination "previous" arrow — points left in LTR, right in RTL */
+[dir="rtl"] [data-testid="pagination-prev"] svg,
+[dir="rtl"] .ha-pagination-prev svg {
+  transform: scaleX(-1);
+}
+
+/* Pagination "next" arrow — points right in LTR, left in RTL */
+[dir="rtl"] [data-testid="pagination-next"] svg,
+[dir="rtl"] .ha-pagination-next svg {
+  transform: scaleX(-1);
+}
+
+/* Navbar user-menu chevron (dropdown indicator) */
+[dir="rtl"] .ha-navbar-user-btn-chevron {
+  transform: scaleX(-1);
+}

--- a/src/hyperadmin/static/css/hyperadmin.css
+++ b/src/hyperadmin/static/css/hyperadmin.css
@@ -10,7 +10,7 @@
  * Browser support: CSS @layer requires Chrome 99+, Firefox 97+, Safari 15.4+
  */
 
-@layer tokens, reset, layout, components, utilities, accessibility, responsive;
+@layer tokens, reset, layout, components, utilities, accessibility, responsive, rtl;
 
 @import "_tokens.css"        layer(tokens);
 @import "_dark-mode.css"     layer(tokens);
@@ -34,3 +34,4 @@
 @import "_utilities.css"     layer(utilities);
 @import "_accessibility.css" layer(accessibility);
 @import "_responsive.css"    layer(responsive);
+@import "_rtl.css"           layer(rtl);

--- a/src/hyperadmin/templates/_base.html
+++ b/src/hyperadmin/templates/_base.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html lang="en" data-ha-default-theme="{{ theme|default('auto') }}">
+<html lang="{{ request.state.locale | default('en') }}"
+      dir="{{ 'rtl' if (request.state.locale | default('en')) in rtl_locales else 'ltr' }}"
+      data-ha-default-theme="{{ theme|default('auto') }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/tests/unit/test_i18n_rtl.py
+++ b/tests/unit/test_i18n_rtl.py
@@ -1,0 +1,228 @@
+"""Unit tests for C3-B — <html dir> driven by locale + RTL_LOCALES constant.
+
+BDD scenarios covered
+---------------------
+
+Scenario: LTR locale sets dir="ltr"
+  Given request.state.locale == "en"
+  When  _base.html renders
+  Then  <html dir="ltr" lang="en">
+
+Scenario: RTL locale sets dir="rtl"
+  Given supported_locales includes "ar" and request locale is "ar"
+  When  _base.html renders
+  Then  <html dir="rtl" lang="ar">
+
+Scenario: RTL_LOCALES constant is correct
+  Then  "ar", "he", "fa", "ur" are in RTL_LOCALES
+  And   "en", "es", "fr", "de", "zh_CN", "ja", "uk" are NOT in RTL_LOCALES
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from starlette.requests import Request
+from starlette.responses import HTMLResponse
+from starlette.testclient import TestClient
+
+from hyperadmin.core.settings import HyperAdminSettings
+from hyperadmin.i18n.middleware import RTL_LOCALES, LocaleMiddleware
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HYPERADMIN_SRC = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "src",
+    "hyperadmin",
+)
+_TEMPLATE_DIR = os.path.join(_HYPERADMIN_SRC, "templates")
+_STATIC_DIR = os.path.join(_HYPERADMIN_SRC, "static")
+
+
+def _make_template_client(
+    supported_locales: list[str],
+    default_locale: str = "en",
+) -> TestClient:
+    """Build a minimal app with LocaleMiddleware that renders _base.html.
+
+    The Jinja environment is wired exactly as Admin.mount() does it:
+    - install_jinja_i18n for the gettext callables
+    - rtl_locales global pointing to RTL_LOCALES
+    - theme, site_title, site_header, admin_prefix, auth_enabled, supported_locales globals
+    """
+    from hyperadmin.i18n.loader import install_jinja_i18n
+
+    settings = HyperAdminSettings(
+        default_locale=default_locale,
+        supported_locales=supported_locales,
+        create_tables=False,
+    )
+
+    templates = Jinja2Templates(directory=_TEMPLATE_DIR)
+    install_jinja_i18n(templates.env)
+    templates.env.globals["rtl_locales"] = RTL_LOCALES
+    templates.env.globals["theme"] = "auto"
+    templates.env.globals["site_title"] = "HyperAdmin"
+    templates.env.globals["site_header"] = "HyperAdmin"
+    templates.env.globals["admin_prefix"] = "/admin"
+    templates.env.globals["auth_enabled"] = False
+    templates.env.globals["supported_locales"] = supported_locales
+
+    app = FastAPI()
+    # Mount static files so url_for('static', path=...) resolves in _base.html
+    app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
+    app.add_middleware(LocaleMiddleware, settings=settings)
+
+    @app.get("/")
+    async def root(request: Request) -> HTMLResponse:
+        response = templates.TemplateResponse(request, "_base.html", {})
+        return response  # type: ignore[return-value]
+
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
+# RTL_LOCALES constant
+# ---------------------------------------------------------------------------
+
+
+class TestRTLLocalesConstant:
+    """Scenario: RTL_LOCALES constant is correct."""
+
+    def test_rtl_locales_is_a_frozenset(self) -> None:
+        assert isinstance(RTL_LOCALES, frozenset)
+
+    def test_rtl_codes_are_in_rtl_locales(self) -> None:
+        # Then "ar", "he", "fa", "ur" are in RTL_LOCALES
+        for code in ("ar", "he", "fa", "ur"):
+            assert code in RTL_LOCALES, f"Expected {code!r} in RTL_LOCALES"
+
+    def test_ltr_locales_are_not_in_rtl_locales(self) -> None:
+        # And "en", "es", "fr", "de", "zh_CN", "ja", "uk" are NOT in RTL_LOCALES
+        for code in ("en", "es", "fr", "de", "zh_CN", "ja", "uk"):
+            assert code not in RTL_LOCALES, f"Expected {code!r} NOT in RTL_LOCALES"
+
+
+# ---------------------------------------------------------------------------
+# Template rendering — lang and dir attributes
+# ---------------------------------------------------------------------------
+
+
+class TestHtmlDirLtr:
+    """Scenario: LTR locale sets dir="ltr"."""
+
+    def test_html_has_lang_en_and_dir_ltr(self) -> None:
+        # Given request.state.locale == "en" (no cookie, no Accept-Language)
+        client = _make_template_client(supported_locales=["en", "es"])
+
+        # When _base.html renders
+        response = client.get("/")
+
+        # Then <html dir="ltr" lang="en">
+        assert response.status_code == 200
+        body = response.text
+        assert 'lang="en"' in body
+        assert 'dir="ltr"' in body
+
+    def test_html_has_lang_es_and_dir_ltr_for_spanish_cookie(self) -> None:
+        # Given request locale resolved to "es" via cookie
+        client = _make_template_client(supported_locales=["en", "es"])
+        client.cookies.set("hyperadmin_locale", "es")
+
+        # When _base.html renders with cookie hyperadmin_locale=es
+        response = client.get("/")
+
+        # Then <html dir="ltr" lang="es">
+        assert response.status_code == 200
+        body = response.text
+        assert 'lang="es"' in body
+        assert 'dir="ltr"' in body
+        assert 'dir="rtl"' not in body
+
+
+class TestHtmlDirRtl:
+    """Scenario: RTL locale sets dir="rtl"."""
+
+    def test_html_has_lang_ar_and_dir_rtl_for_arabic_cookie(self) -> None:
+        # Given supported_locales includes "ar" and cookie sets locale to "ar"
+        client = _make_template_client(supported_locales=["en", "ar"])
+        client.cookies.set("hyperadmin_locale", "ar")
+
+        # When _base.html renders with cookie hyperadmin_locale=ar
+        response = client.get("/")
+
+        # Then <html dir="rtl" lang="ar">
+        assert response.status_code == 200
+        body = response.text
+        assert 'lang="ar"' in body
+        assert 'dir="rtl"' in body
+
+    @pytest.mark.parametrize("rtl_code", ["ar", "he", "fa", "ur"])
+    def test_all_rtl_codes_produce_dir_rtl(self, rtl_code: str) -> None:
+        # Given supported_locales includes the RTL locale
+        client = _make_template_client(supported_locales=["en", rtl_code])
+        client.cookies.set("hyperadmin_locale", rtl_code)
+
+        # When _base.html renders with the RTL locale cookie
+        response = client.get("/")
+
+        # Then dir="rtl" and lang=<rtl_code>
+        assert response.status_code == 200
+        body = response.text
+        assert f'lang="{rtl_code}"' in body
+        assert 'dir="rtl"' in body
+
+    def test_ltr_locale_does_not_produce_rtl_when_rtl_in_supported(self) -> None:
+        # Given both "en" and "ar" are supported, but locale resolves to "en"
+        client = _make_template_client(supported_locales=["en", "ar"])
+
+        # When _base.html renders with no cookie (defaults to "en")
+        response = client.get("/")
+
+        # Then dir="ltr" — RTL_LOCALES must not leak into LTR sessions
+        assert response.status_code == 200
+        body = response.text
+        assert 'dir="ltr"' in body
+        assert 'dir="rtl"' not in body
+
+
+# ---------------------------------------------------------------------------
+# RTL_LOCALES re-export from hyperadmin.i18n
+# ---------------------------------------------------------------------------
+
+
+class TestRTLLocalesReExport:
+    """Verify RTL_LOCALES is accessible from the package-level __init__."""
+
+    def test_rtl_locales_importable_from_package(self) -> None:
+        from hyperadmin.i18n import RTL_LOCALES as pkg_rtl_locales
+
+        assert pkg_rtl_locales is RTL_LOCALES
+
+
+# ---------------------------------------------------------------------------
+# Admin.mount() wires rtl_locales as a Jinja global
+# ---------------------------------------------------------------------------
+
+
+class TestAdminMountRTLGlobal:
+    """Verify Admin.mount() exposes rtl_locales in the Jinja environment."""
+
+    def test_rtl_locales_set_as_jinja_global(self) -> None:
+        from hyperadmin.core.app import Admin
+
+        mock_app = MagicMock(spec=FastAPI)
+        settings = HyperAdminSettings(create_tables=False)
+        admin = Admin(app=mock_app, settings=settings)
+        admin.mount("/admin")
+
+        assert "rtl_locales" in admin.templates.env.globals
+        assert admin.templates.env.globals["rtl_locales"] is RTL_LOCALES


### PR DESCRIPTION
## Summary

Cycle 3 Slot B of the v0.4.1 i18n epic. `<html dir>` is now driven by the
resolved locale; `_rtl.css` carries the few overrides that logical properties
cannot express.

- Adds `RTL_LOCALES: frozenset[str] = frozenset({"ar", "he", "fa", "ur"})` to `i18n/middleware.py`, re-exported from `hyperadmin/i18n/__init__.py`
- Updates `_base.html` `<html>` tag to emit `lang="{{ locale }}"` and `dir="rtl"|"ltr"` based on `rtl_locales` Jinja global
- Wires `rtl_locales = RTL_LOCALES` as a Jinja global in `Admin.mount()` (alongside `theme`, `admin_prefix`, etc.)
- Creates `src/hyperadmin/static/css/_rtl.css` with `[dir="rtl"]`-scoped overrides for sidebar `translateX` direction and directional SVG icon rotations
- Imports `_rtl.css` in `hyperadmin.css` via a new `rtl` CSS `@layer`
- 13 unit tests in `tests/unit/test_i18n_rtl.py` covering all 3 BDD scenarios

## Spec & story

- `docs/specs/i18n.md`
- `.meta/epics/epic-i18n/stories/c3b-html-dir-rtl.md`

## Manual test scenarios

- [ ] Set cookie `hyperadmin_locale=en` → `<html dir="ltr" lang="en">` in page source.
- [ ] Add `"ar"` to `supported_locales` via `HYPERADMIN_SUPPORTED_LOCALES=en,ar` and set the cookie → `<html dir="rtl" lang="ar">`. Sidebar mirrors; table cells right-align.
- [ ] Existing E2E suite green at 1280px (LTR layout unchanged).
- [ ] `uv run poe lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)