### PR TITLE
feat(core): get_queryset hook on ModelAdmin (C2-B, #479)

### DIFF
--- a/src/hyperadmin/core/model.py
+++ b/src/hyperadmin/core/model.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 
 if TYPE_CHECKING:
     import babel.support
+    from starlette.requests import Request
 
 
 class HyperAdminModel(BaseModel, abc.ABC):
@@ -115,6 +116,30 @@ class ModelAdmin:
 
     def __init__(self, model: Any) -> None:
         self.model = model
+
+    def get_queryset(self, request: "Request | None" = None) -> dict[str, Any]:
+        """Return additional equality filters merged into list/detail queries.
+
+        Override in a subclass to implement row-level scoping at the
+        ``ModelAdmin`` level (e.g. ``return {"owner_id": request.state.user.id}``).
+        The returned mapping has the shape ``{column_name: value}`` and is merged
+        into the same ``WHERE`` clause as
+        :meth:`hyperadmin.core.adapters.BaseAdapter.get_queryset` by the view layer
+        (see C2-C: ``views/dynamic.py``).
+
+        Default behaviour returns an empty dict, which is a no-op (backward
+        compatible).
+
+        Args:
+            request: The active Starlette/FastAPI request, when available.
+                ``None`` is permitted so the hook is callable from contexts
+                without an HTTP request (e.g. management scripts, tests).
+
+        Returns:
+            A dict of column-name to value pairs to be ANDed into the query's
+            ``WHERE`` clause. Returns ``{}`` by default.
+        """
+        return {}
 
     @classmethod
     def get_verbose_name(cls, model: Any) -> VerboseNameType:

--- a/tests/unit/test_modeladmin_get_queryset.py
+++ b/tests/unit/test_modeladmin_get_queryset.py
@@ -1,0 +1,71 @@
+"""Unit tests for the ``ModelAdmin.get_queryset`` hook (BDD scenarios from issue #479).
+
+Each test maps 1:1 to a scenario in
+``.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featcore-add-getqueryset-hook-to-modeladmin-base.md``.
+
+The hook mirrors :meth:`hyperadmin.core.adapters.BaseAdapter.get_queryset` semantics:
+synchronous, accepts an optional ``Request`` and returns a dict of equality filters that
+will be merged into list/detail queries by C2-C view-layer wiring.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hyperadmin.core.model import ModelAdmin
+
+
+class _DummyModel:
+    """Lightweight stand-in for an ORM model class used in ``ModelAdmin`` tests."""
+
+    __name__ = "Dummy"
+
+
+def test_default_get_queryset_returns_empty_dict() -> None:
+    """
+    Scenario: default get_queryset returns no filters
+      Given a model with default ModelAdmin
+      When  ``get_queryset(request)`` is called
+      Then  result is ``{}``
+    """
+    # Given a default ModelAdmin instance bound to a model
+    admin = ModelAdmin(model=_DummyModel)
+
+    # When get_queryset is called (with and without an explicit request)
+    result_default = admin.get_queryset()
+    result_with_none = admin.get_queryset(request=None)
+
+    # Then both return an empty dict (no filtering — backward compatible)
+    assert result_default == {}
+    assert result_with_none == {}
+
+
+def test_subclass_override_get_queryset_returns_override_value() -> None:
+    """
+    Scenario: custom get_queryset filters by user
+      Given a ModelAdmin overriding ``get_queryset`` to return owner-scoped filters
+      When  the request carries a user with id=5
+      Then  ``get_queryset`` returns ``{"owner_id": 5}``
+    """
+
+    class _FakeUser:
+        id = 5
+
+    class _FakeState:
+        user = _FakeUser()
+
+    class _FakeRequest:
+        state = _FakeState()
+
+    class OwnerScopedAdmin(ModelAdmin):
+        def get_queryset(self, request: Any | None = None) -> dict[str, Any]:
+            return {"owner_id": request.state.user.id}
+
+    # Given a subclass overriding get_queryset
+    admin = OwnerScopedAdmin(model=_DummyModel)
+
+    # When get_queryset is called with a request whose state carries a user id
+    filters = admin.get_queryset(_FakeRequest())
+
+    # Then the override's value is returned verbatim
+    assert filters == {"owner_id": 5}


### PR DESCRIPTION
## Summary

Adds a synchronous `get_queryset(request)` hook to `ModelAdmin` mirroring the `BaseAdapter` hook landed in C1-B (PR for #478). Default returns `{}` — fully backward compatible. Subclasses may override to scope visible rows by request/user state.

Closes #479

**Spec**: [docs/specs/object-permissions-mfa.md](../blob/develop/docs/specs/object-permissions-mfa.md) (Track A — "API / Protocol Changes → New adapter hook" and how `ModelAdmin` mirrors it)

## BDD checklist

- [x] **Scenario: default get_queryset returns no filters** — `ModelAdmin().get_queryset()` returns `{}`
- [x] **Scenario: custom get_queryset filters by user** — subclass override returns `{"owner_id": request.state.user.id}` verbatim

## Test plan

- [x] `tests/unit/test_modeladmin_get_queryset.py` — 2 unit tests (one per scenario), both passing
- [x] `poe lint` (ruff, mypy, basedpyright, commitizen) — green
- [x] `poe test:unit` — 652 passed, 88.1% coverage
- [x] No view-layer code touched (`views/dynamic.py` untouched — that wiring is C2-C's job)
- [x] No view-layer wiring; signature mirrors `BaseAdapter.get_queryset` (sync, optional `Request`, returns `dict[str, Any]`)

## Scope

Only two files changed:
- `src/hyperadmin/core/model.py` — adds the hook on `ModelAdmin`
- `tests/unit/test_modeladmin_get_queryset.py` — 2 BDD-mapped unit tests

No changes to `views/`, `core/options.py`, `core/adapters.py`, or `core/registry.py`.

Part of v0.5.1 Cycle 2 — Wiring.

> View-layer composition lives in C2-C (the bundled #480 + #481 PR on `views/dynamic.py`), which will compose `ModelAdmin.get_queryset(request)` with the adapter's `get_queryset(request)` filters when wiring list/detail views.