### PR TITLE
feat(auth): ObjectPermission protocol (C1-A, #476)

### DIFF
--- a/src/hyperadmin/core/__init__.py
+++ b/src/hyperadmin/core/__init__.py
@@ -2,6 +2,7 @@
 
 from hyperadmin.core.actions import ActionDef, action, collect_actions
 from hyperadmin.core.adapters import JsonApiAdapter, ListEnvelope, PaginationMeta
+from hyperadmin.core.auth import DefaultObjectPermissionChecker, ObjectPermissionChecker
 from hyperadmin.core.choices import ChoiceItem, ChoicesProvider, SelectFieldMeta
 from hyperadmin.core.display import get_field_label
 from hyperadmin.core.fields import classify_field
@@ -21,12 +22,14 @@ __all__ = [
     "ActionDef",
     "ChoiceItem",
     "ChoicesProvider",
+    "DefaultObjectPermissionChecker",
     "FieldMeta",
     "FieldsetSpec",
     "FormLayout",
     "InlineModelSpec",
     "JsonApiAdapter",
     "ListEnvelope",
+    "ObjectPermissionChecker",
     "PaginationMeta",
     "SelectFieldMeta",
     "action",

--- a/src/hyperadmin/core/auth.py
+++ b/src/hyperadmin/core/auth.py
@@ -45,3 +45,31 @@ class PermissionRegistry(Protocol):
     """Syncs auto-generated and custom permissions to the database."""
 
     async def sync_permissions(self, registered_models: list[Any]) -> None: ...
+
+
+@runtime_checkable
+class ObjectPermissionChecker(Protocol):
+    """Checks whether a user may perform ``action`` on a specific object.
+
+    Complements :class:`PermissionChecker` (model-level) with per-object
+    authorization. ``action`` shares the model-level codenames:
+    ``"view"``, ``"add"``, ``"change"``, ``"delete"``. Implementations may
+    accept additional custom action codenames.
+
+    Superuser bypass and other policy decisions are the responsibility of
+    the concrete implementation, not the protocol.
+    """
+
+    async def has_object_permission(self, user: Any, obj: Any, action: str) -> bool: ...
+
+
+class DefaultObjectPermissionChecker:
+    """Permissive default: allow every action on every object.
+
+    Acts as the no-op fallback when an application has not configured a
+    custom :class:`ObjectPermissionChecker`. Existing model-level
+    :class:`PermissionChecker` enforcement is unaffected.
+    """
+
+    async def has_object_permission(self, user: Any, obj: Any, action: str) -> bool:
+        return True

--- a/tests/unit/test_object_permission_protocol.py
+++ b/tests/unit/test_object_permission_protocol.py
@@ -1,0 +1,99 @@
+"""Tests for the ObjectPermissionChecker protocol (C1-A, #476).
+
+TDD: Verify the runtime-checkable protocol shape and the permissive
+default implementation. Maps 1:1 to BDD scenarios in the story.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+class TestObjectPermissionCheckerProtocol:
+    def test_protocol_importable_from_core_auth(self) -> None:
+        """ObjectPermissionChecker is exported from hyperadmin.core.auth."""
+        from hyperadmin.core.auth import ObjectPermissionChecker
+
+        assert ObjectPermissionChecker is not None
+
+    def test_default_importable_from_core_auth(self) -> None:
+        """DefaultObjectPermissionChecker is exported from hyperadmin.core.auth."""
+        from hyperadmin.core.auth import DefaultObjectPermissionChecker
+
+        assert DefaultObjectPermissionChecker is not None
+
+    def test_protocol_exported_from_core_package(self) -> None:
+        """Protocol and default are re-exported from hyperadmin.core."""
+        from hyperadmin.core import (
+            DefaultObjectPermissionChecker,
+            ObjectPermissionChecker,
+        )
+
+        assert ObjectPermissionChecker is not None
+        assert DefaultObjectPermissionChecker is not None
+
+    def test_protocol_is_runtime_checkable(self) -> None:
+        """
+        Scenario: protocol is runtime-checkable
+          Given a class implementing has_object_permission(user, obj, action) -> bool
+          When  isinstance(instance, ObjectPermissionChecker) is evaluated
+          Then  result is True
+        """
+        from hyperadmin.core.auth import ObjectPermissionChecker
+
+        class MockChecker:
+            async def has_object_permission(self, user: Any, obj: Any, action: str) -> bool:
+                return True
+
+        assert isinstance(MockChecker(), ObjectPermissionChecker)
+
+    def test_non_conforming_class_is_not_an_instance(self) -> None:
+        """A class missing has_object_permission is not an ObjectPermissionChecker."""
+        from hyperadmin.core.auth import ObjectPermissionChecker
+
+        class NotAChecker:
+            pass
+
+        assert not isinstance(NotAChecker(), ObjectPermissionChecker)
+
+
+class TestDefaultObjectPermissionChecker:
+    @pytest.mark.anyio
+    async def test_default_allows_view_access(self) -> None:
+        """
+        Scenario: default implementation allows all access
+          Given DefaultObjectPermissionChecker is used
+          When  has_object_permission(user, order, "view") is called
+          Then  result is True
+        """
+        from hyperadmin.core.auth import DefaultObjectPermissionChecker
+
+        checker = DefaultObjectPermissionChecker()
+        user = object()
+        order = object()
+
+        result = await checker.has_object_permission(user, order, "view")
+
+        assert result is True
+
+    @pytest.mark.anyio
+    async def test_default_allows_arbitrary_action(self) -> None:
+        """Default checker is permissive for any action codename."""
+        from hyperadmin.core.auth import DefaultObjectPermissionChecker
+
+        checker = DefaultObjectPermissionChecker()
+
+        for action in ("view", "add", "change", "delete", "custom"):
+            assert await checker.has_object_permission(None, None, action) is True
+
+    @pytest.mark.anyio
+    async def test_default_satisfies_protocol(self) -> None:
+        """DefaultObjectPermissionChecker is itself an ObjectPermissionChecker."""
+        from hyperadmin.core.auth import (
+            DefaultObjectPermissionChecker,
+            ObjectPermissionChecker,
+        )
+
+        assert isinstance(DefaultObjectPermissionChecker(), ObjectPermissionChecker)


### PR DESCRIPTION
## Summary

Adds `ObjectPermissionChecker` Protocol and `DefaultObjectPermissionChecker` permissive default to `src/hyperadmin/core/auth.py`. Both are re-exported from `hyperadmin.core` to provide the foundation seam for v0.5.1 per-object authorization. Superuser bypass is intentionally deferred to concrete implementations per the SDD.

Closes #476

**Spec**: [docs/specs/object-permissions-mfa.md](../blob/develop/docs/specs/object-permissions-mfa.md)

## BDD scenarios

- [x] **Scenario: protocol is runtime-checkable** — `isinstance(impl, ObjectPermissionChecker)` returns `True` for any class implementing `has_object_permission(user, obj, action) -> bool`.
- [x] **Scenario: default implementation allows all access** — `DefaultObjectPermissionChecker.has_object_permission(user, order, "view")` returns `True` (and likewise for any action codename).

## Test plan

- [x] `poe lint` — all hooks (ruff, mypy, basedpyright, commitizen) pass
- [x] `poe test:unit` — 603 tests pass; 8 new tests in `tests/unit/test_object_permission_protocol.py`

## Scope

- No changes to `auth/permissions.py` (existing `PermissionChecker` impl)
- No `AdminOptions` wiring (deferred to C2-A)
- No superuser bypass logic in the default impl

Part of v0.5.1 Cycle 1 — Foundations.