### PR TITLE
test(unit+e2e): MFA login flow scenarios (C3-C, #488)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: mixed-line-ending
       - id: name-tests-test
         args: [--pytest-test-first]
-        exclude: ^tests/e2e/(_auth_app|_upload_app)\.py$
+        exclude: ^tests/e2e/(_auth_app|_upload_app|_mfa_app)\.py$
       - id: trailing-whitespace
         types: [python]
   - repo: local

--- a/tests/e2e/_mfa_app.py
+++ b/tests/e2e/_mfa_app.py
@@ -12,10 +12,10 @@ This is the only practical way for the Playwright client to read a code
 that lives in the server process — there is no real email backend.
 
 For the rate-limit scenario the service is configured with a tight
-``rate_limit=(1, 3600)``: a single OTP per hour is enough budget for the
-happy-path flows while making the boundary deterministic — every test
-that needs a fresh code starts by resetting the captured history via
-``/_test/reset_otp_state``.
+``rate_limit=(2, 3600)``: two OTP issuances per hour is enough budget
+for the happy-path flows (one at login, one resend) while making the
+boundary deterministic — every test that needs a fresh code starts by
+resetting the captured history via ``/_test/reset_otp_state``.
 """
 
 from __future__ import annotations

--- a/tests/e2e/_mfa_app.py
+++ b/tests/e2e/_mfa_app.py
@@ -1,0 +1,178 @@
+"""Minimal HyperAdmin app with MFA wired for E2E testing (C3-C, #488).
+
+Started by the ``mfa_base_url`` fixture via uvicorn subprocess. Seeds two
+users on startup:
+
+* ``alice / secret`` — ``mfa_enabled=True`` (full two-factor flow)
+* ``bob / secret``   — ``mfa_enabled=False`` (single-factor reference)
+
+The OTP service uses an in-process ``_CapturingSender`` whose latest
+issued code is exposed through test-only HTTP endpoints (``/_test/...``).
+This is the only practical way for the Playwright client to read a code
+that lives in the server process — there is no real email backend.
+
+For the rate-limit scenario the service is configured with a tight
+``rate_limit=(1, 3600)``: a single OTP per hour is enough budget for the
+happy-path flows while making the boundary deterministic — every test
+that needs a fresh code starts by resetting the captured history via
+``/_test/reset_otp_state``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import SQLModel, select
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from hyperadmin.auth.backend import hash_password
+from hyperadmin.auth.models import User
+from hyperadmin.auth.otp import OTP_SESSION_KEY, EmailOTPService
+from hyperadmin.auth.permissions import (
+    ModelPermissionChecker,
+    PermissionSyncService,
+)
+from hyperadmin.auth.session import SessionAuthBackend
+from hyperadmin.core.app import Admin
+from hyperadmin.core.settings import HyperAdminSettings
+
+engine = create_async_engine(
+    "sqlite+aiosqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+)
+
+
+class _CapturingSender:
+    """Test-only email sender: stores the most recent (email, code) pair."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def __call__(self, email: str, code: str) -> None:
+        self.calls.append((email, code))
+
+    def latest_for(self, email: str) -> str | None:
+        for sent_email, sent_code in reversed(self.calls):
+            if sent_email == email:
+                return sent_code
+        return None
+
+    def reset(self) -> None:
+        self.calls.clear()
+
+
+_SENDER = _CapturingSender()
+
+
+async def _seed_users() -> None:
+    """Create alice (MFA on) and bob (MFA off) idempotently."""
+    async with AsyncSession(engine) as session:
+        for username, mfa in (("alice", True), ("bob", False)):
+            existing = (
+                await session.execute(select(User).where(User.username == username))
+            ).scalar_one_or_none()
+            if existing is None:
+                session.add(
+                    User(
+                        username=username,
+                        email=f"{username}@example.com",
+                        password_hash=hash_password("secret"),
+                        is_superuser=True,
+                        mfa_enabled=mfa,
+                        mfa_method="email" if mfa else None,
+                    )
+                )
+        await session.commit()
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    await _seed_users()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+backend = SessionAuthBackend(engine=engine)
+# rate_limit=(2, 3600): two issuances per hour is enough budget for the
+# happy-path scenarios that issue exactly one code, and makes the
+# rate-limit scenario hit on the third call within the same session.
+otp_service = EmailOTPService(email_sender=_SENDER, rate_limit=(2, 3600))
+settings = HyperAdminSettings(create_tables=False, secret_key="e2e-mfa-test-secret")
+
+admin = Admin(
+    app,
+    engine=engine,
+    settings=settings,
+    auth_backend=backend,
+    permission_checker=ModelPermissionChecker(engine=engine),
+    permission_registry=PermissionSyncService(engine=engine),
+    otp_service=otp_service,
+)
+admin.mount(path="/admin")
+
+
+# ── Test-only helper endpoints ────────────────────────────────────────────
+#
+# All under ``/_test/`` so they are clearly out of scope for production-style
+# E2E flows. They are mounted directly on the FastAPI app (NOT on the admin
+# router) so they sit OUTSIDE the auth middleware's ``/admin`` prefix and
+# stay reachable from anonymous and partial-auth Playwright contexts alike.
+
+
+async def _reset_otp_state(request: Request) -> Response:
+    """Wipe captured codes + clear any session OTP/partial-auth state."""
+    _SENDER.reset()
+    request.session.clear()
+    return Response(status_code=204)
+
+
+async def _latest_code(request: Request) -> JSONResponse:
+    """Return the latest OTP code captured for ``?email=...``.
+
+    Lets the Playwright test read the OTP that the server-side service
+    just generated — the only way to drive the verify form deterministically
+    when there is no real email backend.
+    """
+    email = request.query_params.get("email", "")
+    code = _SENDER.latest_for(email)
+    return JSONResponse({"email": email, "code": code})
+
+
+async def _backdate_session_otp(request: Request) -> Response:
+    """Backdate the current session's OTP entry past its TTL.
+
+    Used by the "expired OTP" scenario. Returns 404 if the session has no
+    pending OTP entry — the caller must complete the password step first.
+    """
+    entry = request.session.get(OTP_SESSION_KEY)
+    if not isinstance(entry, dict):
+        return Response(status_code=404)
+    stale = (datetime.now(tz=timezone.utc) - timedelta(hours=1)).isoformat()
+    entry["issued_at"] = stale
+    request.session[OTP_SESSION_KEY] = entry
+    return Response(status_code=204)
+
+
+def _register_test_routes(_app: FastAPI) -> None:
+    # Use the lower-level Starlette router to keep these out of FastAPI's
+    # OpenAPI surface and avoid the response-model machinery; the helpers
+    # take a single ``Request`` and return ``Response`` objects.
+    _app.router.add_route("/_test/reset_otp_state", _reset_otp_state, methods=["POST"])
+    _app.router.add_route("/_test/latest_code", _latest_code, methods=["GET"])
+    _app.router.add_route("/_test/backdate_session_otp", _backdate_session_otp, methods=["POST"])
+
+
+_register_test_routes(app)
+
+
+# Re-export for completeness; the fixture imports ``app`` only.
+_ = (Any,)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -122,6 +122,78 @@ def demo_base_url(e2e_port: int) -> Iterator[str]:
 
 
 @pytest.fixture
+def mfa_base_url(e2e_port: int) -> Iterator[str]:
+    """Start an MFA-enabled HyperAdmin app and yield the base URL.
+
+    Seeds two superusers on startup:
+
+    * ``alice / secret`` with ``mfa_enabled=True``
+    * ``bob   / secret`` with ``mfa_enabled=False``
+
+    Exposes ``/_test/latest_code?email=...``, ``/_test/reset_otp_state``,
+    and ``/_test/backdate_session_otp`` for Playwright to drive the OTP
+    flow deterministically.
+    """
+    pytest.importorskip("uvicorn")
+    requests = pytest.importorskip("requests")  # type: ignore[assignment]
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "tests.e2e._mfa_app:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(e2e_port),
+        "--log-level",
+        "warning",
+    ]
+
+    env = os.environ.copy()
+    env["E2E_TESTING"] = "1"
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+    )
+
+    base = f"http://localhost:{e2e_port}"
+
+    try:
+        deadline = time.time() + _SERVER_TIMEOUT
+        last_err: Exception | None = None
+        while time.time() < deadline:
+            try:
+                r = requests.get(base + "/admin/login", timeout=0.5)
+                if r.status_code == HTTPStatus.OK:
+                    break
+            except Exception as e:
+                last_err = e
+            time.sleep(0.3)
+        else:
+            raise RuntimeError(f"MFA server did not start: {last_err}")
+
+        yield base
+    finally:
+        if proc.poll() is None:
+            try:
+                if os.name == "nt":
+                    proc.terminate()
+                else:
+                    proc.send_signal(signal.SIGTERM)
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()
+
+
+@pytest.fixture
 def auth_base_url(e2e_port: int) -> Iterator[str]:
     """Start an auth-enabled HyperAdmin app and yield the base URL.
 

--- a/tests/e2e/test_mfa_login.py
+++ b/tests/e2e/test_mfa_login.py
@@ -1,0 +1,270 @@
+"""End-to-end tests for the MVP email-OTP MFA flow (C3-C, #488).
+
+Each test maps 1:1 to a Track B BDD scenario in
+``docs/specs/object-permissions-mfa.md``. Inline ``# Given / # When / # Then``
+comments are mandatory per ``.claude/rules/bdd-conventions.md``.
+
+Selectors follow the CLAUDE.md E2E Selector Convention — accessibility-first
+with ``data-testid`` for elements without a natural role. The test app
+served by the ``mfa_base_url`` fixture exposes three test-only endpoints:
+
+* ``POST /_test/reset_otp_state`` — wipe captured codes + session state
+* ``GET  /_test/latest_code?email=`` — read the most recent OTP for that email
+* ``POST /_test/backdate_session_otp`` — backdate session OTP past its TTL
+
+These are HTTP helpers, not selectors — they let the Playwright test read
+the code that the in-process server just generated and drive expiry
+without sleeping for the full TTL.
+"""
+
+from __future__ import annotations
+
+import requests
+from playwright.sync_api import Page, expect
+
+# ── Shared helpers ────────────────────────────────────────────────────────
+
+
+def _reset(base_url: str, page: Page) -> None:
+    """Wipe both server-side capture history and the browser's cookies.
+
+    Must be called at the START of every scenario — the test app's user
+    fixtures are shared across the uvicorn process lifetime, but per-test
+    isolation requires a clean session cookie + a clean OTP capture log.
+    """
+    page.context.clear_cookies()
+    requests.post(f"{base_url}/_test/reset_otp_state", timeout=2)
+
+
+def _latest_code(base_url: str, email: str) -> str:
+    """Return the most recent OTP code captured for ``email`` (server-side)."""
+    resp = requests.get(f"{base_url}/_test/latest_code", params={"email": email}, timeout=2)
+    resp.raise_for_status()
+    code = resp.json().get("code")
+    assert code, f"no OTP captured for {email}"
+    return str(code)
+
+
+def _submit_password(page: Page, base_url: str, username: str, password: str) -> None:
+    """Submit the login form for ``username`` / ``password``."""
+    page.goto(f"{base_url}/admin/login")
+    page.get_by_label("Username").fill(username)
+    page.get_by_label("Password").fill(password)
+    page.get_by_role("button", name="Sign in").click()
+
+
+# ── Scenario: MFA-disabled user logs in with one factor ───────────────────
+
+
+def test_mfa_disabled_user_logs_in_with_one_factor(page: Page, mfa_base_url: str) -> None:
+    """Bob (mfa_enabled=False) skips the MFA challenge entirely."""
+    # Given bob exists with mfa_enabled=False
+    _reset(mfa_base_url, page)
+
+    # When bob submits correct credentials
+    _submit_password(page, mfa_base_url, "bob", "secret")
+
+    # Then he lands directly on the admin dashboard (no MFA challenge)
+    expect(page).to_have_url(f"{mfa_base_url}/admin/")
+
+
+# ── Scenario: MFA-enabled user is redirected to challenge after password ──
+
+
+def test_mfa_enabled_user_is_redirected_to_challenge_after_password(
+    page: Page, mfa_base_url: str
+) -> None:
+    """Alice (mfa_enabled=True) is bounced to the MFA challenge."""
+    # Given alice exists with mfa_enabled=True
+    _reset(mfa_base_url, page)
+
+    # When alice submits her correct password
+    _submit_password(page, mfa_base_url, "alice", "secret")
+
+    # Then she lands on the MFA challenge page (partial-auth)
+    expect(page).to_have_url(f"{mfa_base_url}/admin/mfa/challenge")
+    expect(page.get_by_test_id("mfa-code-input")).to_be_visible()
+    expect(page.get_by_test_id("mfa-verify-btn")).to_be_visible()
+
+
+# ── Scenario: correct OTP code completes login ────────────────────────────
+
+
+def test_correct_otp_code_completes_login(page: Page, mfa_base_url: str) -> None:
+    """Submitting the correct OTP upgrades partial-auth to a full session."""
+    # Given alice has just passed the password step
+    _reset(mfa_base_url, page)
+    _submit_password(page, mfa_base_url, "alice", "secret")
+    expect(page).to_have_url(f"{mfa_base_url}/admin/mfa/challenge")
+
+    # When she enters the issued OTP and submits
+    code = _latest_code(mfa_base_url, "alice@example.com")
+    page.get_by_test_id("mfa-code-input").fill(code)
+    page.get_by_test_id("mfa-verify-btn").click()
+
+    # Then she is redirected to the admin dashboard with a full session
+    expect(page).to_have_url(f"{mfa_base_url}/admin/")
+
+
+# ── Scenario: wrong OTP code shows an error ───────────────────────────────
+
+
+def test_wrong_otp_code_shows_an_error(page: Page, mfa_base_url: str) -> None:
+    """A wrong code re-renders the challenge with an error and keeps partial-auth."""
+    # Given alice has passed the password step
+    _reset(mfa_base_url, page)
+    _submit_password(page, mfa_base_url, "alice", "secret")
+    expect(page).to_have_url(f"{mfa_base_url}/admin/mfa/challenge")
+
+    # When she submits a wrong code
+    page.get_by_test_id("mfa-code-input").fill("000000")
+    page.get_by_test_id("mfa-verify-btn").click()
+
+    # Then the challenge re-renders with an "Invalid code" error.
+    # The verify endpoint returns 200 (re-rendered template) so the URL
+    # stays at /admin/mfa/verify; we assert on the visible error + the
+    # code input still being present (proves we are still on the form).
+    expect(page.get_by_test_id("mfa-error")).to_be_visible()
+    expect(page.get_by_test_id("mfa-error")).to_contain_text("Invalid")
+    expect(page.get_by_test_id("mfa-code-input")).to_be_visible()
+
+
+# ── Scenario: expired OTP code shows error with resend option ─────────────
+
+
+def test_expired_otp_code_shows_error_with_resend_option(page: Page, mfa_base_url: str) -> None:
+    """An expired code shows the "expired" copy and a resend affordance."""
+    # Given alice's OTP entry has been backdated past its TTL
+    _reset(mfa_base_url, page)
+    _submit_password(page, mfa_base_url, "alice", "secret")
+    expect(page).to_have_url(f"{mfa_base_url}/admin/mfa/challenge")
+    issued_code = _latest_code(mfa_base_url, "alice@example.com")
+    # Backdate via the test endpoint from inside the browser context so
+    # the session cookie is sent automatically. Using ``requests`` from
+    # the test process loses the session cookie set by Starlette's
+    # SessionMiddleware (the cookie is HTTPOnly + the request library
+    # doesn't share the browser jar transparently).
+    backdate_status = page.evaluate(
+        """async (url) => {
+            const resp = await fetch(url, { method: 'POST', credentials: 'include' });
+            return resp.status;
+        }""",
+        f"{mfa_base_url}/_test/backdate_session_otp",
+    )
+    assert backdate_status == 204
+
+    # When she submits the (now expired) code
+    page.get_by_test_id("mfa-code-input").fill(issued_code)
+    page.get_by_test_id("mfa-verify-btn").click()
+
+    # Then the page shows an "expired" message and the resend link is visible
+    expect(page.get_by_test_id("mfa-error")).to_be_visible()
+    expect(page.get_by_test_id("mfa-error")).to_contain_text("expired")
+    expect(page.get_by_test_id("mfa-resend-link")).to_be_visible()
+
+
+# ── Scenario: rate limit blocks excessive OTP requests ────────────────────
+
+
+def test_rate_limit_blocks_excessive_otp_requests(page: Page, mfa_base_url: str) -> None:
+    """Repeated resends trigger the rate-limit message in the UI.
+
+    The test app configures the OTP service with ``rate_limit=(2, 3600)``;
+    one code is issued at login, a second at the first resend, and the
+    third resend within the same session must surface the rate-limit copy.
+    """
+    # Given alice is on the MFA challenge page after a successful password
+    _reset(mfa_base_url, page)
+    _submit_password(page, mfa_base_url, "alice", "secret")
+    expect(page).to_have_url(f"{mfa_base_url}/admin/mfa/challenge")
+
+    # When she clicks "Resend code" twice in a row to exhaust the budget
+    page.get_by_test_id("mfa-resend-link").click()
+    # The first resend renders a flash; wait for it before the next click.
+    expect(page.get_by_test_id("mfa-flash")).to_be_visible()
+    page.get_by_test_id("mfa-resend-link").click()
+
+    # Then the rate-limit error surfaces (matches the SDD's "Too many attempts" copy)
+    expect(page.get_by_test_id("mfa-error")).to_be_visible()
+    expect(page.get_by_test_id("mfa-error")).to_contain_text("Too many attempts")
+
+
+# ── Scenario: partial-auth session cannot reach admin routes ──────────────
+
+
+def test_partial_auth_session_cannot_reach_admin_routes(page: Page, mfa_base_url: str) -> None:
+    """The middleware bounces partial-auth users from admin to /mfa/challenge."""
+    # Given alice has only completed the password step
+    _reset(mfa_base_url, page)
+    _submit_password(page, mfa_base_url, "alice", "secret")
+    expect(page).to_have_url(f"{mfa_base_url}/admin/mfa/challenge")
+
+    # When she navigates to a regular admin route (the user list is always present)
+    page.goto(f"{mfa_base_url}/admin/user")
+
+    # Then the partial-auth gate redirects her back to the MFA challenge
+    expect(page).to_have_url(f"{mfa_base_url}/admin/mfa/challenge")
+
+
+# ── Scenario: enable MFA from settings ────────────────────────────────────
+
+
+def test_enable_mfa_from_settings(page: Page, mfa_base_url: str) -> None:
+    """Bob (MFA off) enables MFA from the settings page via OTP confirmation."""
+    # Given bob is fully authenticated and visits /admin/mfa/settings
+    _reset(mfa_base_url, page)
+    _submit_password(page, mfa_base_url, "bob", "secret")
+    expect(page).to_have_url(f"{mfa_base_url}/admin/")
+    page.goto(f"{mfa_base_url}/admin/mfa/settings")
+    expect(page.get_by_test_id("mfa-status-indicator")).to_have_attribute(
+        "data-mfa-enabled", "false"
+    )
+
+    # When he clicks "Enable" — Step 1 of the flow sends an OTP
+    page.get_by_test_id("mfa-enable-btn").click()
+    expect(page.get_by_test_id("mfa-confirm-input")).to_be_visible()
+    enable_code = _latest_code(mfa_base_url, "bob@example.com")
+
+    # And he submits the OTP from his email — Step 2 flips the flag
+    page.get_by_test_id("mfa-confirm-input").fill(enable_code)
+    page.get_by_test_id("mfa-confirm-btn").click()
+
+    # Then the settings page reports MFA is now enabled
+    expect(page.get_by_test_id("mfa-status-indicator")).to_have_attribute(
+        "data-mfa-enabled", "true"
+    )
+
+
+# ── Scenario: disable MFA from settings ───────────────────────────────────
+
+
+def test_disable_mfa_from_settings(page: Page, mfa_base_url: str) -> None:
+    """Alice (MFA on) disables MFA from settings after confirming a fresh OTP."""
+    # Given alice is fully authenticated (login + verify OTP)
+    _reset(mfa_base_url, page)
+    _submit_password(page, mfa_base_url, "alice", "secret")
+    expect(page).to_have_url(f"{mfa_base_url}/admin/mfa/challenge")
+    login_code = _latest_code(mfa_base_url, "alice@example.com")
+    page.get_by_test_id("mfa-code-input").fill(login_code)
+    page.get_by_test_id("mfa-verify-btn").click()
+    expect(page).to_have_url(f"{mfa_base_url}/admin/")
+
+    # And visits the MFA settings page
+    page.goto(f"{mfa_base_url}/admin/mfa/settings")
+    expect(page.get_by_test_id("mfa-status-indicator")).to_have_attribute(
+        "data-mfa-enabled", "true"
+    )
+
+    # When she clicks "Disable" — Step 1 sends a fresh confirmation OTP
+    page.get_by_test_id("mfa-disable-btn").click()
+    expect(page.get_by_test_id("mfa-confirm-input")).to_be_visible()
+    disable_code = _latest_code(mfa_base_url, "alice@example.com")
+
+    # And she submits the disable confirmation code — Step 2 flips the flag
+    page.get_by_test_id("mfa-confirm-input").fill(disable_code)
+    page.get_by_test_id("mfa-confirm-btn").click()
+
+    # Then the settings page reports MFA is now disabled
+    expect(page.get_by_test_id("mfa-status-indicator")).to_have_attribute(
+        "data-mfa-enabled", "false"
+    )

--- a/tests/unit/test_mfa_login_flow.py
+++ b/tests/unit/test_mfa_login_flow.py
@@ -1,0 +1,366 @@
+"""End-to-end integration unit tests for the MFA login flow (C3-C, #488).
+
+This file is the *full integration loop* for the email-OTP MFA feature:
+``login`` → ``partial-auth`` → ``mfa/challenge`` → ``mfa/verify`` → full
+session. The per-component tests live elsewhere and are deliberately NOT
+duplicated here:
+
+* ``tests/unit/test_email_otp_service.py``  — service-level (C1-D)
+* ``tests/unit/test_mfa_challenge_view.py`` — view-level (C2-D)
+* ``tests/unit/test_mfa_login_wiring.py``   — wiring + middleware (C3-A)
+
+Each test composes the whole chain through the real ``Admin`` mount and the
+real session middleware, so the assertions describe observable HTTP
+behaviour (status codes, redirects, persisted DB state) rather than
+implementation internals.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import SQLModel
+
+from hyperadmin.auth.backend import hash_password
+from hyperadmin.auth.models import User
+from hyperadmin.auth.otp import (
+    OTP_SESSION_KEY,
+    PARTIAL_AUTH_SESSION_KEY,
+    EmailOTPService,
+)
+
+
+@pytest.fixture
+async def async_engine(tmp_path):
+    db_file = tmp_path / "test_mfa_login_flow.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_file}")
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    yield engine
+    await engine.dispose()
+
+
+class _CapturingSender:
+    """Test double for ``EmailOTPService.email_sender``.
+
+    Records the (email, code) pair of every successful issuance so tests can
+    drive the verify step with the exact code that the service generated.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    async def __call__(self, email: str, code: str) -> None:
+        self.calls.append((email, code))
+
+
+def _make_alice_data() -> dict[str, Any]:
+    return {
+        "username": "alice",
+        "email": "alice@example.com",
+        "password_hash": hash_password("secret"),
+        "mfa_enabled": True,
+        "mfa_method": "email",
+    }
+
+
+@pytest.fixture
+async def alice(async_engine) -> User:
+    async with AsyncSession(async_engine) as session:
+        user = User(**_make_alice_data())
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+
+
+def _build_app(async_engine, sender: _CapturingSender) -> FastAPI:
+    """Build a fully-wired Admin app with auth + MFA endpoints.
+
+    Uses ``Admin.mount`` so login_view, mfa_challenge_view, mfa_verify_view,
+    mfa_resend_view, and the partial-auth middleware gate are all in play —
+    exactly what the production app sees.
+    """
+    from hyperadmin.auth.session import SessionAuthBackend
+    from hyperadmin.core.app import Admin
+    from hyperadmin.core.registry import site
+    from hyperadmin.core.settings import HyperAdminSettings
+
+    site._registry.clear()
+
+    app = FastAPI()
+    backend = SessionAuthBackend(engine=async_engine)
+    otp_service = EmailOTPService(email_sender=sender)
+    Admin(
+        app,
+        engine=async_engine,
+        settings=HyperAdminSettings(create_tables=False, secret_key="test-secret-c3c"),
+        auth_backend=backend,
+        otp_service=otp_service,
+    ).mount("/admin")
+    return app
+
+
+# ─── Scenario: full login chain succeeds ──────────────────────────────────
+
+
+class TestEndToEndLoginSucceeds:
+    @pytest.mark.anyio
+    async def test_login_then_verify_yields_full_session(self, async_engine, alice) -> None:
+        """
+        Scenario: full login chain succeeds for an MFA-enabled user
+          Given alice has mfa_enabled=True
+          When  she POSTs correct credentials and then the issued OTP
+          Then  the response is a redirect to /admin/
+          And   subsequent admin requests succeed (full auth granted)
+        """
+        # Given alice with MFA on, and a capturing sender wired into the app
+        sender = _CapturingSender()
+        app = _build_app(async_engine, sender)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # When she submits the correct password
+            login_resp = await client.post(
+                "/admin/login",
+                data={"username": "alice", "password": "secret"},
+                follow_redirects=False,
+            )
+            # Then she is redirected to the MFA challenge (partial auth)
+            assert login_resp.status_code == 302
+            assert login_resp.headers["location"].endswith("/admin/mfa/challenge")
+            assert len(sender.calls) == 1
+            sent_email, sent_code = sender.calls[0]
+            assert sent_email == "alice@example.com"
+
+            # When she POSTs the correct OTP
+            verify_resp = await client.post(
+                "/admin/mfa/verify",
+                data={"code": sent_code},
+                follow_redirects=False,
+            )
+            # Then she lands on /admin/ with a full session
+            assert verify_resp.status_code == 302
+            assert verify_resp.headers["location"].endswith("/admin/")
+
+            # And follow-up admin requests are accepted (no MFA bounce)
+            admin_resp = await client.get("/admin/", follow_redirects=False)
+            assert admin_resp.status_code == 200
+
+
+# ─── Scenario: wrong code keeps session in partial-auth ──────────────────
+
+
+class TestWrongCodeKeepsPartialAuth:
+    @pytest.mark.anyio
+    async def test_wrong_otp_does_not_grant_full_session(self, async_engine, alice) -> None:
+        """
+        Scenario: wrong OTP keeps the user in partial-auth
+          Given alice has just submitted her password
+          When  she POSTs an incorrect OTP code
+          Then  the verify view re-renders 200 with an error
+          And   admin routes still bounce her to /mfa/challenge
+        """
+        # Given alice in the partial-auth state after a correct password
+        sender = _CapturingSender()
+        app = _build_app(async_engine, sender)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.post(
+                "/admin/login",
+                data={"username": "alice", "password": "secret"},
+                follow_redirects=False,
+            )
+            assert len(sender.calls) == 1
+
+            # When she submits a wrong code
+            verify_resp = await client.post(
+                "/admin/mfa/verify",
+                data={"code": "000000"},
+                follow_redirects=False,
+            )
+            # Then the challenge re-renders 200 with the "Invalid code" error
+            assert verify_resp.status_code == 200
+            assert "Invalid code" in verify_resp.text
+
+            # And the partial-auth gate still redirects /admin/ to /mfa/challenge
+            admin_resp = await client.get("/admin/", follow_redirects=False)
+            assert admin_resp.status_code == 302
+            assert admin_resp.headers["location"].endswith("/admin/mfa/challenge")
+
+
+# ─── Scenario: middleware blocks partial-auth from regular admin routes ──
+
+
+class TestPartialAuthBlocksAdminRoute:
+    @pytest.mark.anyio
+    async def test_partial_auth_user_redirected_from_user_list(self, async_engine, alice) -> None:
+        """
+        Scenario: middleware blocks a partial-auth session from /admin/user
+          Given alice has only completed the password step
+          When  she GETs /admin/user
+          Then  the response redirects to /admin/mfa/challenge
+        """
+        # Given alice mid-MFA (has a partial-auth marker, no full session)
+        sender = _CapturingSender()
+        app = _build_app(async_engine, sender)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.post(
+                "/admin/login",
+                data={"username": "alice", "password": "secret"},
+                follow_redirects=False,
+            )
+
+            # When she tries to reach a regular admin route
+            resp = await client.get("/admin/user", follow_redirects=False)
+
+            # Then she is bounced to the MFA challenge (NOT to /admin/login)
+            assert resp.status_code == 302
+            assert resp.headers["location"].endswith("/admin/mfa/challenge")
+
+
+# ─── Scenario: resend invalidates the prior code ─────────────────────────
+
+
+class TestResendInvalidatesPriorCode:
+    @pytest.mark.anyio
+    async def test_resend_overwrites_previous_otp(self, async_engine, alice) -> None:
+        """
+        Scenario: resend invalidates the previous OTP
+          Given alice has a pending OTP from the login step
+          When  she POSTs /admin/mfa/resend
+          Then  a fresh code is issued to her email
+          And   the prior code can no longer be used to verify
+        """
+        # Given alice mid-MFA with a pending OTP (the one issued at login)
+        sender = _CapturingSender()
+        app = _build_app(async_engine, sender)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await client.post(
+                "/admin/login",
+                data={"username": "alice", "password": "secret"},
+                follow_redirects=False,
+            )
+            assert len(sender.calls) == 1
+            old_code = sender.calls[0][1]
+
+            # When she POSTs the resend endpoint
+            resend_resp = await client.post("/admin/mfa/resend")
+            # Then a NEW code is issued to her email (different from the first)
+            assert resend_resp.status_code == 200
+            assert len(sender.calls) == 2
+            new_code = sender.calls[1][1]
+            # And the two codes are distinct (overwhelmingly likely with 6
+            # digits of entropy; if they happen to collide, force one retry).
+            if old_code == new_code:
+                resend_resp = await client.post("/admin/mfa/resend")
+                assert resend_resp.status_code == 200
+                assert len(sender.calls) == 3
+                new_code = sender.calls[-1][1]
+            assert new_code != old_code
+
+            # And the OLD code now fails to verify (single active OTP per user)
+            old_verify = await client.post(
+                "/admin/mfa/verify",
+                data={"code": old_code},
+                follow_redirects=False,
+            )
+            assert old_verify.status_code == 200
+            assert "Invalid code" in old_verify.text
+
+            # And the NEW code completes login
+            new_verify = await client.post(
+                "/admin/mfa/verify",
+                data={"code": new_code},
+                follow_redirects=False,
+            )
+            assert new_verify.status_code == 302
+            assert new_verify.headers["location"].endswith("/admin/")
+
+
+# ─── Scenario: expired OTP surfaces the "expired" copy ───────────────────
+
+
+class TestExpiredCodeIsRejectedDistinctly:
+    @pytest.mark.anyio
+    async def test_backdated_otp_renders_expired_message(self, async_engine, alice) -> None:
+        """
+        Scenario: an OTP older than its TTL is rejected with a distinct message
+          Given alice has a pending OTP whose ``issued_at`` is older than the TTL
+          When  she submits that code
+          Then  the page re-renders 200 with an "expired" message and resend link
+        """
+        # Given alice in partial auth with a pending OTP, then we backdate it
+        # by clearing the code from session and re-injecting via the verify
+        # path: easier — we use the existing OTP entry directly via the
+        # session-poking approach used by C2-D's view tests.
+        from starlette.requests import Request
+        from starlette.responses import Response
+
+        from hyperadmin.auth.session import SessionAuthBackend
+        from hyperadmin.core.app import Admin
+        from hyperadmin.core.registry import site
+        from hyperadmin.core.settings import HyperAdminSettings
+
+        site._registry.clear()
+
+        app = FastAPI()
+        backend = SessionAuthBackend(engine=async_engine)
+        sender = _CapturingSender()
+        otp_service = EmailOTPService(email_sender=sender)
+        Admin(
+            app,
+            engine=async_engine,
+            settings=HyperAdminSettings(create_tables=False, secret_key="test-secret-c3c-exp"),
+            auth_backend=backend,
+            otp_service=otp_service,
+        ).mount("/admin")
+
+        async def _backdate(request: Request) -> Response:
+            entry = request.session.get(OTP_SESSION_KEY)
+            if entry is None:
+                return Response(status_code=404)
+            stale = (datetime.now(tz=timezone.utc) - timedelta(hours=1)).isoformat()
+            entry["issued_at"] = stale
+            request.session[OTP_SESSION_KEY] = entry
+            return Response(status_code=204)
+
+        app.router.add_route("/_test/backdate-otp", _backdate, methods=["POST"])
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Given alice completes the password step
+            await client.post(
+                "/admin/login",
+                data={"username": "alice", "password": "secret"},
+                follow_redirects=False,
+            )
+            assert len(sender.calls) == 1
+            issued_code = sender.calls[0][1]
+
+            # And we artificially backdate the OTP entry past its TTL
+            backdate_resp = await client.post("/_test/backdate-otp")
+            assert backdate_resp.status_code == 204
+
+            # When she submits the (now expired) code
+            verify_resp = await client.post(
+                "/admin/mfa/verify",
+                data={"code": issued_code},
+                follow_redirects=False,
+            )
+            # Then the response is 200 with a distinct "expired" message
+            assert verify_resp.status_code == 200
+            assert "expired" in verify_resp.text.lower()
+            # And the resend affordance is still surfaced
+            assert 'data-testid="mfa-resend-link"' in verify_resp.text
+
+
+# Silence unused-import warnings: PARTIAL_AUTH_SESSION_KEY is documented in
+# the module docstring but consumed only indirectly via the wired views.
+_ = PARTIAL_AUTH_SESSION_KEY

--- a/tests/unit/test_mfa_login_flow.py
+++ b/tests/unit/test_mfa_login_flow.py
@@ -18,13 +18,20 @@ implementation internals.
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlmodel import SQLModel
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+    from sqlalchemy.ext.asyncio import AsyncEngine
+    from starlette.requests import Request
 
 from hyperadmin.auth.backend import hash_password
 from hyperadmin.auth.models import User
@@ -36,7 +43,7 @@ from hyperadmin.auth.otp import (
 
 
 @pytest.fixture
-async def async_engine(tmp_path):
+async def async_engine(tmp_path: Path) -> AsyncIterator[AsyncEngine]:
     db_file = tmp_path / "test_mfa_login_flow.db"
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_file}")
     async with engine.begin() as conn:
@@ -60,17 +67,20 @@ class _CapturingSender:
 
 
 def _make_alice_data() -> dict[str, Any]:
+    # is_superuser=True mirrors the e2e test app fixture in tests/e2e/_mfa_app.py
+    # so admin-route assertions stay consistent across unit and e2e suites.
     return {
         "username": "alice",
         "email": "alice@example.com",
         "password_hash": hash_password("secret"),
+        "is_superuser": True,
         "mfa_enabled": True,
         "mfa_method": "email",
     }
 
 
 @pytest.fixture
-async def alice(async_engine) -> User:
+async def alice(async_engine: AsyncEngine) -> User:
     async with AsyncSession(async_engine) as session:
         user = User(**_make_alice_data())
         session.add(user)
@@ -79,7 +89,7 @@ async def alice(async_engine) -> User:
         return user
 
 
-def _build_app(async_engine, sender: _CapturingSender) -> FastAPI:
+def _build_app(async_engine: AsyncEngine, sender: _CapturingSender) -> FastAPI:
     """Build a fully-wired Admin app with auth + MFA endpoints.
 
     Uses ``Admin.mount`` so login_view, mfa_challenge_view, mfa_verify_view,
@@ -91,6 +101,8 @@ def _build_app(async_engine, sender: _CapturingSender) -> FastAPI:
     from hyperadmin.core.registry import site
     from hyperadmin.core.settings import HyperAdminSettings
 
+    # Direct access to the private registry — no public reset() exists on
+    # the site singleton today. If site grows one, swap this for it.
     site._registry.clear()
 
     app = FastAPI()
@@ -300,14 +312,15 @@ class TestExpiredCodeIsRejectedDistinctly:
         # by clearing the code from session and re-injecting via the verify
         # path: easier — we use the existing OTP entry directly via the
         # session-poking approach used by C2-D's view tests.
-        from starlette.requests import Request
-        from starlette.responses import Response
+        from starlette.responses import Response  # runtime — Response() is constructed here
 
         from hyperadmin.auth.session import SessionAuthBackend
         from hyperadmin.core.app import Admin
         from hyperadmin.core.registry import site
         from hyperadmin.core.settings import HyperAdminSettings
 
+        # Direct access to the private registry — no public reset() exists on
+        # the site singleton today. If site grows one, swap this for it.
         site._registry.clear()
 
         app = FastAPI()


### PR DESCRIPTION
## Summary

- 5 unit integration tests in `tests/unit/test_mfa_login_flow.py` exercising the full chain (login -> partial-auth -> challenge -> verify -> full session) through real `Admin.mount` + middleware.
- 9 Playwright tests in `tests/e2e/test_mfa_login.py`, one per Track B BDD scenario from the SDD, with mandatory inline `# Given / # When / # Then` comments.
- New `tests/e2e/_mfa_app.py` test app (otp_service wired, alice MFA-on + bob MFA-off seeded) plus `mfa_base_url` fixture in `tests/e2e/conftest.py`.
- Three test-only HTTP endpoints (`/_test/reset_otp_state`, `/_test/latest_code`, `/_test/backdate_session_otp`) so Playwright drives the OTP flow deterministically without a real email backend.

Closes #488.
Spec: [`docs/specs/object-permissions-mfa.md`](../blob/develop/docs/specs/object-permissions-mfa.md) (Track B — §"Tests" + integration scenarios).

## BDD Scenarios

E2E (Track B from the SDD):
- [x] MFA-disabled user logs in with one factor
- [x] MFA-enabled user is redirected to challenge after password
- [x] correct OTP code completes login
- [x] wrong OTP code shows an error
- [x] expired OTP code shows error with resend option
- [x] rate limit blocks excessive OTP requests
- [x] partial-auth session cannot reach admin routes
- [x] enable MFA from settings
- [x] disable MFA from settings

Unit-level integration loop:
- [x] full login chain succeeds for an MFA-enabled user
- [x] wrong OTP keeps the user in partial-auth
- [x] middleware blocks a partial-auth session from /admin/user
- [x] resend invalidates the previous OTP
- [x] backdated OTP renders the distinct "expired" message

## Test plan

- [x] `poe lint` — pre-commit hooks green (ruff, ruff-format, mypy, basedpyright, commitizen)
- [x] `poe test:unit` — 686 unit tests pass (no regressions)
- [x] `poe test:e2e -k mfa_login` — 9 / 9 green
- [x] Combined `pytest tests/unit/test_mfa_login_flow.py tests/e2e/test_mfa_login.py` — 14 / 14 green in 16s

## Notes

- Per-component unit tests already shipped in C1-D / C2-D / C3-A and are NOT duplicated here; this slot covers the integration loop only.
- Selectors follow the CLAUDE.md E2E Selector Convention (accessibility-first; `data-testid` only where no natural role exists). No `ha-*` CSS selectors anywhere.
- The expired-code scenario backdates `session[OTP_SESSION_KEY]["issued_at"]` via a test endpoint dispatched from inside the browser context (so the session cookie travels with the request) — this avoids waiting for the real 5-minute TTL.
- The rate-limit scenario uses a tight `rate_limit=(2, 3600)` on the test app's `EmailOTPService` so the third resend within the same session deterministically surfaces the "Too many attempts" copy.

Part of v0.5.1 Cycle 3 — Integration. Closes Track B end-to-end. **Last slot of v0.5.1.**