### PR TITLE
feat(adapters): get_queryset hook + per-request RLS filter (C1-B, #478)

### DIFF
--- a/src/hyperadmin/adapters/sqlalchemy.py
+++ b/src/hyperadmin/adapters/sqlalchemy.py
@@ -23,8 +23,23 @@ class SQLAlchemyAdapter(BaseAdapter):
             raise ValueError("Could not inspect model. Is it a valid SQLAlchemy model?")
 
     async def get(self, pk: Any) -> Any:
+        """Retrieve an object by primary key, applying any ``get_queryset`` filters.
+
+        Filters returned by :meth:`get_queryset` are ANDed with the primary-key
+        predicate so excluded rows resolve to ``None`` (not raised).
+        """
+        queryset_filters = self._resolve_queryset_filters()
         async with AsyncSession(self.engine) as session:
-            return await session.get(self.model, pk)
+            if not queryset_filters:
+                return await session.get(self.model, pk)
+            assert self.inspector is not None  # noqa: S101 — validated in __init__
+            pk_col = self.inspector.primary_key[0]
+            conditions = [pk_col == pk]
+            for key, value in queryset_filters.items():
+                conditions.append(getattr(self.model, key) == value)
+            query = select(self.model).where(and_(*conditions))
+            result = await session.execute(query)
+            return result.scalar_one_or_none()
 
     async def list(
         self,
@@ -35,7 +50,10 @@ class SQLAlchemyAdapter(BaseAdapter):
         order_by: str | None = None,
         search_fields: list[str] | None = None,  # noqa: ARG002
     ) -> tuple[list[Any], int]:
-        where_conditions = []
+        queryset_filters = self._resolve_queryset_filters()
+        where_conditions = [
+            getattr(self.model, key) == value for key, value in queryset_filters.items()
+        ]
         if filters:
             for key, value in filters.items():
                 where_conditions.append(getattr(self.model, key) == value)

--- a/src/hyperadmin/adapters/sqlmodel.py
+++ b/src/hyperadmin/adapters/sqlmodel.py
@@ -27,16 +27,22 @@ class SQLModelAdapter(BaseAdapter):
         """
         Retrieves a single object by its primary key.
 
+        Any filters returned by :meth:`get_queryset` are merged into the WHERE clause
+        before the primary-key predicate so excluded rows resolve to ``None``.
+
         Args:
             pk: The primary key of the object to retrieve.
 
         Returns:
             The retrieved object, or None if not found.
         """
+        queryset_filters = self._resolve_queryset_filters()
         async with AsyncSession(self.engine) as session:
             mapper = inspect(self.model)
             options = [selectinload(getattr(self.model, rel.key)) for rel in mapper.relationships]
             query = select(self.model).where(self.model.id == pk).options(*options)
+            for key, value in queryset_filters.items():
+                query = query.where(getattr(self.model, key) == value)
             result = await session.execute(query)
             return result.scalar_one_or_none()
 
@@ -51,7 +57,12 @@ class SQLModelAdapter(BaseAdapter):
     ) -> tuple[list[Any], int]:
         """
         Retrieves a list of objects with optional pagination, searching, and filtering.
+
+        Filters returned by :meth:`get_queryset` are applied **before** any
+        view-layer ``filters`` so they cannot be bypassed. The same predicates are
+        included in the count query, keeping pagination math consistent.
         """
+        queryset_filters = self._resolve_queryset_filters()
         async with AsyncSession(self.engine) as session:
             query = select(self.model)
 
@@ -59,6 +70,10 @@ class SQLModelAdapter(BaseAdapter):
             mapper = inspect(self.model)
             for rel in mapper.relationships:
                 query = query.options(selectinload(getattr(self.model, rel.key)))
+
+            # Apply queryset hook filters first (RLS / tenant scoping)
+            for key, value in queryset_filters.items():
+                query = query.where(getattr(self.model, key) == value)
 
             # Apply filtering
             if filters:

--- a/src/hyperadmin/core/adapters.py
+++ b/src/hyperadmin/core/adapters.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import builtins
 
