### PR TITLE
feat(views): row-level security + object permission checks (C2-C, #480, #481)

### DIFF
--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 import re
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Union, cast, get_args, get_origin
 
 from fastapi import HTTPException, Query, Request
@@ -130,6 +131,36 @@ class DynamicModelView:
         if not await self.permission_checker.has_permission(user, codename):
             raise HTTPException(status_code=403, detail="Permission denied")
 
+    @contextmanager
+    def _request_queryset_filter(self, request: Request):
+        """Register the per-request queryset filter on the adapter for the duration of a view.
+
+        Composes :meth:`hyperadmin.core.model.ModelAdmin.get_queryset` (when an admin
+        instance is wired) into the adapter's ``set_queryset_filter`` seam so that
+        ``adapter.list()`` and ``adapter.get()`` apply ModelAdmin-defined row-level
+        filters before any view-layer filters.
+
+        The previous filter (if any) is restored on exit so that a long-lived adapter
+        cannot leak filters across requests.
+        """
+        admin_instance = self._admin_instance
+        previous_filter = getattr(self.adapter, "_queryset_filter", None)
+
+        def _filter_for_request(req: Request | None) -> dict[str, Any]:
+            if admin_instance is None:
+                return {}
+            get_queryset = getattr(admin_instance, "get_queryset", None)
+            if get_queryset is None:
+                return {}
+            result = get_queryset(req if req is not None else request)
+            return result if isinstance(result, dict) else {}
+
+        self.adapter.set_queryset_filter(_filter_for_request)
+        try:
+            yield
+        finally:
+            self.adapter._queryset_filter = previous_filter
+
     def _get_template_name(self, view_name: str) -> str:
         model_name = self.model.__name__.lower()
 
@@ -214,15 +245,17 @@ class DynamicModelView:
         order_by = f"-{sort_by}" if sort_direction == "desc" else sort_by
 
         try:
-            # Use adapter's list method
-            items, total_items = await self.adapter.list(
-                page=page,
-                page_size=page_size,
-                search=search or None,
-                filters=filters_to_apply,
-                order_by=order_by,
-                search_fields=self.search_fields,
-            )
+            # Use adapter's list method, scoped to the per-request queryset filter
+            # so that ModelAdmin.get_queryset(request) is merged into the WHERE clause.
+            with self._request_queryset_filter(request):
+                items, total_items = await self.adapter.list(
+                    page=page,
+                    page_size=page_size,
+                    search=search or None,
+                    filters=filters_to_apply,
+                    order_by=order_by,
+                    search_fields=self.search_fields,
+                )
 
             # Calculate pagination info
             total_pages = math.ceil(total_items / page_size) if page_size > 0 else 0
@@ -307,7 +340,8 @@ class DynamicModelView:
         Assumes the model has an 'id' field.
         """
         await self._check_permission(request, "view")
-        item = await self.adapter.get(pk=item_id)
+        with self._request_queryset_filter(request):
+            item = await self.adapter.get(pk=item_id)
 
         if not item:
             raise HTTPException(status_code=404, detail="Item not found")
@@ -643,7 +677,8 @@ class DynamicModelView:
     ):
         """Renders the update form, optionally pre-filled with submitted values and errors."""
         await self._check_permission(request, "change")
-        item = await self.adapter.get(pk=item_id)
+        with self._request_queryset_filter(request):
+            item = await self.adapter.get(pk=item_id)
         if not item:
             raise HTTPException(status_code=404, detail="Item not found")
 
@@ -711,6 +746,10 @@ class DynamicModelView:
     async def update_view(self, request: Request, item_id: int):
         """Handles form submission for updating an item."""
         await self._check_permission(request, "change")
+        with self._request_queryset_filter(request):
+            existing = await self.adapter.get(pk=item_id)
+        if not existing:
+            raise HTTPException(status_code=404, detail="Item not found")
         form_data = await request.form()
 
         relation_widgets = await self._build_relation_widgets(
@@ -1093,7 +1132,8 @@ class DynamicModelView:
     async def delete_action(self, request: Request, item_id: int):
         """Deletes an item."""
         await self._check_permission(request, "delete")
-        item = await self.adapter.get(pk=item_id)
+        with self._request_queryset_filter(request):
+            item = await self.adapter.get(pk=item_id)
         if not item:
             raise HTTPException(status_code=404, detail="Item not found")
 

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -161,6 +161,29 @@ class DynamicModelView:
         finally:
             self.adapter._queryset_filter = previous_filter
 
+    async def _check_object_permission(self, request: Request, obj: Any, action: str) -> None:
+        """Raise 403 if ``obj`` fails the configured object-level permission check.
+
+        Does nothing when ``options.object_permission_checker`` is ``None``
+        (backward compatible — model-level :class:`PermissionChecker` enforcement
+        remains the only authz layer in that case).
+
+        Args:
+            request: The active request — its ``state.user`` is forwarded to the
+                checker.
+            obj: The object the user is attempting to act on.
+            action: One of ``"view"``, ``"add"``, ``"change"``, ``"delete"`` (or a
+                custom codename understood by the checker).
+        """
+        checker = getattr(self.options, "object_permission_checker", None)
+        if checker is None:
+            return
+        user = getattr(request.state, "user", None)
+        if user is None:
+            raise HTTPException(status_code=403, detail="Authentication required")
+        if not await checker.has_object_permission(user, obj, action):
+            raise HTTPException(status_code=403, detail="Permission denied")
+
     def _get_template_name(self, view_name: str) -> str:
         model_name = self.model.__name__.lower()
 
@@ -345,6 +368,8 @@ class DynamicModelView:
 
         if not item:
             raise HTTPException(status_code=404, detail="Item not found")
+
+        await self._check_object_permission(request, item, "view")
 
         file_fields = self._get_file_fields()
         item_data = item.model_dump()
@@ -750,6 +775,7 @@ class DynamicModelView:
             existing = await self.adapter.get(pk=item_id)
         if not existing:
             raise HTTPException(status_code=404, detail="Item not found")
+        await self._check_object_permission(request, existing, "change")
         form_data = await request.form()
 
         relation_widgets = await self._build_relation_widgets(
@@ -1136,6 +1162,8 @@ class DynamicModelView:
             item = await self.adapter.get(pk=item_id)
         if not item:
             raise HTTPException(status_code=404, detail="Item not found")
+
+        await self._check_object_permission(request, item, "delete")
 
         file_paths = self._collect_file_paths(item)
         await self.adapter.delete(pk=item_id)

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -2,6 +2,7 @@ import logging
 import math
 import os
 import re
+from collections.abc import Generator
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Union, cast, get_args, get_origin
 
@@ -132,7 +133,7 @@ class DynamicModelView:
             raise HTTPException(status_code=403, detail="Permission denied")
 
     @contextmanager
-    def _request_queryset_filter(self, request: Request):
+    def _request_queryset_filter(self, request: Request) -> Generator[None, None, None]:
         """Register the per-request queryset filter on the adapter for the duration of a view.
 
         Composes :meth:`hyperadmin.core.model.ModelAdmin.get_queryset` (when an admin

--- a/tests/unit/test_views_get_queryset_wiring.py
+++ b/tests/unit/test_views_get_queryset_wiring.py
@@ -1,0 +1,161 @@
+"""View-layer wiring of ``ModelAdmin.get_queryset`` (C2-C, #480).
+
+Each test maps 1:1 to a BDD scenario from
+``.meta/epics/.../stories/featviews-wire-getqueryset-into-listview-detailview.md``.
+
+These exercise ``DynamicModelView`` end-to-end against a real SQLite engine via
+FastAPI's ``TestClient`` so that the adapter ↔ view wiring (C1-B + C2-B + C2-C) is
+covered as a stack — the C1-B/C2-B hooks were proven in isolation already; here we
+prove the view layer activates them per request.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import anyio
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
+from hyperadmin.main import Admin
+
+
+class OrderRLS(SQLModel, table=True):
+    """Test model with ``owner_id`` for row-level security scenarios."""
+
+    __tablename__ = "test_order_rls_qs"
+
+    id: int | None = Field(default=None, primary_key=True)
+    title: str
+    owner_id: int = Field(default=0, index=True)
+
+
+# Module-level mutable used by ModelAdmins to simulate a per-request user.
+# Tests reset this between cases via the autouse ``cleanup_registry`` fixture.
+_active_user_id: dict[str, int | None] = {"value": None}
+
+
+@pytest.fixture(autouse=True)
+def cleanup_registry():
+    """Wipe the global model registry and active-user shim between tests."""
+    site._registry = {}
+    _active_user_id["value"] = None
+    yield
+    site._registry = {}
+    _active_user_id["value"] = None
+
+
+def _seed_orders(engine: Any) -> None:
+    """Populate the test DB with three orders owned by users 1 and 2."""
+
+    async def _setup() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+        from sqlalchemy.orm import sessionmaker
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            session.add(OrderRLS(id=1, title="bob-order-1", owner_id=1))
+            session.add(OrderRLS(id=2, title="bob-order-2", owner_id=1))
+            session.add(OrderRLS(id=3, title="alice-order-1", owner_id=2))
+            await session.commit()
+
+    anyio.run(_setup)
+
+
+def _build_app(admin_class: type[ModelAdmin]) -> TestClient:
+    app = FastAPI()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    _seed_orders(engine)
+
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
+    site.register(OrderRLS, admin_class)
+    admin.mount(path="/admin")
+    return TestClient(app)
+
+
+class _OwnerScopedAdmin(ModelAdmin):
+    """ModelAdmin that scopes queries to ``_active_user_id`` to simulate RLS."""
+
+    adapter_class = SQLModelAdapter
+
+    def get_queryset(self, request: Request | None = None) -> dict[str, Any]:
+        uid = _active_user_id["value"]
+        if uid is None:
+            return {}
+        return {"owner_id": uid}
+
+
+class _DefaultAdmin(ModelAdmin):
+    """ModelAdmin with the default no-op ``get_queryset`` (returns ``{}``)."""
+
+    adapter_class = SQLModelAdapter
+
+
+def test_list_view_filters_rows_excluded_by_get_queryset() -> None:
+    """
+    Scenario: list_view only shows records matching get_queryset filter
+      Given user "bob" (id=1) owns orders [1, 2] and "alice" (id=2) owns [3]
+      And   ModelAdmin.get_queryset returns {"owner_id": active_user.id}
+      When  bob visits GET /admin/orderrls
+      Then  only orders [1, 2] are listed (alice's order #3 is excluded)
+    """
+    # Given
+    client = _build_app(_OwnerScopedAdmin)
+    _active_user_id["value"] = 1
+
+    # When
+    response = client.get("/admin/orderrls")
+
+    # Then
+    assert response.status_code == 200
+    assert "bob-order-1" in response.text
+    assert "bob-order-2" in response.text
+    assert "alice-order-1" not in response.text
+
+
+def test_detail_view_returns_404_when_row_excluded_by_get_queryset() -> None:
+    """
+    Scenario: detail_view returns 404 for filtered-out record
+      Given alice's order #3 is excluded by bob's get_queryset filter
+      When  bob visits GET /admin/orderrls/3
+      Then  the response is 404 Not Found
+    """
+    # Given
+    client = _build_app(_OwnerScopedAdmin)
+    _active_user_id["value"] = 1  # bob
+
+    # When
+    response = client.get("/admin/orderrls/3")
+
+    # Then
+    assert response.status_code == 404
+
+
+def test_default_get_queryset_is_a_noop() -> None:
+    """
+    Scenario: default get_queryset returns no filters (backward compatible)
+      Given a ModelAdmin with the default ``get_queryset`` returning {}
+      When  GET /admin/orderrls
+      Then  all three rows are visible
+    """
+    # Given
+    client = _build_app(_DefaultAdmin)
+
+    # When
+    response = client.get("/admin/orderrls")
+
+    # Then
+    assert response.status_code == 200
+    assert "bob-order-1" in response.text
+    assert "bob-order-2" in response.text
+    assert "alice-order-1" in response.text

--- a/tests/unit/test_views_object_permissions.py
+++ b/tests/unit/test_views_object_permissions.py
@@ -205,3 +205,33 @@ def test_superuser_bypass_when_checker_allows_superusers() -> None:
     # Then
     assert response.status_code == 200
     assert "bob-order-1" in response.text
+
+
+def test_detail_view_returns_403_when_user_not_authenticated() -> None:
+    """
+    Scenario: missing request.state.user under an active checker yields 403
+      Given an ObjectPermissionChecker is configured but request.state.user is None
+      When  GET /admin/orderobjectperm/1
+      Then  the response is 403 (the helper refuses to authorize an anonymous request)
+    """
+    # Given a client whose middleware pins request.state.user to None
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _attach_no_user(request: Request, call_next: Any) -> Any:
+        request.state.user = None
+        return await call_next(request)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    _seed_orders(engine)
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
+    options = AdminOptions(object_permission_checker=_ViewOnlyChecker())
+    site.register(OrderObjectPerm, _DefaultAdmin, options=options)
+    admin.mount(path="/admin")
+    client = TestClient(app)
+
+    # When
+    response = client.get("/admin/orderobjectperm/1")
+
+    # Then
+    assert response.status_code == 403

--- a/tests/unit/test_views_object_permissions.py
+++ b/tests/unit/test_views_object_permissions.py
@@ -1,0 +1,207 @@
+"""View-layer object-level permission checks (C2-C, #481).
+
+Each test maps 1:1 to a BDD scenario from
+``.meta/epics/.../stories/featviews-add-object-level-permission-checks-to-detailupdate.md``.
+
+Exercises ``DynamicModelView`` end-to-end against a real SQLite engine and a
+custom-middleware-backed ``request.state.user``, so the helper's wiring through
+``options.object_permission_checker`` is fully covered.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import anyio
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.options import AdminOptions
+from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
+from hyperadmin.main import Admin
+
+
+class OrderObjectPerm(SQLModel, table=True):
+    """Test model used for object-level permission scenarios."""
+
+    __tablename__ = "test_order_object_perm"
+
+    id: int | None = Field(default=None, primary_key=True)
+    title: str
+    owner_id: int = Field(default=0, index=True)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_registry():
+    """Wipe the global model registry between tests."""
+    site._registry = {}
+    yield
+    site._registry = {}
+
+
+def _seed_orders(engine: Any) -> None:
+    async def _setup() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+        from sqlalchemy.orm import sessionmaker
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            session.add(OrderObjectPerm(id=1, title="bob-order-1", owner_id=1))
+            session.add(OrderObjectPerm(id=2, title="alice-order-1", owner_id=2))
+            await session.commit()
+
+    anyio.run(_setup)
+
+
+class _DenyAllChecker:
+    """ObjectPermissionChecker that denies every action."""
+
+    async def has_object_permission(self, user: Any, obj: Any, action: str) -> bool:
+        return False
+
+
+class _ViewOnlyChecker:
+    """Allows view but denies change/delete (object-level)."""
+
+    async def has_object_permission(self, user: Any, obj: Any, action: str) -> bool:
+        return action == "view"
+
+
+class _SuperuserBypassChecker:
+    """Denies non-superusers but lets a flagged ``is_superuser`` user through.
+
+    Models the SDD requirement that the superuser bypass lives in the checker
+    implementation, not in the view-layer helper.
+    """
+
+    async def has_object_permission(self, user: Any, obj: Any, action: str) -> bool:
+        return bool(getattr(user, "is_superuser", False))
+
+
+class _Bob:
+    """Stand-in for a non-superuser ``request.state.user``."""
+
+    is_superuser = False
+
+
+class _Admin:
+    """Stand-in for a superuser ``request.state.user``."""
+
+    is_superuser = True
+
+
+class _DefaultAdmin(ModelAdmin):
+    adapter_class = SQLModelAdapter
+
+
+def _client_with_checker(checker: Any, user: Any | None = None) -> TestClient:
+    """Build a TestClient whose admin uses ``checker`` for object permissions.
+
+    Adds an ASGI middleware that pins ``request.state.user`` to a stand-in
+    object — required by ``_check_object_permission`` to resolve the user.
+    """
+    app = FastAPI()
+    pinned_user = user if user is not None else _Bob()
+
+    @app.middleware("http")
+    async def _attach_user(request: Request, call_next: Any) -> Any:
+        request.state.user = pinned_user
+        return await call_next(request)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    _seed_orders(engine)
+
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
+    options = AdminOptions(object_permission_checker=checker)
+    site.register(OrderObjectPerm, _DefaultAdmin, options=options)
+    admin.mount(path="/admin")
+
+    return TestClient(app)
+
+
+def test_detail_view_returns_403_when_object_permission_denied() -> None:
+    """
+    Scenario: staff user cannot view another user's record when checker denies
+      Given an ObjectPermissionChecker that denies every action
+      When  GET /admin/orderobjectperm/1
+      Then  the response is 403 Forbidden
+    """
+    # Given
+    client = _client_with_checker(_DenyAllChecker())
+
+    # When
+    response = client.get("/admin/orderobjectperm/1")
+
+    # Then
+    assert response.status_code == 403
+
+
+def test_update_view_returns_403_when_change_denied() -> None:
+    """
+    Scenario: object permission check on update
+      Given the checker denies "change" on order #1
+      When  PUT /admin/orderobjectperm/1 with valid data
+      Then  the response is 403 Forbidden
+    """
+    # Given
+    client = _client_with_checker(_ViewOnlyChecker())
+
+    # When
+    response = client.put(
+        "/admin/orderobjectperm/1",
+        data={"title": "renamed", "owner_id": "1"},
+        headers={"HX-Request": "true"},
+        follow_redirects=False,
+    )
+
+    # Then
+    assert response.status_code == 403
+
+
+def test_delete_action_returns_403_when_delete_denied() -> None:
+    """
+    Scenario: object permission check on delete
+      Given the checker denies "delete" on order #1
+      When  DELETE /admin/orderobjectperm/1
+      Then  the response is 403 Forbidden
+    """
+    # Given
+    client = _client_with_checker(_ViewOnlyChecker())
+
+    # When
+    response = client.delete(
+        "/admin/orderobjectperm/1",
+        headers={"HX-Request": "true"},
+        follow_redirects=False,
+    )
+
+    # Then
+    assert response.status_code == 403
+
+
+def test_superuser_bypass_when_checker_allows_superusers() -> None:
+    """
+    Scenario: superuser bypasses object-level checks
+      Given a checker that returns True for users with ``is_superuser=True``
+      And   the request.state.user is a superuser
+      When  GET /admin/orderobjectperm/1
+      Then  the response is 200 OK (the bypass lives in the checker impl)
+    """
+    # Given
+    client = _client_with_checker(_SuperuserBypassChecker(), user=_Admin())
+
+    # When
+    response = client.get("/admin/orderobjectperm/1")
+
+    # Then
+    assert response.status_code == 200
+    assert "bob-order-1" in response.text


### PR DESCRIPTION
## Summary

Last slot of v0.5.1 Cycle 2 — wires object-level authorization into the view layer.
This is a **two-commit bundle** because both stories (#480 + #481) add helpers and
call sites to the same hunks of \`detail_view\` / \`update_view\` / \`delete_action\` in
\`src/hyperadmin/views/dynamic.py\`; parallel dispatch would have hard-conflicted.

- **Commit 1** (\`cda9666\`, #480) — \`_request_queryset_filter\` context manager wires
  \`ModelAdmin.get_queryset(request)\` into the adapter's C1-B \`set_queryset_filter\`
  seam for the duration of \`list_view\`, \`detail_view\`, \`update_form_view\`,
  \`update_view\`, and \`delete_action\`. Previous filter is restored on exit so a
  long-lived adapter cannot leak filters across requests. \`update_view\` and
  \`delete_action\` now also fetch+404 so mutations on filtered-out rows resolve to
  404 (matches the read-side behaviour).
- **Commit 2** (\`f6e3c43\`, #481) — adds \`_check_object_permission(request, obj,
  action)\` and calls it from \`detail_view\` (\`view\`), \`update_view\` (\`change\`),
  and \`delete_action\` (\`delete\`) immediately after fetch, before any rendering or
  mutation. Helper consults \`AdminOptions.object_permission_checker\` (C2-A);
  no-op when unset (backward compatible). Superuser bypass lives in the checker
  implementation per SDD.

Closes #480, #481.

**Spec**: [\`docs/specs/object-permissions-mfa.md\`](../blob/develop/docs/specs/object-permissions-mfa.md)
(Track A — *API / Protocol Changes → New adapter hook* and *View-layer helper*).

## BDD checklist

### #480 — get_queryset wiring (3 / 3)
- [x] Scenario: list_view only shows records matching get_queryset filter
- [x] Scenario: detail_view returns 404 for filtered-out record
- [x] Scenario: empty get_queryset is a no-op (backward compatible)

### #481 — object-level permission checks (4 / 4)
- [x] Scenario: detail returns 403 when checker denies "view"
- [x] Scenario: update returns 403 when checker denies "change"
- [x] Scenario: delete returns 403 when checker denies "delete"
- [x] Scenario: superuser bypasses object-level checks (bypass in checker impl)

## Test plan

- [x] \`uv run pytest tests/unit/test_views_get_queryset_wiring.py\` — 3 passed
- [x] \`uv run pytest tests/unit/test_views_object_permissions.py\` — 4 passed
- [x] \`uv run pytest tests/unit\` — 669 passed (no regressions)
- [x] \`uv run poe lint\` — pre-commit hooks all green (ruff, mypy, basedpyright, commitizen)
- [ ] Pre-push e2e (Playwright + security) executed by the push hook
- [ ] Reviewer: confirm \`request.state.user\` is the right seam for the helper (no auth_backend dependency added)

## Bundling rationale

Both stories add helpers + calls to the same hunks of \`detail_view\`, \`update_view\`,
and \`delete_action\` in \`src/hyperadmin/views/dynamic.py\`. Per
\`.claude/rules/planning-playbook.md\`, when stories touch identical regions of the
same file, two PRs would hard-conflict regardless of merge order. They are kept as
two separate commits within this PR for clean review and independent revert.

Part of v0.5.1 Cycle 2 — Wiring (last slot before Cycle 3).