### PR TITLE
feat(auth): MFA fields on User model (C1-C, #483)

### DIFF
--- a/src/hyperadmin/auth/models.py
+++ b/src/hyperadmin/auth/models.py
@@ -16,6 +16,13 @@ class User(SQLModel, table=True):
     last_name: str = Field(default="", max_length=50)
     is_active: bool = Field(default=True)
     is_superuser: bool = Field(default=False)
+    # MFA fields (additive, backward compatible — existing rows default to disabled, no
+    # migration required). ``mfa_method`` is a free-form string rather than an Enum so
+    # future methods (totp/sms/webauthn) can be added without a breaking schema change;
+    # validation of allowed values lives in the service layer. For the MVP only "email"
+    # is wired end-to-end — see docs/specs/object-permissions-mfa.md (Track B).
+    mfa_enabled: bool = Field(default=False)
+    mfa_method: str | None = Field(default=None, max_length=32)
     created_at: datetime = Field(default_factory=datetime.now)
     updated_at: datetime | None = Field(default=None)
 

--- a/tests/unit/test_user_mfa_fields.py
+++ b/tests/unit/test_user_mfa_fields.py
@@ -1,0 +1,83 @@
+"""Tests for MFA fields on the User model (C1-C, #483).
+
+Maps the BDD scenarios from the story
+``.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/
+featauth-add-mfa-fields-to-user-model.md`` 1:1 to test functions.
+
+Spec: docs/specs/object-permissions-mfa.md (Track B, "Data Model Changes").
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlmodel import Session, SQLModel, select
+
+
+@pytest.fixture
+def engine(tmp_path):
+    # Import models so their tables register on SQLModel.metadata before create_all().
+    import hyperadmin.auth.models  # noqa: F401
+
+    db_file = tmp_path / "test_user_mfa.db"
+    eng = create_engine(f"sqlite:///{db_file}")
+    SQLModel.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def session(engine):
+    with Session(engine) as s:
+        yield s
+
+
+def test_new_user_has_mfa_disabled_by_default(session: Session) -> None:
+    """
+    Scenario: new user has MFA disabled by default
+      Given a new User record is created
+      When  the user's fields are inspected
+      Then  ``mfa_enabled`` is ``False`` and ``mfa_method`` is ``None``
+    """
+    from hyperadmin.auth.models import User
+
+    # Given a new User record is created
+    user = User(
+        username="defaults_mfa",
+        email="defaults_mfa@example.com",
+        password_hash="fakehash",
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    # When the user's fields are inspected
+    # Then mfa_enabled is False and mfa_method is None
+    assert user.mfa_enabled is False
+    assert user.mfa_method is None
+
+
+def test_mfa_fields_are_persisted(session: Session) -> None:
+    """
+    Scenario: MFA fields are persisted
+      Given user "alice" enables MFA with method "email"
+      When  the user record is saved and reloaded
+      Then  ``mfa_enabled`` is ``True`` and ``mfa_method`` is ``"email"``
+    """
+    from hyperadmin.auth.models import User
+
+    # Given user "alice" enables MFA with method "email"
+    alice = User(
+        username="alice",
+        email="alice@example.com",
+        password_hash="fakehash",
+        mfa_enabled=True,
+        mfa_method="email",
+    )
+    session.add(alice)
+    session.commit()
+
+    # When the user record is saved and reloaded
+    session.expire_all()
+    reloaded = session.exec(select(User).where(User.username == "alice")).one()
+
+    # Then mfa_enabled is True and mfa_method is "email"
+    assert reloaded.mfa_enabled is True
+    assert reloaded.mfa_method == "email"


### PR DESCRIPTION
## Summary

- Adds two additive fields to `User` (`mfa_enabled: bool`, `mfa_method: str | None`) with safe defaults.
- Defaults (`False` / `None`) keep this backward compatible — no migration required for existing rows.
- `mfa_method` is a string (not an Enum) per SDD so future methods (totp/sms/webauthn) extend without a breaking schema change. MVP only wires `"email"` end-to-end in later slots.

Closes #483.

**Spec:** [`docs/specs/object-permissions-mfa.md`](../blob/develop/docs/specs/object-permissions-mfa.md) — Track B, "Data Model Changes".

## BDD scenarios (story #483)

- [x] Scenario: new user has MFA disabled by default — `tests/unit/test_user_mfa_fields.py::test_new_user_has_mfa_disabled_by_default`
- [x] Scenario: MFA fields are persisted — `tests/unit/test_user_mfa_fields.py::test_mfa_fields_are_persisted`

## Test plan

- [x] `poe lint` — all hooks green (ruff, ruff format, mypy, basedpyright, commitizen)
- [x] `poe test:unit` — 597 passed (2 new + existing suite, no regressions)
- [ ] No E2E impact — data-model layer only (per Bottom-Up rule, slot scope)

## Backward compatibility

Backward compatible — no migration required. Both new columns are additive with default values; existing rows transparently materialise as `mfa_enabled=False, mfa_method=None`.

## Scope guardrails (this slot)

- Touches **only** `src/hyperadmin/auth/models.py` + a new unit test.
- Does **not** modify `auth/views.py`, `auth/middleware.py`, `auth/otp.py` — those belong to later C1/C2 slots.
- No `MfaMethod` Enum class, per SDD decision.

## Files changed

- `src/hyperadmin/auth/models.py` (+8 lines: 2 fields + 5-line docstring comment)
- `tests/unit/test_user_mfa_fields.py` (new, 82 lines, 2 tests)

---

Part of v0.5.1 Cycle 1 — Foundations.