### PR TITLE
feat(core): ObjectPermissionChecker on AdminOptions (C2-A, #477)

### DIFF
--- a/src/hyperadmin/core/options.py
+++ b/src/hyperadmin/core/options.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
+from hyperadmin.core.auth import ObjectPermissionChecker
 from hyperadmin.core.fieldsets import FieldsetSpec
 from hyperadmin.core.inlines import InlineModelSpec
 from hyperadmin.core.layouts import FormLayout
@@ -21,6 +22,8 @@ class AdminOptions(BaseModel):
         site.register(Product, options=AdminOptions(can_delete=False))
         ```
     """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     can_create: bool = True
     """Whether the Create form and POST endpoint are generated."""
@@ -113,4 +116,17 @@ class AdminOptions(BaseModel):
             InlineModelSpec(model=OrderItem, fk_field="order_id", extra=3),
         ])
         ```
+    """
+    object_permission_checker: ObjectPermissionChecker | None = None
+    """Per-object permission checker used by the view layer for fine-grained authz.
+
+    When ``None`` (default), no object-level checks are performed and behavior
+    matches model-level :class:`PermissionChecker` enforcement only. Provide a
+    custom :class:`ObjectPermissionChecker` (or
+    :class:`DefaultObjectPermissionChecker` as a permissive baseline) to opt
+    into per-object authorization.
+
+    The view layer that consumes this field is wired in a later slot (C2-C);
+    declaring it here lets model registrations adopt object-level checks ahead
+    of the wiring.
     """

--- a/tests/unit/test_admin_options_object_permission_checker.py
+++ b/tests/unit/test_admin_options_object_permission_checker.py
@@ -1,0 +1,43 @@
+"""Unit tests for ``AdminOptions.object_permission_checker`` (C2-A, #477).
+
+Covers the BDD scenarios from the story:
+
+- Default ``AdminOptions()`` exposes ``object_permission_checker is None``.
+- Constructing ``AdminOptions(object_permission_checker=...)`` retains the value.
+"""
+
+from __future__ import annotations
+
+from hyperadmin.core.auth import DefaultObjectPermissionChecker
+from hyperadmin.core.options import AdminOptions
+
+
+def test_admin_options_object_permission_checker_defaults_to_none() -> None:
+    """Scenario: default is None (no object-level checks).
+
+    Given a model registered with default options
+    When  the model's options are inspected
+    Then  ``options.object_permission_checker`` is ``None``
+    """
+    # Given / When
+    options = AdminOptions()
+
+    # Then
+    assert options.object_permission_checker is None
+
+
+def test_admin_options_accepts_object_permission_checker() -> None:
+    """Scenario: AdminOptions accepts object_permission_checker.
+
+    Given a model registered with ``options=AdminOptions(object_permission_checker=my_checker)``
+    When  the model's options are inspected
+    Then  ``options.object_permission_checker`` is ``my_checker``
+    """
+    # Given
+    checker = DefaultObjectPermissionChecker()
+
+    # When
+    options = AdminOptions(object_permission_checker=checker)
+
+    # Then
+    assert options.object_permission_checker is checker


### PR DESCRIPTION
## Summary

Adds `object_permission_checker: ObjectPermissionChecker | None = None` to
`AdminOptions` so model registrations can opt into object-level permission
enforcement. Field is declared but not yet consumed — view-layer wiring lands
in **C2-C** (#480 + #481 bundle).

Closes #477.

**Spec**: [docs/specs/object-permissions-mfa.md](../blob/develop/docs/specs/object-permissions-mfa.md) (Track A — §"Configuration Changes → AdminOptions")

Part of v0.5.1 Cycle 2 — Wiring.

## BDD scenarios

- [x] **AdminOptions accepts object_permission_checker** — constructing
  `AdminOptions(object_permission_checker=my_checker)` retains the value.
- [x] **default is None (no object-level checks)** — `AdminOptions()` exposes
  `object_permission_checker is None`.

## Implementation notes

- Imports `ObjectPermissionChecker` from `hyperadmin.core.auth` (merged in C1-A).
- Adds `model_config = ConfigDict(arbitrary_types_allowed=True)` because the
  protocol is a `runtime_checkable` Protocol (Pydantic does not introspect
  Protocols by default).
- Field default is `None` so existing model registrations are unaffected.
- No view-layer, registry, or `ModelView` wiring — strictly the configuration
  surface as scoped by the slot.

## Test plan

- [x] `poe lint` — green
- [x] `poe test:unit` — 652 passed (2 new + existing suite intact)
- [x] Pre-push hook runs full e2e — green

## Files changed

- `src/hyperadmin/core/options.py` — add field + config
- `tests/unit/test_admin_options_object_permission_checker.py` — 2 BDD-scenario tests