### PR TITLE
test(unit+e2e): object-level permissions and RLS scenarios (C3-B, #482)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: mixed-line-ending
       - id: name-tests-test
         args: [--pytest-test-first]
-        exclude: ^tests/e2e/(_auth_app|_upload_app)\.py$
+        exclude: ^tests/e2e/(_auth_app|_upload_app|_object_perm_app)\.py$
       - id: trailing-whitespace
         types: [python]
   - repo: local

--- a/tests/e2e/_object_perm_app.py
+++ b/tests/e2e/_object_perm_app.py
@@ -1,0 +1,258 @@
+"""Object-level-permission HyperAdmin app for E2E testing (C3-B, #482).
+
+Spec: ``docs/specs/object-permissions-mfa.md`` — Track A.
+
+Two test models keep each enforcement layer isolated, so individual
+scenarios pin down a single rule:
+
+* ``Order`` — protected ONLY by an :class:`ObjectPermissionChecker` that
+  denies non-superusers any interaction with id 40. ``OrderAdmin`` does
+  NOT override ``get_queryset`` (every row is visible to every authenticated
+  user; the only authz layer that can deny is the object-level checker).
+  Verifies the 4 detail/update/delete/superuser-bypass scenarios.
+* ``Document`` — protected ONLY by an ``OwnerScopedAdmin.get_queryset``
+  that filters list/detail to ``request.state.user.id`` for non-superusers.
+  No object-permission checker is attached. Verifies the RLS list scenario.
+
+Seeded users (password ``secret123`` for both):
+  * ``bob`` (id=1) — non-superuser holding all model-level Order permissions
+    (so any 403 is purely the object-level checker, not the model-level one).
+  * ``admin`` (id=2) — superuser, used to verify the bypass scenario.
+
+Seeded data:
+  * Orders: #10/#20 (owner_id=1, bob), #40 (owner_id=99).
+  * Documents: #100/#200 owned by bob (id=1); #400 owned by user 99.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlmodel import Field, SQLModel, select
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+from hyperadmin.auth.backend import hash_password
+from hyperadmin.auth.models import (
+    Permission,
+    User,
+    UserPermission,
+)
+from hyperadmin.auth.permissions import (
+    ModelPermissionChecker,
+    PermissionSyncService,
+)
+from hyperadmin.auth.session import SessionAuthBackend
+from hyperadmin.core.app import Admin
+from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.options import AdminOptions
+from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
+
+
+class Order(SQLModel, table=True):
+    """Order model — protected by an ObjectPermissionChecker only."""
+
+    __tablename__ = "test_e2e_order_object_perm"
+
+    id: int | None = Field(default=None, primary_key=True)
+    title: str = Field(max_length=120)
+    owner_id: int = Field(default=0, index=True)
+
+
+class Document(SQLModel, table=True):
+    """Document model — protected by ModelAdmin.get_queryset (RLS) only."""
+
+    __tablename__ = "test_e2e_document_rls"
+
+    id: int | None = Field(default=None, primary_key=True)
+    title: str = Field(max_length=120)
+    owner_id: int = Field(default=0, index=True)
+
+
+# Use a single shared on-disk SQLite database file so the uvicorn subprocess
+# (and any sub-workers) sees the seeded users + rows. ``sqlite:///:memory:``
+# creates a per-connection isolated DB, which would defeat the seed.
+_DB_PATH = os.environ.get("HYPERADMIN_E2E_OBJPERM_DB", "/tmp/hyperadmin-e2e-objperm.db")  # noqa: S108
+if os.path.exists(_DB_PATH):
+    os.remove(_DB_PATH)
+
+engine = create_async_engine(
+    f"sqlite+aiosqlite:///{_DB_PATH}",
+    connect_args={"check_same_thread": False},
+)
+
+
+class _BlockOrderFortyChecker:
+    """ObjectPermissionChecker that denies non-superusers access to order id=40.
+
+    Models the SDD's "superuser bypass lives in the checker, not the helper"
+    requirement: superusers are explicitly allowed regardless of object id.
+    """
+
+    BLOCKED_ID = 40
+
+    async def has_object_permission(self, user: Any, obj: Any, action: str) -> bool:
+        if getattr(user, "is_superuser", False):
+            return True
+        return getattr(obj, "id", None) != self.BLOCKED_ID
+
+
+class OrderAdmin(ModelAdmin):
+    """No row-level filter — only the ObjectPermissionChecker can deny."""
+
+
+class DocumentAdmin(ModelAdmin):
+    """Row-level scoped to ``request.state.user.id`` for non-superusers.
+
+    Used to verify ``ModelAdmin.get_queryset`` flows into the rendered list
+    table without a separate object-permission layer.
+    """
+
+    def get_queryset(self, request: Request | None = None) -> dict[str, Any]:
+        if request is None:
+            return {}
+        user = getattr(request.state, "user", None)
+        if user is None:
+            return {}
+        if getattr(user, "is_superuser", False):
+            return {}
+        return {"owner_id": user.id}
+
+
+async def _seed() -> None:
+    """Create users, grant model-level permissions, and seed orders + documents.
+
+    After this runs:
+      * ``bob`` (id=1) is a non-superuser with all Order CRUD model permissions
+        (so any 403 we observe in the 4 object-permission scenarios is
+        unambiguously caused by the OBJECT-level checker, not by the
+        model-level one).
+      * ``admin`` (id=2) is a superuser.
+      * Orders ``#10/#20`` (owner_id=1) and ``#40`` (owner_id=99).
+      * Documents ``#100/#200`` (owner_id=1) and ``#400`` (owner_id=99).
+    """
+    async with AsyncSession(engine) as session:
+        existing = await session.execute(select(User).where(User.username == "bob"))
+        if existing.scalar_one_or_none() is None:
+            session.add(
+                User(
+                    id=1,
+                    username="bob",
+                    email="bob@example.com",
+                    password_hash=hash_password("secret123"),
+                    is_superuser=False,
+                )
+            )
+            session.add(
+                User(
+                    id=2,
+                    username="admin",
+                    email="admin@example.com",
+                    password_hash=hash_password("secret123"),
+                    is_superuser=True,
+                )
+            )
+            await session.commit()
+
+        existing_orders = (await session.execute(select(Order))).scalars().all()
+        if not existing_orders:
+            session.add(Order(id=10, title="bob-order-A", owner_id=1))
+            session.add(Order(id=20, title="bob-order-B", owner_id=1))
+            session.add(Order(id=40, title="alice-order-A", owner_id=99))
+            await session.commit()
+
+        existing_docs = (await session.execute(select(Document))).scalars().all()
+        if not existing_docs:
+            session.add(Document(id=100, title="bob-doc-A", owner_id=1))
+            session.add(Document(id=200, title="bob-doc-B", owner_id=1))
+            session.add(Document(id=400, title="alice-doc-A", owner_id=99))
+            await session.commit()
+
+        # Grant bob the model-level Order + Document permissions so any
+        # observed 403/404 is attributable to the layer under test, not to
+        # missing model-level grants.
+        codenames = [
+            "view_order",
+            "change_order",
+            "delete_order",
+            "view_document",
+            "change_document",
+            "delete_document",
+        ]
+        perms = (
+            (
+                await session.execute(
+                    select(Permission).where(
+                        Permission.codename.in_(codenames)  # type: ignore[attr-defined]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        existing_grants = (
+            (await session.execute(select(UserPermission).where(UserPermission.user_id == 1)))
+            .scalars()
+            .all()
+        )
+        granted_ids = {g.permission_id for g in existing_grants}
+        for perm in perms:
+            if perm.id is not None and perm.id not in granted_ids:
+                session.add(UserPermission(user_id=1, permission_id=perm.id))
+        await session.commit()
+
+
+app = FastAPI()
+
+backend = SessionAuthBackend(engine=engine)
+settings = HyperAdminSettings(
+    create_tables=False,
+    secret_key="e2e-object-perm-secret",
+    auto_discover=False,  # we register models ourselves with custom admins.
+)
+
+
+# Register the test models BEFORE ``Admin.mount()`` so their options carry the
+# object-permission checker / queryset hook into the generated routes.
+site._registry = {}  # clean registry per process
+site.register(
+    Order,
+    admin_class=OrderAdmin,
+    options=AdminOptions(object_permission_checker=_BlockOrderFortyChecker()),
+)
+site.register(Document, admin_class=DocumentAdmin)
+
+admin = Admin(
+    app,
+    engine=engine,
+    settings=settings,
+    auth_backend=backend,
+    permission_checker=ModelPermissionChecker(engine=engine),
+    permission_registry=PermissionSyncService(engine=engine),
+)
+admin.mount(path="/admin")
+
+
+# Startup ordering:
+# 1. Create tables (so PermissionSyncService can write to hyperadmin_permissions).
+# 2. ``_sync_permissions`` (queued by ``Admin.mount`` and copied to
+#    ``app.router.on_startup`` by ``include_router``) — creates the
+#    order_*/document_* Permission rows.
+# 3. ``_seed`` — seeds users, orders, documents, and bob's permission grants.
+#
+# Registering on ``app.router.on_startup`` directly preserves ordering
+# relative to the ``include_router``-copied hook.
+
+
+async def _create_tables() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+
+app.router.on_startup.insert(0, _create_tables)
+app.router.on_startup.append(_seed)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -198,8 +198,11 @@ def object_perm_base_url(e2e_port: int) -> Iterator[str]:
       * three ``Order`` rows (#10, #20 owned by bob; #40 owned by user 99).
 
     The configured object-permission checker denies non-superusers any
-    interaction with order #40, while ``OrderAdmin.get_queryset`` filters
-    list/detail to ``request.state.user.id`` for non-superusers.
+    interaction with order #40 (Order is the object-permission model). RLS
+    is exercised via a separate ``Document`` model whose ``DocumentAdmin``
+    overrides ``get_queryset`` to filter list/detail to
+    ``request.state.user.id`` for non-superusers — keeping each enforcement
+    layer isolated to its own model so a single scenario tests one rule.
     """
     pytest.importorskip("uvicorn")
     requests = pytest.importorskip("requests")  # type: ignore[assignment]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -185,3 +185,79 @@ def auth_base_url(e2e_port: int) -> Iterator[str]:
                 proc.wait(timeout=5)
             except Exception:
                 proc.kill()
+
+
+@pytest.fixture
+def object_perm_base_url(e2e_port: int) -> Iterator[str]:
+    """Start an object-permission-enabled HyperAdmin app for E2E tests.
+
+    Wires :mod:`tests.e2e._object_perm_app`, which seeds:
+      * non-superuser ``bob`` (password ``secret123``) holding all model-level
+        ``Order`` permissions — any 403 observed is therefore object-level.
+      * superuser ``admin`` (password ``secret123``).
+      * three ``Order`` rows (#10, #20 owned by bob; #40 owned by user 99).
+
+    The configured object-permission checker denies non-superusers any
+    interaction with order #40, while ``OrderAdmin.get_queryset`` filters
+    list/detail to ``request.state.user.id`` for non-superusers.
+    """
+    pytest.importorskip("uvicorn")
+    requests = pytest.importorskip("requests")  # type: ignore[assignment]
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "tests.e2e._object_perm_app:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(e2e_port),
+        "--log-level",
+        "warning",
+    ]
+
+    env = os.environ.copy()
+    env["E2E_TESTING"] = "1"
+    # Each subprocess gets its own DB file so tests don't see stale data
+    # from a previously-run server.
+    env["HYPERADMIN_E2E_OBJPERM_DB"] = f"/tmp/hyperadmin-e2e-objperm-{e2e_port}.db"  # noqa: S108
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+    )
+
+    base = f"http://localhost:{e2e_port}"
+
+    try:
+        deadline = time.time() + _SERVER_TIMEOUT
+        last_err: Exception | None = None
+        while time.time() < deadline:
+            try:
+                r = requests.get(base + "/admin/login", timeout=0.5)
+                if r.status_code == HTTPStatus.OK:
+                    break
+            except Exception as e:
+                last_err = e
+            time.sleep(0.3)
+        else:
+            raise RuntimeError(f"Object-perm server did not start: {last_err}")
+
+        yield base
+    finally:
+        if proc.poll() is None:
+            try:
+                if os.name == "nt":
+                    proc.terminate()
+                else:
+                    proc.send_signal(signal.SIGTERM)
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()

