### PR TITLE
chore(meta): close v0.5.1 milestone — Object Permissions + MFA

### DIFF
--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/epic.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/epic.md
@@ -2,7 +2,7 @@
 type: epic
 id: mmZ2u_cMD2xN
 title: "epic(auth): Object-Level Permissions & MVP OTP/MFA"
-status: todo
+status: done
 priority: medium
 owner: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/docsspec-sdd-for-object-permissions-mfa.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/docsspec-sdd-for-object-permissions-mfa.md
@@ -2,7 +2,7 @@
 type: story
 id: kYChpBCvqQS2
 title: "docs(spec): SDD for object permissions & MFA"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featadapters-add-getqueryset-hook-to-baseadapter-sqlmodelada.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featadapters-add-getqueryset-hook-to-baseadapter-sqlmodelada.md
@@ -2,7 +2,7 @@
 type: story
 id: WSzsCVC1pZgM
 title: "feat(adapters): add get_queryset hook to BaseAdapter + SQLModelAdapter"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-add-mfa-fields-to-user-model.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-add-mfa-fields-to-user-model.md
@@ -2,7 +2,7 @@
 type: story
 id: D5j6fmfAwPOj
 title: "feat(auth): add MFA fields to User model"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-create-emailotpservice.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-create-emailotpservice.md
@@ -2,7 +2,7 @@
 type: story
 id: kdjNeiFT6qZq
 title: "feat(auth): create EmailOTPService"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-create-mfa-challenge-view-and-template.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-create-mfa-challenge-view-and-template.md
@@ -2,7 +2,7 @@
 type: story
 id: CBsaCBKihlPO
 title: "feat(auth): create MFA challenge view and template"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-create-objectpermission-protocol.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-create-objectpermission-protocol.md
@@ -2,7 +2,7 @@
 type: story
 id: 8MZnZcE0N-5N
 title: "feat(auth): create ObjectPermission protocol"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-wire-mfa-into-login-flow-enabledisable-settings.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featauth-wire-mfa-into-login-flow-enabledisable-settings.md
@@ -2,7 +2,7 @@
 type: story
 id: 92AFIIrAK4P3
 title: "feat(auth): wire MFA into login flow + enable/disable settings"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featcore-add-getqueryset-hook-to-modeladmin-base.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featcore-add-getqueryset-hook-to-modeladmin-base.md
@@ -2,7 +2,7 @@
 type: story
 id: i-dtpjuGTmqG
 title: "feat(core): add get_queryset hook to ModelAdmin base"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featcore-add-objectpermissionchecker-to-adminoptions.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featcore-add-objectpermissionchecker-to-adminoptions.md
@@ -2,7 +2,7 @@
 type: story
 id: kZh6EAS_Ij9W
 title: "feat(core): add object_permission_checker to AdminOptions"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featviews-add-object-level-permission-checks-to-detailupdate.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featviews-add-object-level-permission-checks-to-detailupdate.md
@@ -2,7 +2,7 @@
 type: story
 id: 2Nnn8kmJGbD8
 title: "feat(views): add object-level permission checks to detail/update/delete"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featviews-wire-getqueryset-into-listview-detailview.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/featviews-wire-getqueryset-into-listview-detailview.md
@@ -2,7 +2,7 @@
 type: story
 id: ypfwd4OQb8J3
 title: "feat(views): wire get_queryset into list_view + detail_view"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/test-unit-e2e-tests-for-mfa-login-flow.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/test-unit-e2e-tests-for-mfa-login-flow.md
@@ -2,7 +2,7 @@
 type: story
 id: anaYKOBTKNLJ
 title: "test: unit + e2e tests for MFA login flow"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/test-unit-e2e-tests-for-object-level-permissions-rls.md
+++ b/.meta/epics/epicauth-object-level-permissions-mvp-otpmfa/stories/test-unit-e2e-tests-for-object-level-permissions-rls.md
@@ -2,7 +2,7 @@
 type: story
 id: tRQuz_eZrFXy
 title: "test: unit + e2e tests for object-level permissions & RLS"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:

--- a/.meta/roadmap/milestones/v051-object-permissions-mfa.md
+++ b/.meta/roadmap/milestones/v051-object-permissions-mfa.md
@@ -3,7 +3,7 @@ type: milestone
 id: 3cfSqnqrvtDG
 title: v0.5.1 — Object Permissions & MFA
 target_date: 2026-06-29T00:00:00Z
-status: in_progress
+status: done
 github:
   milestone_id: 16
   repo: yevheniidehtiar/hyper-admin


### PR DESCRIPTION
## Summary

Final release PR for v0.5.1. Flips the epic, all 13 stories, and the milestone from `in_progress` → `done` in `.meta/`. No source changes.

## What v0.5.1 delivered

**Track A — Object-level permissions + RLS:**
- `ObjectPermissionChecker` Protocol in `core/auth.py` (#534)
- `BaseAdapter.get_queryset()` + `set_queryset_filter` hook (#535)
- `AdminOptions.object_permission_checker` field (#540)
- `ModelAdmin.get_queryset(request)` hook (#542)
- View-layer wiring (queryset filter ctx mgr + `_check_object_permission`) for list/detail/update/delete (#544)
- Unit + E2E coverage (#547)

**Track B — MVP email-OTP MFA:**
- `User.mfa_enabled` / `User.mfa_method` fields (#537)
- `EmailOTPService` + session-key constants (`OTP_SESSION_KEY`, `PARTIAL_AUTH_SESSION_KEY`) + `RateLimitError` (#539)
- MFA challenge / verify / resend views + template (#541)
- `login_view` MFA branching, partial-auth middleware gate, settings/enable/disable views + template (#545)
- Unit + E2E coverage (#546)

**Plus:**
- v0.5.1 SDD itself (#532), pre-flight cleanups (#533), SDD status flip (#536)
- Story metadata fix (#543)
- v0.5.0 inline cell editing landed alongside (#538)

## Acceptance criteria

- [x] All 13 v0.5.1 implementation stories merged on `develop`
- [x] All BDD scenarios from `docs/specs/object-permissions-mfa.md` covered by unit + E2E
- [x] No regressions — full `poe test:unit` (700+ tests) and `poe test:e2e` green at every cycle gate
- [x] Both tracks backward-compatible (defaults are no-ops; existing apps unchanged)
- [x] `gh api repos/yevheniidehtiar/hyper-admin/milestones/16` reports 0 open issues

## Two follow-up items intentionally deferred

1. **`QuerysetFilter` type-alias hardening** in `core/adapters.py` — flagged by the C1-B reviewer (PR #535) as latent fragility ("not a current breakage"). Move out of `TYPE_CHECKING` so the `__init__` annotation stays robust if `from __future__ import annotations` is ever removed.
2. **`inline_save_view` RLS + object-perm wrapping** in `views/dynamic.py` — flagged by the C2-C reviewer (PR #544). Out of declared #480/#481 scope. Without it, RLS-excluded users can still trigger inline saves.

Both should land as small follow-up PRs after this release closes.

## Unrelated meta-hygiene observation

`gitpm validate` reports 8 errors in `epic-inline-cell-editing/` from PR #538 (stories use `in-progress` instead of `in_progress`, `estimate` as string instead of number). Pre-existing — does not affect this PR. Tracked separately.

## Next milestones unblocked

- **v0.5.2 OAuth/SSO** — partial-auth session pattern + middleware gate are reusable
- **v0.5.3 Multi-tenancy** — `set_queryset_filter` seam ready to consume

## After merge

- Close GitHub milestone 16
- Optional: tag a release if v0.5.1 is the next version cut