+    from starlette.requests import Request
+
     from hyperadmin.core.choices import ChoiceItem
     from hyperadmin.core.inlines import InlineModelSpec
+
+    QuerysetFilter = Callable[["Request | None"], dict[str, Any]]
 
 
 @dataclass
@@ -49,6 +54,63 @@ class BaseAdapter(ABC):
     def __init__(self, model: Any, engine: Any) -> None:
         self.model = model
         self.engine = engine
+        self._queryset_filter: QuerysetFilter | None = None
+
+    def get_queryset(self, request: Request | None = None) -> dict[str, Any]:
+        """Return additional equality filters merged into ``list()`` and ``get()`` queries.
+
+        The returned mapping has the shape ``{column_name: value}`` and is applied as
+        equality predicates **before** any view-layer filters. Use this hook to implement
+        features like row-level security or tenant scoping without leaking those concerns
+        into the view layer.
+
+        Subclasses may override this method directly, or callers may register a
+        per-request callable via :meth:`set_queryset_filter`. The callable is
+        re-evaluated on every ``list()`` / ``get()`` — no caching — so it must be pure
+        or request-scoped.
+
+        Default behaviour returns an empty dict, which is a no-op (backward compatible).
+
+        Args:
+            request: The active Starlette/FastAPI request, when available. ``None`` is
+                permitted so the hook is callable from contexts without an HTTP request
+                (e.g. management scripts, tests).
+
+        Returns:
+            A dict of column-name to value pairs to be ANDed into the query's WHERE
+            clause. Returns ``{}`` by default.
+        """
+        if self._queryset_filter is None:
+            return {}
+        return self._queryset_filter(request)
+
+    def set_queryset_filter(self, filter_fn: QuerysetFilter) -> None:
+        """Register a per-request callable that returns additional queryset filters.
+
+        The callable receives the current :class:`starlette.requests.Request` (or
+        ``None``) and must return a dict of ``{column_name: value}`` equality filters.
+        It is re-invoked on every ``list()`` / ``get()`` so it may consult
+        request-scoped state (e.g. ``request.state.user``).
+
+        Args:
+            filter_fn: A callable taking an optional :class:`Request` and returning a
+                dict of equality filters.
+        """
+        self._queryset_filter = filter_fn
+
+    def _resolve_queryset_filters(self, request: Request | None = None) -> dict[str, Any]:
+        """Invoke :meth:`get_queryset` and validate the return type.
+
+        Raises:
+            TypeError: If ``get_queryset`` returns a value that is not a ``dict``.
+        """
+        result = self.get_queryset(request)
+        if not isinstance(result, dict):
+            raise TypeError(
+                f"{type(self).__name__}.get_queryset() must return a dict, "
+                f"got {type(result).__name__}"
+            )
+        return result
 
     @abstractmethod
     async def get(self, pk: Any) -> Any:

