### PR TITLE
chore(meta): correct C2-B story file paths

### DIFF
--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featcore-add-getqueryset-hook-to-modeladmin-base.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featcore-add-getqueryset-hook-to-modeladmin-base.md
@@ -28,7 +28,8 @@ Add an optional `get_queryset(request)` method to the ModelAdmin base class so u
 
 ## Files to Change
 
-- `src/hyperadmin/core/options.py` — add `get_queryset` as optional callable on AdminOptions or ModelAdmin
+- `src/hyperadmin/core/model.py` — add `ModelAdmin.get_queryset(request)` hook (sync, mirrors `BaseAdapter.get_queryset` per SDD §"API / Protocol Changes → New adapter hook")
+- `tests/unit/test_modeladmin_get_queryset.py` — new
 
 ## Design
 


### PR DESCRIPTION
Tiny meta-only fix flagged by the C2-B review (#542). The story file said the hook would land in `core/options.py` but the SDD architecture diagram (and the implementation in PR #542) put it on `ModelAdmin` in `core/model.py`. Updated `Files to Change` accordingly.

1 line edit. No source changes.