### PR TITLE
docs(spec): flip object-permissions-mfa SDD status to Approved

### DIFF
--- a/docs/specs/object-permissions-mfa.md
+++ b/docs/specs/object-permissions-mfa.md
@@ -3,11 +3,12 @@
 | Field | Value |
 |---|---|
 | Author | Claude Code |
-| Status | Draft |
+| Status | Approved |
 | Issue | #473 |
 | Milestone | v0.5.1 — Object Permissions & MFA |
 | Created | 2026-05-03 |
 | Last updated | 2026-05-03 |
+| Approved | 2026-05-03 (PR #532 merged; review story #475 done) |
 
 ---
 


### PR DESCRIPTION
## Summary

One-line status fix on `docs/specs/object-permissions-mfa.md`: Status field flipped `Draft → Approved` to match the merged state.

## Why

PR #532 merged the SDD; PR #533 flipped the spec-review story #475 to `done`. The SDD frontmatter Status field was left at `Draft` — out of sync.

The C1-A code review (PR #534) flagged this as a process warning: implementing against an SDD whose header says Draft is technically a SDD-conventions violation.

## Diff

```
| Author | Claude Code |
-| Status | Draft |
+| Status | Approved |
| Issue | #473 |
| Milestone | v0.5.1 — Object Permissions & MFA |
| Created | 2026-05-03 |
| Last updated | 2026-05-03 |
+| Approved | 2026-05-03 (PR #532 merged; review story #475 done) |
```

## Test plan

- [x] commitizen pre-commit passes
- [x] No content changes

## Stack

This unblocks merging PR #534 (C1-A) and PR #535 (C1-B) without the "implementing against draft spec" warning.