### PR TITLE
feat(auth): MFA challenge view + template (C2-D, #486)

### DIFF
--- a/src/hyperadmin/auth/views.py
+++ b/src/hyperadmin/auth/views.py
@@ -1,10 +1,29 @@
-"""Login and logout view handlers for HyperAdmin."""
+"""Login, logout and MFA view handlers for HyperAdmin.
+
+The MFA endpoints (``/mfa/challenge``, ``/mfa/verify``, ``/mfa/resend``)
+were added in v0.5.1 (C2-D, #486). They consume the partial-auth marker
+written under ``PARTIAL_AUTH_SESSION_KEY`` by ``login_view``. The actual
+wiring of ``login_view`` to populate that marker, plus the middleware
+gate that redirects partial-auth users to the challenge, lands in C3-A
+— this module only owns the consumer side.
+"""
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import select
 from starlette.responses import RedirectResponse
+
+from hyperadmin.auth.models import User
+from hyperadmin.auth.otp import (
+    OTP_SESSION_KEY,
+    PARTIAL_AUTH_SESSION_KEY,
+    RateLimitError,
+)
+from hyperadmin.i18n import gettext as _
 
 if TYPE_CHECKING:
     from fastapi.templating import Jinja2Templates
@@ -43,3 +62,197 @@ async def logout_view(
     """Handle POST logout — clear session and redirect to login."""
     await auth_backend.logout(request)
     return RedirectResponse(url=f"{admin_prefix}/login", status_code=302)
+
+
+# ── MFA challenge / verify / resend (C2-D, #486) ───────────────────────────
+
+
+def _read_partial_auth(request: Request) -> dict[str, Any] | None:
+    """Return the partial-auth marker if present and well-shaped, else None.
+
+    Per the SDD's resolved Open Question #2, the marker is a structured dict
+    ``{"stage": "mfa_pending", "user_id": <int>}``. Anything else (a stale
+    bare-int from earlier drafts, or a corrupted entry) is treated as absent.
+    """
+    raw = request.session.get(PARTIAL_AUTH_SESSION_KEY)
+    if not isinstance(raw, dict):
+        return None
+    if raw.get("stage") != "mfa_pending":
+        return None
+    if not isinstance(raw.get("user_id"), int):
+        return None
+    return raw
+
+
+async def _load_partial_user(engine: Any, user_id: int) -> User | None:
+    async with AsyncSession(engine) as session:
+        stmt = select(User).where(User.id == user_id)
+        return (await session.execute(stmt)).scalar_one_or_none()
+
+
+def _entry_is_expired(entry: dict[str, Any], otp_service: Any) -> bool:
+    """Return True if a session OTP entry is past its TTL.
+
+    Mirrors the TTL math inside ``EmailOTPService.verify`` so the view can
+    surface a distinct "expired" message without depending on the service's
+    return value (which collapses expiry and mismatch into False).
+    """
+    ttl = getattr(otp_service, "_ttl_seconds", 300)
+    raw_issued_at = entry.get("issued_at")
+    if not isinstance(raw_issued_at, str):
+        return True
+    try:
+        issued_at = datetime.fromisoformat(raw_issued_at)
+    except ValueError:
+        return True
+    if issued_at.tzinfo is None:
+        issued_at = issued_at.replace(tzinfo=timezone.utc)
+    return datetime.now(tz=timezone.utc) - issued_at > timedelta(seconds=ttl)
+
+
+def _challenge_response(
+    request: Request,
+    templates: Jinja2Templates,
+    admin_prefix: str,
+    *,
+    error: str | None = None,
+    flash: str | None = None,
+    expired: bool = False,
+    status_code: int = 200,
+) -> Any:
+    """Render the MFA challenge template with optional error/flash state."""
+    context = {
+        "request": request,
+        "admin_prefix": admin_prefix,
+        "error": error,
+        "flash": flash,
+        "expired": expired,
+    }
+    return templates.TemplateResponse(
+        request,
+        "auth/mfa_challenge.html",
+        context,
+        status_code=status_code,
+    )
+
+
+async def mfa_challenge_view(
+    request: Request,
+    templates: Jinja2Templates,
+    admin_prefix: str,
+) -> Any:
+    """GET /admin/mfa/challenge — render the OTP entry form.
+
+    Requires a partial-auth session. If absent, the user is bounced to
+    ``/admin/login`` — there is no useful challenge for an anonymous
+    visitor and silently rendering the form would mislead them.
+    """
+    partial = _read_partial_auth(request)
+    if partial is None:
+        return RedirectResponse(url=f"{admin_prefix}/login", status_code=302)
+    return _challenge_response(request, templates, admin_prefix)
+
+
+async def mfa_verify_view(
+    request: Request,
+    templates: Jinja2Templates,
+    auth_backend: Any,
+    otp_service: Any,
+    admin_prefix: str,
+) -> Any:
+    """POST /admin/mfa/verify — validate the submitted code, upgrade session.
+
+    On success: clear ``PARTIAL_AUTH_SESSION_KEY`` BEFORE granting the full
+    session via ``auth_backend.login``. The order matters: burning the
+    partial marker first ensures any race between concurrent requests
+    cannot escalate a partial-auth cookie into full auth.
+    """
+    partial = _read_partial_auth(request)
+    if partial is None:
+        return RedirectResponse(url=f"{admin_prefix}/login", status_code=302)
+
+    user = await _load_partial_user(auth_backend.engine, partial["user_id"])
+    if user is None:
+        # User was deleted between password and MFA — drop them back to login.
+        request.session.pop(PARTIAL_AUTH_SESSION_KEY, None)
+        return RedirectResponse(url=f"{admin_prefix}/login", status_code=302)
+
+    form = await request.form()
+    submitted = str(form.get("code", "")).strip()
+
+    # Detect expiry / missing-entry states BEFORE delegating to ``verify`` so
+    # we can render distinct error copy ("Code expired" vs "Invalid code").
+    # ``EmailOTPService.verify`` collapses both into a False return — that is
+    # correct for the service contract, but the user-facing template needs
+    # to know which path to render (expired → highlight resend).
+    entry = request.session.get(OTP_SESSION_KEY)
+    if entry is None:
+        return _challenge_response(
+            request,
+            templates,
+            admin_prefix,
+            error=_("Code expired, please request a new one."),
+            expired=True,
+        )
+    if _entry_is_expired(entry, otp_service):
+        return _challenge_response(
+            request,
+            templates,
+            admin_prefix,
+            error=_("Code expired, please request a new one."),
+            expired=True,
+        )
+
+    ok = await otp_service.verify(user, submitted, request.session)
+    if ok:
+        # Clear partial marker FIRST, then grant full auth — see docstring.
+        request.session.pop(PARTIAL_AUTH_SESSION_KEY, None)
+        await auth_backend.login(request, user)
+        return RedirectResponse(url=f"{admin_prefix}/", status_code=302)
+
+    return _challenge_response(
+        request,
+        templates,
+        admin_prefix,
+        error=_("Invalid code."),
+    )
+
+
+async def mfa_resend_view(
+    request: Request,
+    templates: Jinja2Templates,
+    auth_backend: Any,
+    otp_service: Any,
+    admin_prefix: str,
+) -> Any:
+    """POST /admin/mfa/resend — re-issue an OTP, rate-limited.
+
+    Designed for HTMX (``hx-post``) so the surrounding challenge page
+    stays put and only the flash region is swapped. Falling back to a
+    plain form-POST also works: the full page re-renders with the flash.
+    """
+    partial = _read_partial_auth(request)
+    if partial is None:
+        return RedirectResponse(url=f"{admin_prefix}/login", status_code=302)
+
+    user = await _load_partial_user(auth_backend.engine, partial["user_id"])
+    if user is None:
+        request.session.pop(PARTIAL_AUTH_SESSION_KEY, None)
+        return RedirectResponse(url=f"{admin_prefix}/login", status_code=302)
+
+    try:
+        await otp_service.generate_and_send(user, request.session)
+    except RateLimitError:
+        return _challenge_response(
+            request,
+            templates,
+            admin_prefix,
+            error=_("Too many attempts, try again later."),
+        )
+
+    return _challenge_response(
+        request,
+        templates,
+        admin_prefix,
+        flash=_("A new code has been sent to your email."),
+    )

--- a/src/hyperadmin/auth/views.py
+++ b/src/hyperadmin/auth/views.py
@@ -27,6 +27,7 @@ from hyperadmin.i18n import gettext as _
 
 if TYPE_CHECKING:
     from fastapi.templating import Jinja2Templates
+    from sqlalchemy.ext.asyncio import AsyncEngine
     from starlette.requests import Request
 
 
@@ -84,7 +85,7 @@ def _read_partial_auth(request: Request) -> dict[str, Any] | None:
     return raw
 
 
-async def _load_partial_user(engine: Any, user_id: int) -> User | None:
+async def _load_partial_user(engine: AsyncEngine, user_id: int) -> User | None:
     async with AsyncSession(engine) as session:
         stmt = select(User).where(User.id == user_id)
         return (await session.execute(stmt)).scalar_one_or_none()

--- a/src/hyperadmin/templates/auth/mfa_challenge.html
+++ b/src/hyperadmin/templates/auth/mfa_challenge.html
@@ -1,0 +1,74 @@
+{%- extends "_base.html" -%}
+
+{%- block title -%}{{ _("MFA Challenge") }} — HyperAdmin{%- endblock -%}
+
+{%- block messages -%}{%- endblock -%}
+{%- block navbar -%}{%- endblock -%}
+{%- block sidebar -%}{%- endblock -%}
+
+{%- block content -%}
+<div class="ha-login-container">
+    <div class="ha-login-card">
+        <h1 id="mfa-title" class="ha-login-title">{{ _("Two-factor verification") }}</h1>
+        <p class="ha-text-muted">
+            {{ _("Enter the 6-digit code we sent to your email.") }}
+        </p>
+
+        <div id="mfa-flash-region" aria-live="polite">
+            {%- if error -%}
+            <div class="ha-alert ha-alert-error" data-testid="mfa-error" role="alert">
+                {{ error }}
+            </div>
+            {%- endif -%}
+            {%- if flash -%}
+            <div class="ha-alert ha-alert-info" data-testid="mfa-flash" role="status">
+                {{ flash }}
+            </div>
+            {%- endif -%}
+        </div>
+
+        <form method="post"
+              action="{{ admin_prefix }}/mfa/verify"
+              data-testid="mfa-verify-form"
+              aria-labelledby="mfa-title">
+            <div class="ha-form-group">
+                <label for="mfa-code" class="ha-label">{{ _("Verification code") }}</label>
+                <input
+                    type="text"
+                    id="mfa-code"
+                    name="code"
+                    class="ha-input"
+                    data-testid="mfa-code-input"
+                    inputmode="numeric"
+                    pattern="[0-9]{6}"
+                    maxlength="6"
+                    autocomplete="one-time-code"
+                    required
+                    autofocus
+                >
+            </div>
+            <button type="submit"
+                    class="ha-btn ha-btn-primary ha-btn-block"
+                    data-testid="mfa-verify-btn">
+                {{ _("Verify") }}
+            </button>
+        </form>
+
+        <p class="ha-text-muted ha-mt-2">
+            {%- if expired -%}
+            {{ _("Your code has expired.") }}
+            {%- endif -%}
+            <button
+                type="button"
+                class="ha-btn-link"
+                data-testid="mfa-resend-link"
+                hx-post="{{ admin_prefix }}/mfa/resend"
+                hx-target="#mfa-flash-region"
+                hx-select="#mfa-flash-region"
+                hx-swap="outerHTML">
+                {{ _("Resend code") }}
+            </button>
+        </p>
+    </div>
+</div>
+{%- endblock -%}

--- a/tests/unit/test_mfa_challenge_view.py
+++ b/tests/unit/test_mfa_challenge_view.py
@@ -1,0 +1,402 @@
+"""Unit tests for MFA challenge / verify / resend views (C2-D, #486).
+
+Maps the 4 BDD scenarios from
+.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-create-mfa-challenge-view-and-template.md
+to tests, plus edge cases enumerated in
+docs/specs/object-permissions-mfa.md (Edge Cases & Error Handling).
+
+C2-D adds three NEW endpoints; the C3-A wiring of `login_view` and the
+partial-auth middleware gate is intentionally out of scope here. These
+tests therefore prime ``request.session[PARTIAL_AUTH_SESSION_KEY]`` by
+hand to simulate the post-password / pre-MFA state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.templating import Jinja2Templates
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import SQLModel
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.responses import Response
+
+from hyperadmin.auth.backend import hash_password
+from hyperadmin.auth.models import User
+from hyperadmin.auth.otp import (
+    OTP_SESSION_KEY,
+    PARTIAL_AUTH_SESSION_KEY,
+    EmailOTPService,
+    RateLimitError,
+)
+
+
+@pytest.fixture
+async def async_engine(tmp_path):
+    db_file = tmp_path / "test_mfa_challenge.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_file}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+@pytest.fixture
+async def alice(async_engine) -> User:
+    async with AsyncSession(async_engine) as session:
+        user = User(
+            username="alice",
+            email="alice@example.com",
+            password_hash=hash_password("secret"),
+            mfa_enabled=True,
+            mfa_method="email",
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+class _CapturingSender:
+    """Test double for the EmailOTPService email_sender callable."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.raise_on_send: BaseException | None = None
+
+    async def __call__(self, email: str, code: str) -> None:
+        if self.raise_on_send is not None:
+            raise self.raise_on_send
+        self.calls.append((email, code))
+
+
+def _build_app(async_engine, otp_service: Any | None = None, sender: Any | None = None):
+    """Build a minimal FastAPI app exposing the MFA endpoints.
+
+    The app intentionally does NOT wire ``login_view`` to populate a
+    partial-auth session — that is C3-A's job. Tests prime the session
+    by hand via the ``/_test/seed-partial-auth`` helper route below.
+    """
+    from hyperadmin.auth.session import SessionAuthBackend
+    from hyperadmin.auth.views import (
+        mfa_challenge_view,
+        mfa_resend_view,
+        mfa_verify_view,
+    )
+    from hyperadmin.core.app import Admin
+    from hyperadmin.core.registry import site
+    from hyperadmin.core.settings import HyperAdminSettings
+
+    site._registry.clear()
+
+    app = FastAPI()
+    backend = SessionAuthBackend(engine=async_engine)
+    Admin(
+        app,
+        engine=async_engine,
+        settings=HyperAdminSettings(create_tables=False, secret_key="test-secret"),
+        auth_backend=backend,
+    )
+
+    if otp_service is None:
+        otp_service = EmailOTPService(email_sender=sender or _CapturingSender())
+
+    # C3-A will wire these into core/app.py::_register_auth_routes; for
+    # C2-D unit tests we wire them directly so we can exercise the views
+    # in isolation. The session middleware is added BELOW the routes so
+    # cookies are actually written.
+    import os as _os
+
+    template_dir = _os.path.join(
+        _os.path.dirname(_os.path.dirname(_os.path.dirname(_os.path.abspath(__file__)))),
+        "src",
+        "hyperadmin",
+        "templates",
+    )
+    templates = Jinja2Templates(directory=template_dir)
+    from hyperadmin.i18n import install_jinja_i18n
+
+    install_jinja_i18n(templates.env)
+    templates.env.globals["admin_prefix"] = "/admin"
+    templates.env.globals["auth_enabled"] = True
+    templates.env.globals["theme"] = "default"
+    templates.env.globals["site_title"] = "HyperAdmin"
+    templates.env.globals["site_header"] = "HyperAdmin"
+    templates.env.globals["supported_locales"] = ["en"]
+    templates.env.globals["rtl_locales"] = []
+
+    async def _challenge_get(request: Request):
+        return await mfa_challenge_view(request, templates, "/admin")
+
+    async def _verify_post(request: Request):
+        return await mfa_verify_view(request, templates, backend, otp_service, "/admin")
+
+    async def _resend_post(request: Request):
+        return await mfa_resend_view(request, templates, backend, otp_service, "/admin")
+
+    async def _seed(request: Request):
+        # Test-only helper: simulates what C3-A's modified login_view will
+        # do after a correct password for an MFA-enabled user.
+        form = await request.form()
+        request.session[PARTIAL_AUTH_SESSION_KEY] = {
+            "stage": "mfa_pending",
+            "user_id": int(form["user_id"]),
+        }
+        return Response(status_code=204)
+
+    async def _seed_otp_route(request: Request):
+        # Test-only helper: writes an OTP entry directly to the session
+        # so we can drive verify() with known codes / known issued_at.
+        form = await request.form()
+        request.session[OTP_SESSION_KEY] = {
+            "code_hash": hash_password(str(form["code"])),
+            "issued_at": str(form["issued_at"]),
+            "attempts": 0,
+            "user_id": int(form["user_id"]),
+        }
+        return Response(status_code=204)
+
+    app.add_api_route("/admin/mfa/challenge", _challenge_get, methods=["GET"])
+    app.add_api_route("/admin/mfa/verify", _verify_post, methods=["POST"])
+    app.add_api_route("/admin/mfa/resend", _resend_post, methods=["POST"])
+    app.add_api_route("/_test/seed-partial-auth", _seed, methods=["POST"])
+    app.add_api_route("/_test/seed-otp", _seed_otp_route, methods=["POST"])
+
+    app.add_middleware(SessionMiddleware, secret_key="test-secret")
+    return app
+
+
+async def _seed_partial(client: AsyncClient, user_id: int) -> None:
+    resp = await client.post("/_test/seed-partial-auth", data={"user_id": user_id})
+    assert resp.status_code == 204
+
+
+async def _seed_otp(client: AsyncClient, user_id: int, code: str, issued_at: str) -> None:
+    resp = await client.post(
+        "/_test/seed-otp",
+        data={"user_id": user_id, "code": code, "issued_at": issued_at},
+    )
+    assert resp.status_code == 204
+
+
+# --- Scenario 1: GET /admin/mfa/challenge renders the form ----------------
+
+
+class TestChallengePage:
+    @pytest.mark.anyio
+    async def test_challenge_page_renders_with_code_input_and_verify_button(
+        self, async_engine, alice
+    ) -> None:
+        """
+        Scenario: MFA challenge page renders with code input
+          Given user "alice" passed password authentication and has mfa_enabled=True
+          When  GET /admin/mfa/challenge
+          Then  page renders a form with a 6-digit code input and "Verify" button
+        """
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Given alice has a partial-auth session
+            await _seed_partial(client, alice.id)
+
+            # When she GETs the challenge page
+            resp = await client.get("/admin/mfa/challenge")
+
+            # Then the page renders with the code input + verify button
+            assert resp.status_code == 200
+            body = resp.text
+            assert 'data-testid="mfa-code-input"' in body
+            assert 'data-testid="mfa-verify-btn"' in body
+            assert 'data-testid="mfa-resend-link"' in body
+
+    @pytest.mark.anyio
+    async def test_challenge_page_without_partial_auth_redirects_to_login(
+        self, async_engine
+    ) -> None:
+        """Edge case: GET /admin/mfa/challenge with NO partial-auth session
+        must redirect to /admin/login — there is no user to challenge.
+        """
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/admin/mfa/challenge", follow_redirects=False)
+            assert resp.status_code == 302
+            assert resp.headers["location"].endswith("/admin/login")
+
+
+# --- Scenario 2: correct OTP code completes login -------------------------
+
+
+class TestVerifyHappyPath:
+    @pytest.mark.anyio
+    async def test_correct_code_upgrades_session_and_redirects(self, async_engine, alice) -> None:
+        """
+        Scenario: correct OTP code completes login
+          Given user "alice" is on MFA challenge page and code "123456" was sent
+          When  POST /admin/mfa/verify with code=123456
+          Then  session is created and redirect to /admin/
+        """
+        from datetime import datetime, timezone
+
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Given alice has a partial-auth session and a pending OTP "123456"
+            await _seed_partial(client, alice.id)
+            await _seed_otp(
+                client,
+                alice.id,
+                "123456",
+                datetime.now(tz=timezone.utc).isoformat(),
+            )
+
+            # When she POSTs the correct code
+            resp = await client.post(
+                "/admin/mfa/verify",
+                data={"code": "123456"},
+                follow_redirects=False,
+            )
+
+            # Then the session is upgraded and she is redirected to /admin/
+            assert resp.status_code == 302
+            assert resp.headers["location"].endswith("/admin/")
+
+            # And the partial-auth marker is gone (full session takes over)
+            resp2 = await client.get("/admin/mfa/challenge", follow_redirects=False)
+            assert resp2.status_code == 302
+            assert resp2.headers["location"].endswith("/admin/login")
+
+
+# --- Scenario 3: wrong OTP code shows error -------------------------------
+
+
+class TestVerifyWrongCode:
+    @pytest.mark.anyio
+    async def test_wrong_code_shows_invalid_error_and_keeps_partial_session(
+        self, async_engine, alice
+    ) -> None:
+        """
+        Scenario: wrong OTP code shows error
+          Given user "alice" is on MFA challenge page
+          When  POST /admin/mfa/verify with code=999999
+          Then  error "Invalid code" is shown and user stays on challenge page
+        """
+        from datetime import datetime, timezone
+
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await _seed_partial(client, alice.id)
+            await _seed_otp(
+                client,
+                alice.id,
+                "123456",
+                datetime.now(tz=timezone.utc).isoformat(),
+            )
+
+            resp = await client.post(
+                "/admin/mfa/verify",
+                data={"code": "999999"},
+                follow_redirects=False,
+            )
+
+            assert resp.status_code == 200
+            assert "Invalid code" in resp.text
+            assert 'data-testid="mfa-code-input"' in resp.text
+
+            # Partial session still active
+            challenge = await client.get("/admin/mfa/challenge", follow_redirects=False)
+            assert challenge.status_code == 200
+
+
+# --- Scenario 4: expired OTP code shows error with resend ----------------
+
+
+class TestVerifyExpiredCode:
+    @pytest.mark.anyio
+    async def test_expired_code_shows_error_with_resend_link(self, async_engine, alice) -> None:
+        """
+        Scenario: expired OTP code shows error with resend option
+          Given user "alice" has an OTP code that expired
+          When  POST /admin/mfa/verify with the expired code
+          Then  error "Code expired, please request a new one" is shown
+          And   a "Resend code" link is available
+        """
+        from datetime import datetime, timedelta, timezone
+
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await _seed_partial(client, alice.id)
+            stale = (datetime.now(tz=timezone.utc) - timedelta(seconds=3600)).isoformat()
+            await _seed_otp(client, alice.id, "123456", stale)
+
+            resp = await client.post(
+                "/admin/mfa/verify",
+                data={"code": "123456"},
+                follow_redirects=False,
+            )
+
+            assert resp.status_code == 200
+            # Either "Code expired" or "Invalid or expired code" — the
+            # template surfaces an explicit expired message when the
+            # service returned False AND no fresh entry remains.
+            assert "expired" in resp.text.lower()
+            assert 'data-testid="mfa-resend-link"' in resp.text
+
+
+# --- Edge: resend triggers EmailOTPService.generate_and_send -------------
+
+
+class TestResend:
+    @pytest.mark.anyio
+    async def test_resend_calls_generate_and_send(self, async_engine, alice) -> None:
+        """Edge: POST /admin/mfa/resend triggers EmailOTPService.generate_and_send."""
+        sender = _CapturingSender()
+        service = EmailOTPService(email_sender=sender)
+        app = _build_app(async_engine, otp_service=service)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await _seed_partial(client, alice.id)
+
+            resp = await client.post("/admin/mfa/resend")
+
+            # The view re-renders the challenge page (200) with a flash
+            # confirming the new code was sent.
+            assert resp.status_code == 200
+            assert len(sender.calls) == 1
+            assert sender.calls[0][0] == "alice@example.com"
+
+    @pytest.mark.anyio
+    async def test_resend_when_rate_limited_renders_flash(self, async_engine, alice) -> None:
+        """Edge: rate-limit hit surfaces flash, does not crash."""
+
+        class _AlwaysRateLimited:
+            async def generate_and_send(self, user: User, session: dict) -> None:
+                raise RateLimitError("too many")
+
+            async def verify(
+                self, user: User, code: str, session: dict
+            ) -> bool:  # pragma: no cover - not used in this test
+                return False
+
+        app = _build_app(async_engine, otp_service=_AlwaysRateLimited())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await _seed_partial(client, alice.id)
+            resp = await client.post("/admin/mfa/resend")
+            assert resp.status_code == 200
+            assert "too many attempts" in resp.text.lower()
+
+    @pytest.mark.anyio
+    async def test_resend_without_partial_auth_redirects_to_login(self, async_engine) -> None:
+        """Edge: anonymous resend → redirect to login (no session to refresh)."""
+        app = _build_app(async_engine)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/admin/mfa/resend", follow_redirects=False)
+            assert resp.status_code == 302
+            assert resp.headers["location"].endswith("/admin/login")

--- a/tests/unit/test_mfa_challenge_view.py
+++ b/tests/unit/test_mfa_challenge_view.py
@@ -219,10 +219,13 @@ class TestChallengePage:
         """Edge case: GET /admin/mfa/challenge with NO partial-auth session
         must redirect to /admin/login — there is no user to challenge.
         """
+        # Given a fresh client with no session cookie at all
         app = _build_app(async_engine)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # When GET /admin/mfa/challenge
             resp = await client.get("/admin/mfa/challenge", follow_redirects=False)
+            # Then the response is a 302 to /admin/login
             assert resp.status_code == 302
             assert resp.headers["location"].endswith("/admin/login")
 
@@ -289,6 +292,7 @@ class TestVerifyWrongCode:
         app = _build_app(async_engine)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Given alice has a partial-auth session and a fresh OTP "123456" pending
             await _seed_partial(client, alice.id)
             await _seed_otp(
                 client,
@@ -297,17 +301,19 @@ class TestVerifyWrongCode:
                 datetime.now(tz=timezone.utc).isoformat(),
             )
 
+            # When POST /admin/mfa/verify with the wrong code 999999
             resp = await client.post(
                 "/admin/mfa/verify",
                 data={"code": "999999"},
                 follow_redirects=False,
             )
 
+            # Then the page re-renders 200 with the "Invalid code" error
             assert resp.status_code == 200
             assert "Invalid code" in resp.text
             assert 'data-testid="mfa-code-input"' in resp.text
 
-            # Partial session still active
+            # And the partial-auth session is preserved
             challenge = await client.get("/admin/mfa/challenge", follow_redirects=False)
             assert challenge.status_code == 200
 
@@ -330,21 +336,25 @@ class TestVerifyExpiredCode:
         app = _build_app(async_engine)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Given alice has a partial-auth session and an OTP issued 1 hour ago (TTL=300s)
             await _seed_partial(client, alice.id)
             stale = (datetime.now(tz=timezone.utc) - timedelta(seconds=3600)).isoformat()
             await _seed_otp(client, alice.id, "123456", stale)
 
+            # When POST /admin/mfa/verify with the (now-expired) code
             resp = await client.post(
                 "/admin/mfa/verify",
                 data={"code": "123456"},
                 follow_redirects=False,
             )
 
+            # Then 200 with an "expired" message
             assert resp.status_code == 200
             # Either "Code expired" or "Invalid or expired code" — the
             # template surfaces an explicit expired message when the
             # service returned False AND no fresh entry remains.
             assert "expired" in resp.text.lower()
+            # And a resend-code affordance is visible so the user can recover
             assert 'data-testid="mfa-resend-link"' in resp.text
 
 
@@ -355,6 +365,7 @@ class TestResend:
     @pytest.mark.anyio
     async def test_resend_calls_generate_and_send(self, async_engine, alice) -> None:
         """Edge: POST /admin/mfa/resend triggers EmailOTPService.generate_and_send."""
+        # Given a partial-auth session and a capturing email sender wired into the service
         sender = _CapturingSender()
         service = EmailOTPService(email_sender=sender)
         app = _build_app(async_engine, otp_service=service)
@@ -362,10 +373,11 @@ class TestResend:
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             await _seed_partial(client, alice.id)
 
+            # When POST /admin/mfa/resend
             resp = await client.post("/admin/mfa/resend")
 
-            # The view re-renders the challenge page (200) with a flash
-            # confirming the new code was sent.
+            # Then the view re-renders the challenge page (200) and the
+            # email sender was invoked exactly once for alice's address
             assert resp.status_code == 200
             assert len(sender.calls) == 1
             assert sender.calls[0][0] == "alice@example.com"
@@ -383,20 +395,26 @@ class TestResend:
             ) -> bool:  # pragma: no cover - not used in this test
                 return False
 
+        # Given an OTP service that always raises RateLimitError on send
         app = _build_app(async_engine, otp_service=_AlwaysRateLimited())
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
             await _seed_partial(client, alice.id)
+            # When POST /admin/mfa/resend
             resp = await client.post("/admin/mfa/resend")
+            # Then 200 with a "too many attempts" flash (no 500)
             assert resp.status_code == 200
             assert "too many attempts" in resp.text.lower()
 
     @pytest.mark.anyio
     async def test_resend_without_partial_auth_redirects_to_login(self, async_engine) -> None:
         """Edge: anonymous resend → redirect to login (no session to refresh)."""
+        # Given a fresh anonymous client
         app = _build_app(async_engine)
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # When POST /admin/mfa/resend with no partial-auth cookie
             resp = await client.post("/admin/mfa/resend", follow_redirects=False)
+            # Then 302 to /admin/login
             assert resp.status_code == 302
             assert resp.headers["location"].endswith("/admin/login")


### PR DESCRIPTION
## Summary

- Adds three new auth endpoints — `GET /admin/mfa/challenge`, `POST /admin/mfa/verify`, `POST /admin/mfa/resend` — that consume the partial-auth marker written under `PARTIAL_AUTH_SESSION_KEY` (C1-D contract).
- Adds `src/hyperadmin/templates/auth/mfa_challenge.html` with the required `data-testid` hooks (`mfa-code-input`, `mfa-verify-btn`, `mfa-resend-link`) and an HTMX-driven resend link that swaps only the flash region.
- On successful verify, the partial-auth marker is **cleared first** and the full session is granted **second** so any cookie/race window cannot escalate a partial-auth cookie into full auth.
- Out of scope (C3-A): wiring `login_view` to write the partial marker, and the middleware gate that funnels partial-auth users to `/admin/mfa/challenge`. This PR is the consumer side.

Closes #486

**Spec**: [`docs/specs/object-permissions-mfa.md`](../blob/develop/docs/specs/object-permissions-mfa.md) — Track B, "API / Protocol Changes → MFA endpoints" + "Edge Cases".

## BDD Scenarios

- [x] **MFA challenge page renders with code input** — GET `/admin/mfa/challenge` (with partial-auth) renders form with 6-digit input + verify button.
- [x] **Correct OTP code completes login** — POST `/admin/mfa/verify` with correct code clears partial marker, calls `auth_backend.login`, and 302s to `/admin/`.
- [x] **Wrong OTP code shows error** — POST with wrong code re-renders the challenge with "Invalid code." and the partial session stays put.
- [x] **Expired OTP code shows error with resend option** — POST with stale code renders "Code expired, please request a new one." and the resend link is visible.

## Edge cases covered

- [x] GET `/admin/mfa/challenge` with **no** partial-auth session → 302 to `/admin/login`.
- [x] POST `/admin/mfa/resend` triggers `EmailOTPService.generate_and_send` exactly once; the captured email matches the partial-auth user.
- [x] POST `/admin/mfa/resend` when rate-limited → renders flash "Too many attempts, try again later." (does not crash).
- [x] POST `/admin/mfa/resend` without partial-auth → 302 to `/admin/login`.

## Test plan

- [x] `poe lint` — clean (ruff + mypy + basedpyright + commitizen).
- [x] `poe test:unit` — 658 passed (8 new tests in `tests/unit/test_mfa_challenge_view.py`, all green).
- [ ] Pre-push hook will run the full E2E suite — develop has refreshed visual baselines so it should be clean.

## Manual test scenarios

The C3-A wiring isn't merged yet, so manually exercising the flow needs a hand-primed partial-auth session. Spin up a dev server and run this snippet in a Python REPL connected to the same SQLite DB to seed Alice with MFA enabled:

```python
import asyncio
from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
from hyperadmin.auth.backend import hash_password
from hyperadmin.auth.models import User

async def seed():
    engine = create_async_engine("sqlite+aiosqlite:///dev.db")
    async with AsyncSession(engine) as s:
        s.add(User(
            username="alice", email="alice@example.com",
            password_hash=hash_password("secret"),
            mfa_enabled=True, mfa_method="email",
        ))
        await s.commit()

asyncio.run(seed())
```

Then in the browser DevTools console (after visiting `/admin/login` once to get a session cookie), prime the partial-auth marker by hand. The simplest way is to add a temporary debug route to your test app:

```python
@app.post("/_dev/seed-partial-auth")
async def _seed(request):
    request.session["auth_state"] = {"stage": "mfa_pending", "user_id": 1}
    return {"ok": True}
```

Then walk through:

1. `POST /_dev/seed-partial-auth` to install the partial marker.
2. `GET /admin/mfa/challenge` — verify the form renders, showing the 6-digit input and a "Resend code" button.
3. `POST /admin/mfa/resend` — confirm a new email is sent (or stub the sender to print to stdout).
4. Submit the wrong code — expect `200` with "Invalid code." and the form still shown.
5. Submit the correct code — expect `302` to `/admin/`, the partial marker cleared, the full session cookie set.
6. Wait past the configured TTL (default 300s) and submit any code — expect "Code expired, please request a new one." and the resend link visible.
7. Hammer resend three times within the rate-limit window (default 3/600s) and trigger a fourth — expect the "Too many attempts, try again later." flash; no crash.

## Files changed

- `src/hyperadmin/auth/views.py` — +3 endpoints, +3 helpers (`_read_partial_auth`, `_load_partial_user`, `_entry_is_expired`).
- `src/hyperadmin/templates/auth/mfa_challenge.html` — new.
- `tests/unit/test_mfa_challenge_view.py` — 8 tests (4 BDD + 4 edges).

Part of v0.5.1 Cycle 2 — Wiring.

Note: C3-A will land the actual wiring of `login_view` to write the partial-auth marker, plus the middleware gate. This PR is the consumer side.