--- a/tests/e2e/test_object_permissions.py
+++ b/tests/e2e/test_object_permissions.py
@@ -1,0 +1,147 @@
+"""End-to-end tests for object-level permissions and row-level security (C3-B, #482).
+
+Spec: ``docs/specs/object-permissions-mfa.md`` — Track A (integration scenarios).
+
+Each test maps 1:1 to an SDD Track A integration scenario. Inline
+``# Given / # When / # Then`` comments are mandatory (BDD conventions).
+
+Selectors follow ``CLAUDE.md`` (E2E Selector Convention):
+``get_by_role`` > ``get_by_label`` > ``get_by_text`` > ``get_by_test_id``.
+``ha-*`` CSS classes are styling-only and never used as selectors.
+
+The companion app (``tests.e2e._object_perm_app``) registers two test models
+that isolate each enforcement layer:
+
+* ``Order`` — protected ONLY by an :class:`ObjectPermissionChecker` that
+  denies non-superusers any interaction with id 40. Verifies the four
+  detail/update/delete/superuser-bypass scenarios.
+* ``Document`` — protected ONLY by ``ModelAdmin.get_queryset`` filtering
+  rows to ``request.state.user.id``. Verifies the RLS list scenario.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+
+def _login(page: Page, base_url: str, username: str, password: str = "secret123") -> None:  # noqa: S107
+    """Submit the admin login form and wait until we reach the dashboard."""
+    page.goto(f"{base_url}/admin/login")
+    page.get_by_label("Username").fill(username)
+    page.get_by_label("Password").fill(password)
+    page.get_by_role("button", name="Sign in").click()
+    expect(page).to_have_url(f"{base_url}/admin/")
+
+
+def test_staff_cannot_view_another_users_record_when_object_permission_denies(
+    page: Page, object_perm_base_url: str
+) -> None:
+    """
+    Scenario: staff cannot view another user's record when object permission denies
+      Given user "bob" has view_order model permission
+      And   ObjectPermissionChecker denies "bob" access to order#40
+      When  GET /admin/order/40
+      Then  the response is 403 Forbidden
+    """
+    # Given bob is logged in (he holds view_order; the model-level layer permits)
+    _login(page, object_perm_base_url, "bob")
+
+    # When bob navigates directly to order #40
+    response = page.request.get(f"{object_perm_base_url}/admin/order/40")
+
+    # Then the object-level checker denies — 403, not 200
+    assert response.status == 403
+
+
+def test_object_permission_check_is_enforced_on_update(
+    page: Page, object_perm_base_url: str
+) -> None:
+    """
+    Scenario: object permission check is enforced on update
+      Given ObjectPermissionChecker denies "bob" change access to order#40
+      When  PUT /admin/order/40 with valid data (the wired update method)
+      Then  the response is 403 Forbidden
+    """
+    # Given bob is logged in (he holds change_order at the model level)
+    _login(page, object_perm_base_url, "bob")
+
+    # When bob attempts to update order #40
+    response = page.request.put(
+        f"{object_perm_base_url}/admin/order/40",
+        form={"title": "hacked", "owner_id": "99"},
+        headers={"HX-Request": "true"},
+    )
+
+    # Then the object-level checker blocks the change — 403
+    assert response.status == 403
+
+
+def test_object_permission_check_is_enforced_on_delete(
+    page: Page, object_perm_base_url: str
+) -> None:
+    """
+    Scenario: object permission check is enforced on delete
+      Given ObjectPermissionChecker denies "bob" delete access to order#40
+      When  DELETE /admin/order/40 (the wired delete method)
+      Then  the response is 403 Forbidden
+    """
+    # Given bob is logged in (he holds delete_order at the model level)
+    _login(page, object_perm_base_url, "bob")
+
+    # When bob attempts to delete order #40
+    response = page.request.delete(
+        f"{object_perm_base_url}/admin/order/40",
+        headers={"HX-Request": "true"},
+    )
+
+    # Then the object-level checker blocks the delete — 403
+    assert response.status == 403
+
+
+def test_superuser_bypasses_object_level_checks(page: Page, object_perm_base_url: str) -> None:
+    """
+    Scenario: superuser bypasses object-level checks
+      Given a superuser "admin"
+      And   ObjectPermissionChecker would deny order#40 for everyone non-super
+      When  GET /admin/order/40
+      Then  the response is 200 OK
+    """
+    # Given the superuser is logged in
+    _login(page, object_perm_base_url, "admin")
+
+    # When the superuser navigates to order #40
+    page.goto(f"{object_perm_base_url}/admin/order/40")
+
+    # Then the page renders normally — the checker's superuser branch wins
+    expect(page.get_by_test_id("detail-fields")).to_be_visible()
+    expect(page.get_by_role("heading", name="alice-order-A")).to_be_visible()
+
+
+def test_get_queryset_filters_list_results_visible_to_non_superuser(
+    page: Page, object_perm_base_url: str
+) -> None:
+    """
+    Scenario: get_queryset filters list results visible to non-superuser
+      Given a non-superuser whose ModelAdmin.get_queryset returns {"owner_id": user.id}
+      When  GET /admin/document/
+      Then  only their owner_id rows are visible in the list table
+      And   the count reflects the filtered total
+    """
+    # Given bob is logged in and three documents exist (two owned by bob, one not)
+    _login(page, object_perm_base_url, "bob")
+
+    # When bob visits the Document list
+    page.goto(f"{object_perm_base_url}/admin/document")
+
+    # Then only his rows appear in the list table
+    table = page.get_by_test_id("list-table")
+    expect(table).to_be_visible()
+    expect(table.get_by_text("bob-doc-A")).to_be_visible()
+    expect(table.get_by_text("bob-doc-B")).to_be_visible()
+    # And alice's row is filtered out
+    expect(table.get_by_text("alice-doc-A")).to_have_count(0)
+    # And the row count reflects the filtered total (2 of 3)
+    rows = page.get_by_test_id("list-row")
+    expect(rows).to_have_count(2)
+    # And the pagination total reflects the filtered count (not the unscoped 3)
+    expect(page.get_by_test_id("pagination-info")).to_contain_text("of 2 results")

--- a/tests/e2e/test_object_permissions.py
+++ b/tests/e2e/test_object_permissions.py
@@ -65,7 +65,9 @@ def test_object_permission_check_is_enforced_on_update(
     # Given bob is logged in (he holds change_order at the model level)
     _login(page, object_perm_base_url, "bob")
 
-    # When bob attempts to update order #40
+    # When bob attempts to update order #40 — note the wired route is PUT
+    # per src/hyperadmin/routing.py (methods=["PUT"] for update_view), not
+    # POST. Don't "fix" this to POST without rewiring the router.
     response = page.request.put(
         f"{object_perm_base_url}/admin/order/40",
         form={"title": "hacked", "owner_id": "99"},

--- a/tests/unit/test_object_permissions.py
+++ b/tests/unit/test_object_permissions.py
@@ -1,0 +1,278 @@
+"""Integration-level unit tests for object-level permissions and RLS (C3-B, #482).
+
+Spec: ``docs/specs/object-permissions-mfa.md`` — Track A.
+
+These tests exercise the FULL Track A chain (request →
+:meth:`hyperadmin.core.model.ModelAdmin.get_queryset` →
+:meth:`hyperadmin.core.adapters.BaseAdapter.set_queryset_filter` → SQL) end-to-end
+through ``DynamicModelView``, plus the combination of a queryset filter and an
+:class:`hyperadmin.core.auth.ObjectPermissionChecker` on the same request to verify
+denial precedence.
+
+Existing C2-C unit tests already cover each layer in isolation
+(``test_views_object_permissions.py``, ``test_views_get_queryset_wiring.py``,
+``test_modeladmin_get_queryset.py``, ``test_adapter_get_queryset.py``); this file
+intentionally targets the cross-layer integration paths the C3-B story calls out.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import anyio
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.options import AdminOptions
+from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
+from hyperadmin.main import Admin
+
+
+class OrderC3B(SQLModel, table=True):
+    """Test model with ``owner_id`` for row-level scoping scenarios."""
+
+    __tablename__ = "test_order_c3b"
+
+    id: int | None = Field(default=None, primary_key=True)
+    title: str
+    owner_id: int = Field(default=0, index=True)
+
+
+class _User:
+    """Stand-in for a non-superuser ``request.state.user`` with an ``id`` attribute."""
+
+    def __init__(self, user_id: int, *, is_superuser: bool = False) -> None:
+        self.id = user_id
+        self.is_superuser = is_superuser
+
+
+class _OwnerScopedAdmin(ModelAdmin):
+    """ModelAdmin scoped to ``request.state.user.id`` — RLS at the admin layer."""
+
+    adapter_class = SQLModelAdapter
+
+    def get_queryset(self, request: Request | None = None) -> dict[str, Any]:
+        if request is None:
+            return {}
+        user = getattr(request.state, "user", None)
+        if user is None:
+            return {}
+        return {"owner_id": user.id}
+
+
+class _DenyOrderForty(_User):
+    """Marker user that triggers the checker to deny order id=40."""
+
+
+class _BlockSpecificObjectChecker:
+    """ObjectPermissionChecker that denies access to a specific object id.
+
+    Used to compose with ``_OwnerScopedAdmin`` so we can test denial precedence:
+    the queryset filter excludes rows the user does not own (yielding 404), but
+    when a row IS owned by the user, the object-level checker can still deny
+    (yielding 403). This is the exact precedence rule defined in the SDD's
+    "Edge Cases & Error Handling" section.
+    """
+
+    def __init__(self, blocked_id: int) -> None:
+        self.blocked_id = blocked_id
+
+    async def has_object_permission(self, user: Any, obj: Any, action: str) -> bool:
+        return getattr(obj, "id", None) != self.blocked_id
+
+
+@pytest.fixture(autouse=True)
+def cleanup_registry() -> Any:
+    """Wipe the global model registry between tests to avoid cross-pollution."""
+    site._registry = {}
+    yield
+    site._registry = {}
+
+
+def _seed_orders(engine: Any) -> None:
+    """Seed three orders: two owned by user 1 (bob), one by user 2 (alice)."""
+
+    async def _setup() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+        from sqlalchemy.orm import sessionmaker
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with async_session() as session:
+            session.add(OrderC3B(id=10, title="bob-order-A", owner_id=1))
+            session.add(OrderC3B(id=20, title="bob-order-B", owner_id=1))
+            session.add(OrderC3B(id=40, title="alice-order-A", owner_id=2))
+            await session.commit()
+
+    anyio.run(_setup)
+
+
+def _build_client(
+    admin_class: type[ModelAdmin],
+    *,
+    pinned_user: Any | None = None,
+    object_permission_checker: Any | None = None,
+) -> TestClient:
+    """Build a TestClient with ``pinned_user`` attached on every request.
+
+    This mirrors how the live ``AuthenticationMiddleware`` would populate
+    ``request.state.user`` after a successful session lookup.
+    """
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _attach_user(request: Request, call_next: Any) -> Any:
+        request.state.user = pinned_user
+        return await call_next(request)
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    _seed_orders(engine)
+
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
+    options = AdminOptions(object_permission_checker=object_permission_checker)
+    site.register(OrderC3B, admin_class, options=options)
+    admin.mount(path="/admin")
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Story scenario: get_queryset composes ModelAdmin → adapter → SQL
+# ---------------------------------------------------------------------------
+
+
+def test_modeladmin_get_queryset_composes_through_adapter_to_sql() -> None:
+    """
+    Scenario: ModelAdmin.get_queryset(request) flows into the SQL WHERE clause
+      Given a ModelAdmin returns ``{"owner_id": user.id}`` for the active request
+      When  GET /admin/orderc3b is issued by user id=1 (owns 2 of 3 orders)
+      Then  the list contains only that user's rows (other owners are excluded)
+      And   the pagination total reflects the filtered count
+    """
+    # Given a ModelAdmin scoped to request.state.user.id and bob (id=1)
+    client = _build_client(_OwnerScopedAdmin, pinned_user=_User(1))
+
+    # When bob lists orders
+    response = client.get("/admin/orderc3b")
+
+    # Then only his two rows are visible — alice's order is filtered out before SQL
+    assert response.status_code == 200
+    assert "bob-order-A" in response.text
+    assert "bob-order-B" in response.text
+    assert "alice-order-A" not in response.text
+    # And the pagination total reflects the filtered count (2 of 3)
+    assert "of 2 results" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Story scenario: detail view 404s for rows excluded by get_queryset (RLS)
+# ---------------------------------------------------------------------------
+
+
+def test_detail_view_returns_404_when_row_filtered_out_by_modeladmin() -> None:
+    """
+    Scenario: detail view treats rows excluded by get_queryset as nonexistent
+      Given bob's ModelAdmin returns ``{"owner_id": 1}``
+      And   order #40 is owned by alice (owner_id=2)
+      When  bob visits GET /admin/orderc3b/40
+      Then  the response is 404 Not Found (the row is invisible to bob, not just denied)
+    """
+    # Given a request scoped to bob (id=1)
+    client = _build_client(_OwnerScopedAdmin, pinned_user=_User(1))
+
+    # When bob requests alice's order #40 directly by URL
+    response = client.get("/admin/orderc3b/40")
+
+    # Then the row is reported as not found — RLS hides existence, not just access
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Story scenario: 404 (filter) precedes 403 (object permission denial)
+# ---------------------------------------------------------------------------
+
+
+def test_filter_excluded_row_returns_404_even_when_object_checker_would_deny() -> None:
+    """
+    Scenario: queryset filter precedes object-permission check (404 wins over 403)
+      Given bob's ModelAdmin returns ``{"owner_id": 1}``
+      And   the ObjectPermissionChecker would deny order #40 to everyone
+      When  bob visits GET /admin/orderc3b/40 (alice's row)
+      Then  the response is 404 — the row is filtered out before the checker runs
+      (the object-level checker never sees an object it could deny)
+    """
+    # Given an admin filtered to bob and a checker that would deny order #40
+    client = _build_client(
+        _OwnerScopedAdmin,
+        pinned_user=_User(1),
+        object_permission_checker=_BlockSpecificObjectChecker(blocked_id=40),
+    )
+
+    # When bob requests alice's order
+    response = client.get("/admin/orderc3b/40")
+
+    # Then 404 wins — get_queryset hid the row before the checker could deny it
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Story scenario: object-permission 403 fires only on rows the filter let through
+# ---------------------------------------------------------------------------
+
+
+def test_object_permission_denial_returns_403_when_row_passes_queryset_filter() -> None:
+    """
+    Scenario: object-permission denial yields 403 only on rows the filter admits
+      Given bob's ModelAdmin returns ``{"owner_id": 1}``
+      And   the ObjectPermissionChecker would deny order #20 (which bob owns)
+      When  bob visits GET /admin/orderc3b/20
+      Then  the response is 403 — the row passed the filter, then the checker denied
+    """
+    # Given an admin filtered to bob and a checker that denies bob's own #20
+    client = _build_client(
+        _OwnerScopedAdmin,
+        pinned_user=_User(1),
+        object_permission_checker=_BlockSpecificObjectChecker(blocked_id=20),
+    )
+
+    # When bob requests his own (filter-admitted) order #20
+    response = client.get("/admin/orderc3b/20")
+
+    # Then the object-level checker is reached and denies — 403, not 404
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Story scenario: filter + checker both let an owned, allowed row through
+# ---------------------------------------------------------------------------
+
+
+def test_owned_and_allowed_row_is_visible_through_full_stack() -> None:
+    """
+    Scenario: row owned by user AND allowed by object checker is fully visible
+      Given bob's ModelAdmin returns ``{"owner_id": 1}``
+      And   the ObjectPermissionChecker only denies order #40
+      When  bob visits GET /admin/orderc3b/10 (his row, allowed)
+      Then  the response is 200 OK and the row's data is rendered
+    """
+    # Given an admin filtered to bob with a checker that only denies #40
+    client = _build_client(
+        _OwnerScopedAdmin,
+        pinned_user=_User(1),
+        object_permission_checker=_BlockSpecificObjectChecker(blocked_id=40),
+    )
+
+    # When bob requests his own order #10
+    response = client.get("/admin/orderc3b/10")
+
+    # Then the page renders successfully with the row's title
+    assert response.status_code == 200
+    assert "bob-order-A" in response.text

--- a/tests/unit/test_object_permissions.py
+++ b/tests/unit/test_object_permissions.py
@@ -66,10 +66,6 @@ class _OwnerScopedAdmin(ModelAdmin):
         return {"owner_id": user.id}
 
 
-class _DenyOrderForty(_User):
-    """Marker user that triggers the checker to deny order id=40."""
-
-
 class _BlockSpecificObjectChecker:
     """ObjectPermissionChecker that denies access to a specific object id.
 


### PR DESCRIPTION
## Summary

- Add 5 integration-level unit tests in `tests/unit/test_object_permissions.py` covering the full Track A chain: request → `ModelAdmin.get_queryset` → adapter → SQL → view, plus denial precedence between the queryset filter (404) and `ObjectPermissionChecker` (403).
- Add 5 Playwright scenarios in `tests/e2e/test_object_permissions.py` (1:1 with the SDD Track A integration scenarios), each with mandatory inline `# Given / # When / # Then` comments.
- Introduce a dedicated auth-enabled e2e app `tests/e2e/_object_perm_app.py` with two test models — `Order` (only `ObjectPermissionChecker`) and `Document` (only RLS via `get_queryset`) — so each scenario pins down a single enforcement layer.
- Wire a new `object_perm_base_url` fixture in `tests/e2e/conftest.py` and exclude the new test app from the `name-tests-test` pattern.

Closes #482.
Spec: [docs/specs/object-permissions-mfa.md](../blob/develop/docs/specs/object-permissions-mfa.md) — Track A, "Tests" + integration scenarios.

Part of v0.5.1 Cycle 3 — Integration. Closes Track A end-to-end.

## BDD scenario checklist

### E2E (1:1 with SDD Track A integration scenarios)

- [x] staff cannot view another user's record when object permission denies
- [x] object permission check is enforced on update
- [x] object permission check is enforced on delete
- [x] superuser bypasses object-level checks
- [x] get_queryset filters list results visible to non-superuser

### Unit (cross-layer integration scenarios)

- [x] `ModelAdmin.get_queryset(request)` composes through adapter to SQL (list view)
- [x] detail view returns 404 when row filtered out by ModelAdmin
- [x] filter-excluded row returns 404 even when object checker would deny (404 wins)
- [x] object-permission denial returns 403 when row passes queryset filter (403 wins)
- [x] owned and allowed row is fully visible through the full stack

## Test plan

- [x] `uv run poe lint` — all hooks green (ruff, mypy, basedpyright, commitizen, etc.)
- [x] `uv run pytest tests/unit/ --no-cov` — 686 passed
- [x] `uv run pytest tests/e2e/test_object_permissions.py -k object_permissions --no-cov` — 5 passed
- [x] `uv run pytest tests/unit/test_object_permissions.py tests/e2e/test_object_permissions.py --no-cov` — 10 passed
- [ ] Pre-push hook runs full unit + e2e suite — completed during `git push`

## Manual scenarios

1. Log in as `bob`/`secret123` on the example app — model-level permissions remain enforced (no behavioural regression).
2. Configure an `AdminOptions(object_permission_checker=...)` on a `ModelAdmin`; visiting a denied object's detail/edit/delete returns 403.
3. Override `ModelAdmin.get_queryset(request)` to return `{"owner_id": request.state.user.id}`; the list view shows only that user's rows and the pagination total reflects the filtered count.