--- a/tests/unit/test_adapter_get_queryset.py
+++ b/tests/unit/test_adapter_get_queryset.py
@@ -1,0 +1,285 @@
+"""Unit tests for the BaseAdapter.get_queryset hook (BDD scenarios from issue #478).
+
+Each test maps 1:1 to a scenario in
+``.meta/epics/.../featadapters-add-getqueryset-hook-to-baseadapter-sqlmodelada.md``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.adapters.sqlalchemy import SQLAlchemyAdapter
+from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+
+
+class Document(SQLModel, table=True):
+    """Test model with an ``owner_id`` column for row-level filter scenarios."""
+
+    __tablename__ = "test_get_queryset_document"
+
+    id: int | None = Field(default=None, primary_key=True)
+    title: str
+    owner_id: int = Field(default=0, index=True)
+
+
+@pytest.fixture
+async def engine() -> AsyncEngine:
+    eng = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with eng.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    return eng
+
+
+@pytest.fixture
+async def sqlmodel_adapter(engine: AsyncEngine) -> SQLModelAdapter:
+    return SQLModelAdapter(model=Document, engine=engine)
+
+
+@pytest.fixture
+async def sqlalchemy_adapter(engine: AsyncEngine) -> SQLAlchemyAdapter:
+    return SQLAlchemyAdapter(model=Document, engine=engine)
+
+
+async def _seed(adapter: SQLModelAdapter | SQLAlchemyAdapter, owner_counts: dict[int, int]) -> None:
+    """Create N rows per owner_id."""
+    for owner_id, count in owner_counts.items():
+        for i in range(count):
+            await adapter.create({"title": f"doc-{owner_id}-{i}", "owner_id": owner_id})
+
+
+# ---------------------------------------------------------------------------
+# Scenario: get_queryset filters list results
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_queryset_filters_list_results_sqlmodel(
+    sqlmodel_adapter: SQLModelAdapter,
+) -> None:
+    """
+    Scenario: get_queryset filters are applied to list results
+      Given adapter has get_queryset() returning {"owner_id": 1}
+      When  adapter.list() is called
+      Then  only matching records are returned
+    """
+    # Given
+    await _seed(sqlmodel_adapter, {1: 3, 2: 5})
+    sqlmodel_adapter.set_queryset_filter(lambda _request: {"owner_id": 1})
+
+    # When
+    rows, total = await sqlmodel_adapter.list(page=1, page_size=50)
+
+    # Then
+    assert total == 3
+    assert all(row.owner_id == 1 for row in rows)
+
+
+@pytest.mark.anyio
+async def test_get_queryset_filters_list_results_sqlalchemy(
+    sqlalchemy_adapter: SQLAlchemyAdapter,
+) -> None:
+    # Given
+    await _seed(sqlalchemy_adapter, {1: 3, 2: 5})
+    sqlalchemy_adapter.set_queryset_filter(lambda _request: {"owner_id": 1})
+
+    # When
+    rows, total = await sqlalchemy_adapter.list(page=1, page_size=50)
+
+    # Then
+    assert total == 3
+    assert all(row.owner_id == 1 for row in rows)
+
+
+# ---------------------------------------------------------------------------
+# Scenario: get_queryset filters get() results (returns None when row excluded)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_queryset_filters_get_results_sqlmodel(
+    sqlmodel_adapter: SQLModelAdapter,
+) -> None:
+    """
+    Scenario: get_queryset filters are applied to get() results
+      Given adapter has get_queryset() returning {"owner_id": 1}
+      When  adapter.get(pk=X) is called for a record with owner_id=2
+      Then  result is None (record filtered out)
+    """
+    # Given
+    visible = await sqlmodel_adapter.create({"title": "mine", "owner_id": 1})
+    hidden = await sqlmodel_adapter.create({"title": "yours", "owner_id": 2})
+    sqlmodel_adapter.set_queryset_filter(lambda _request: {"owner_id": 1})
+
+    # When
+    visible_result = await sqlmodel_adapter.get(pk=visible.id)
+    hidden_result = await sqlmodel_adapter.get(pk=hidden.id)
+
+    # Then
+    assert visible_result is not None
+    assert visible_result.id == visible.id
+    assert hidden_result is None
+
+
+@pytest.mark.anyio
+async def test_get_queryset_filters_get_results_sqlalchemy(
+    sqlalchemy_adapter: SQLAlchemyAdapter,
+) -> None:
+    # Given
+    visible = await sqlalchemy_adapter.create({"title": "mine", "owner_id": 1})
+    hidden = await sqlalchemy_adapter.create({"title": "yours", "owner_id": 2})
+    sqlalchemy_adapter.set_queryset_filter(lambda _request: {"owner_id": 1})
+
+    # When
+    visible_result = await sqlalchemy_adapter.get(pk=visible.id)
+    hidden_result = await sqlalchemy_adapter.get(pk=hidden.id)
+
+    # Then
+    assert visible_result is not None
+    assert visible_result.id == visible.id
+    assert hidden_result is None
+
+
+# ---------------------------------------------------------------------------
+# Scenario: empty get_queryset is a no-op (backward compatible)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_empty_get_queryset_is_no_op_sqlmodel(
+    sqlmodel_adapter: SQLModelAdapter,
+) -> None:
+    """
+    Scenario: empty get_queryset returns all records (backward compatible)
+      Given adapter has default get_queryset() returning {}
+      When  adapter.list() is called
+      Then  all records are returned (no extra filtering)
+    """
+    # Given
+    await _seed(sqlmodel_adapter, {1: 3, 2: 5})
+
+    # When (no set_queryset_filter call — default behavior)
+    rows, total = await sqlmodel_adapter.list(page=1, page_size=50)
+
+    # Then
+    assert total == 8
+    assert len(rows) == 8
+
+
+@pytest.mark.anyio
+async def test_empty_get_queryset_is_no_op_sqlalchemy(
+    sqlalchemy_adapter: SQLAlchemyAdapter,
+) -> None:
+    # Given
+    await _seed(sqlalchemy_adapter, {1: 3, 2: 5})
+
+    # When
+    rows, total = await sqlalchemy_adapter.list(page=1, page_size=50)
+
+    # Then
+    assert total == 8
+    assert len(rows) == 8
+
+
+@pytest.mark.anyio
+async def test_default_get_queryset_returns_empty_dict(
+    sqlmodel_adapter: SQLModelAdapter,
+) -> None:
+    """Default ``get_queryset`` returns an empty dict, never ``None``."""
+    assert sqlmodel_adapter.get_queryset() == {}
+    assert sqlmodel_adapter.get_queryset(request=None) == {}
+
+
+# ---------------------------------------------------------------------------
+# Scenario: get_queryset count reflects filtered total
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_queryset_count_reflects_filter_sqlmodel(
+    sqlmodel_adapter: SQLModelAdapter,
+) -> None:
+    """
+    Scenario: get_queryset count reflects filtered results
+      Given 100 records total, 30 matching {"owner_id": 1}
+      When  adapter.list() is called with queryset filter {"owner_id": 1}
+      Then  total count is 30
+    """
+    # Given
+    await _seed(sqlmodel_adapter, {1: 30, 2: 70})
+    sqlmodel_adapter.set_queryset_filter(lambda _request: {"owner_id": 1})
+
+    # When
+    rows, total = await sqlmodel_adapter.list(page=1, page_size=10)
+
+    # Then
+    assert total == 30
+    assert len(rows) == 10  # paginated
+    assert all(row.owner_id == 1 for row in rows)
+
+
+@pytest.mark.anyio
+async def test_get_queryset_count_reflects_filter_sqlalchemy(
+    sqlalchemy_adapter: SQLAlchemyAdapter,
+) -> None:
+    # Given
+    await _seed(sqlalchemy_adapter, {1: 30, 2: 70})
+    sqlalchemy_adapter.set_queryset_filter(lambda _request: {"owner_id": 1})
+
+    # When
+    rows, total = await sqlalchemy_adapter.list(page=1, page_size=10)
+
+    # Then
+    assert total == 30
+    assert len(rows) == 10
+    assert all(row.owner_id == 1 for row in rows)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases (per SDD §"Edge Cases & Error Handling")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_get_queryset_non_dict_raises_type_error(
+    sqlmodel_adapter: SQLModelAdapter,
+) -> None:
+    """If a custom ``get_queryset`` returns a non-dict, raise ``TypeError`` early."""
+    sqlmodel_adapter.set_queryset_filter(lambda _request: ["not", "a", "dict"])  # type: ignore[arg-type,return-value]
+    with pytest.raises(TypeError):
+        await sqlmodel_adapter.list(page=1, page_size=10)
+
+
+@pytest.mark.anyio
+async def test_get_queryset_non_dict_raises_type_error_on_get(
+    sqlmodel_adapter: SQLModelAdapter,
+) -> None:
+    created = await sqlmodel_adapter.create({"title": "x", "owner_id": 1})
+    sqlmodel_adapter.set_queryset_filter(lambda _request: 42)  # type: ignore[arg-type,return-value]
+    with pytest.raises(TypeError):
+        await sqlmodel_adapter.get(pk=created.id)
+
+
+@pytest.mark.anyio
+async def test_set_queryset_filter_evaluated_per_request(
+    sqlmodel_adapter: SQLModelAdapter,
+) -> None:
+    """The filter callable is re-evaluated on every list/get — no caching."""
+    await _seed(sqlmodel_adapter, {1: 2, 2: 2})
+
+    state: dict[str, Any] = {"current_owner": 1}
+
+    def dynamic_filter(_request: Any) -> dict[str, Any]:
+        return {"owner_id": state["current_owner"]}
+
+    sqlmodel_adapter.set_queryset_filter(dynamic_filter)
+
+    _, total_owner_1 = await sqlmodel_adapter.list(page=1, page_size=10)
+    state["current_owner"] = 2
+    _, total_owner_2 = await sqlmodel_adapter.list(page=1, page_size=10)
+
+    assert total_owner_1 == 2
+    assert total_owner_2 == 2


### PR DESCRIPTION
## Summary

- `BaseAdapter.get_queryset(request)` lands as a default-no-op hook returning `{}`, with a `set_queryset_filter(filter_fn)` setter for registering a per-request, re-evaluated callable.
- `SQLModelAdapter.list()` and `.get()` merge the hook's dict into the WHERE clause **before** any view-layer filters (RLS / tenant scoping cannot be bypassed).
- `SQLAlchemyAdapter.list()` and `.get()` mirror the behaviour; `get()` falls back to a `SELECT ... WHERE pk = ? AND ...` when filters are present so excluded rows resolve to `None`.
- Count query respects the same predicates so paginated totals stay consistent.
- Non-dict returns raise `TypeError` early (per SDD edge cases); the filter callable is re-invoked per request, never cached.

Closes #478. Note: #426 is a duplicate, already closed during v0.5.1 pre-flight.

**Spec:** [`docs/specs/object-permissions-mfa.md`](../blob/develop/docs/specs/object-permissions-mfa.md) (Track A — "API / Protocol Changes → New adapter hook")

## BDD scenario checklist

- [x] **Scenario:** `get_queryset` filters are applied to list results — covered by `test_get_queryset_filters_list_results_sqlmodel` / `_sqlalchemy`
- [x] **Scenario:** `get_queryset` filters are applied to `get()` results (returns `None` when row excluded) — covered by `test_get_queryset_filters_get_results_sqlmodel` / `_sqlalchemy`
- [x] **Scenario:** empty `get_queryset` returns all records (backward compatible) — covered by `test_empty_get_queryset_is_no_op_sqlmodel` / `_sqlalchemy`
- [x] **Scenario:** `get_queryset` count reflects filtered results (30 of 100, page_size=10) — covered by `test_get_queryset_count_reflects_filter_sqlmodel` / `_sqlalchemy`

Plus three SDD edge-case tests:
- `test_default_get_queryset_returns_empty_dict` — default returns `{}`, never `None`
- `test_get_queryset_non_dict_raises_type_error[_on_get]` — type validation surfaces misconfig
- `test_set_queryset_filter_evaluated_per_request` — callable is re-evaluated per call, no caching

## Test plan

- [x] `poe lint` — ruff + ruff-format + mypy + basedpyright + pre-commit all green
- [x] `poe test:unit` — full unit suite (607 passed; new file adds 12 tests)
- [x] All 4 BDD scenarios covered for both `SQLModelAdapter` and `SQLAlchemyAdapter`
- [x] Backward-compatibility verified: pre-existing adapter tests still pass without modification

## Scope

Bottom-up: this is the adapter layer only. Views, options, and `model.py` are intentionally untouched — those are later cycles (C1-C, C2, …).

Part of v0.5.1 Cycle 1 — Foundations. The seam landing here is what v0.5.3 multi-tenancy will plug into via `set_queryset_filter()` registered from a tenant-aware middleware.