### PR TITLE
docs(specs): SDD drafts for v0.7.0/v0.7.1 scalability epics

### DIFF
--- a/docs/specs/adapter-query-performance.md
+++ b/docs/specs/adapter-query-performance.md
@@ -1,0 +1,546 @@
+# SDD: Adapter Query Performance (selectinload, pagination, count, search)
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | #211 |
+| Milestone | v0.7.0 — High-Volume & High-Load Scalability |
+| Created | 2026-05-05 |
+| Last updated | 2026-05-05 |
+
+---
+
+## Problem
+
+HyperAdmin's adapter layer (`SQLModelAdapter`, `SQLAlchemyAdapter`) was designed for ergonomics
+on small/medium datasets and degrades sharply on production-sized tables. The v0.7.0 milestone
+("High-Volume & High-Load Scalability") commits HyperAdmin to working on **10M-row** tables
+under realistic load. Today, four named bottlenecks block that goal:
+
+1. **Unconditional `selectinload` on every relation.** `SQLModelAdapter.list()` walks
+   `mapper.relationships` and adds a `selectinload()` for each one (`adapters/sqlmodel.py:71-72`).
+   On a model with 5 FKs / collections that is **5 extra SELECTs per list request** — every page
+   load — regardless of which relations the table actually displays. There is no opt-out.
+2. **OFFSET-based pagination.** Both adapters use `query.offset((page - 1) * page_size).limit(...)`.
+   At `OFFSET 10_000_000` the database scans 10M rows before returning the page — a linear
+   degradation that no index can fix. Deep pagination is effectively unusable.
+3. **`COUNT(*)` on every list request, never cached.** Both adapters issue a separate
+   `select(func.count())` alongside every list query. On a 10M-row table with non-trivial
+   `WHERE` predicates this costs seconds **per request** and dominates the p99 latency.
+4. **`ILIKE '%search%'` on heuristically-detected string columns.** `SQLAlchemyAdapter.list()`
+   currently **silently ignores the `search_fields` parameter** (`# noqa: ARG002`,
+   `adapters/sqlalchemy.py:51`) and unconditionally `ILIKE`s every `String`/`AutoString` column
+   on the model. On a wide table this means full-table scans across columns the operator never
+   intended to be searchable. `SQLModelAdapter` honours `search_fields` but its default
+   heuristic has the same shape.
+
+`AdminOptions.search_fields` already exists as a config field but only one adapter consumes it.
+There is no way to disable eager relation loading, no caching seam for COUNT, and no cursor /
+keyset pagination support. v0.7.0 cannot meet its load-testing acceptance criteria
+(`epic-locust-load-testing-suite-100-reqs-against-10m-records`) without these four fixes.
+
+## Goals
+
+- **A1 — Configurable selectinload.** Default list views to **load nothing** (no
+  `selectinload`); reduce list-view query count by **at least 5 SELECTs per request** on
+  models with 5+ relations. Provide explicit opt-in (`list_select_related: list[str]`) and an
+  opt-in helper (`auto_select_related=True`) that auto-derives needed relations from
+  `column_list`. Detail view keeps current auto-detect behaviour for backward compatibility.
+- **A2 — Configurable search_fields parity.** `SQLAlchemyAdapter.list()` honours the
+  `search_fields` argument identically to `SQLModelAdapter`. When unset, both adapters fall
+  back to the same heuristic (string columns excluding the primary key) so users get
+  predictable, declarable search scope.
+- **A3 — Opt-in COUNT cache.** Pluggable `CountCache` Protocol in `core/cache.py`. Default
+  in-memory TTL implementation ships in v0.7.0. Cache key is `(model_qualname, filters,
+  search, queryset_filters)` — explicitly excludes pagination/order. With a 30-second TTL on a
+  10M-row dataset, COUNT(*) load drops by **>95%** at sustained 100 req/s.
+- **A4 — Keyset (cursor) pagination.** Opt-in `pagination_mode="cursor"` on `AdminOptions`.
+  Provides **O(log N)** pagination via index seek on `(sort_col, pk)` regardless of depth.
+  Returns opaque base64-urlsafe cursors; falls back to OFFSET when sort target is
+  non-deterministic.
+
+All goals are individually deliverable and pairwise composable.
+
+## Non-Goals
+
+- **Full-text search backends.** `tsvector` (PostgreSQL), MeiliSearch, Typesense, Elastic — all
+  out of scope. A2 only fixes the existing `ILIKE` parity gap.
+- **Distributed cache backend.** `RedisCountCache` is **deferred to v0.8**. The protocol is
+  declared in v0.7.0 so a Redis impl can ship without an SDD revision; only the in-memory
+  backend ships now.
+- **Detail-view selectinload default change.** Detail views keep the current auto-detect
+  behaviour. Changing them risks breaking `__str__` rendering on FK-referenced rows; that
+  is a separate, BC-sensitive design conversation.
+- **Adapter CRUD redesign.** `create()`, `update()`, `delete()`, `get_choices()`,
+  `save_inline_rows()` are untouched.
+- **Schema migrations.** No DB schema changes — every change is in adapter / view / template
+  code or in-memory caches.
+- **Replacing `BaseAdapter.list()` signature.** This SDD adds `list_paginated()` alongside
+  `list()` and deprecates the latter; signature collapse is deferred to v1.0.
+- **Approximate row counts (PG `pg_class.reltuples` / `EXPLAIN`).** Owned by the sibling epic
+  (filter-choice scalability — `BaseAdapter.estimate_row_count()`); A3 here is exact-but-cached.
+
+## BDD Scenarios
+
+Aggregated from stories under
+`.meta/epics/epic-adapter-query-performance-selectinload-pagination-count/stories/`. Per-story
+scenarios remain canonical; this section is the integration-level view used by the
+implementation sub-tasks.
+
+### A1 — Configurable selectinload (#215, #216, #217, #218)
+
+```
+Scenario: list view with default options issues no relation SELECTs
+  Given a Product model with 5 relations and AdminOptions(list_select_related=None)
+  When  GET /admin/product is rendered with 10 rows
+  Then  exactly one SELECT against product is issued
+  And   no SELECT against any relation table is issued
+
+Scenario: list_select_related explicitly loads named relations
+  Given AdminOptions(list_select_related=["category", "vendor"])
+  When  the adapter list() is called
+  Then  selectinload is applied for "category" and "vendor"
+  And   no selectinload is applied for any other relation
+
+Scenario: auto_select_related derives relations from column_list
+  Given AdminOptions(column_list=["name", "category.name"], auto_select_related=True)
+  When  the adapter list() is called
+  Then  selectinload is applied for "category"
+  And   no other relation is loaded
+
+Scenario: detail view preserves auto-detect (backward compatible)
+  Given AdminOptions(detail_select_related=None)
+  When  GET /admin/product/42 is rendered
+  Then  FK relations referenced by __str__ rendering are eagerly loaded
+  And   the rendered template raises no DetachedInstanceError
+```
+
+### A2 — Configurable search_fields (#219, #220, #221, #222)
+
+```
+Scenario: SQLAlchemyAdapter honours search_fields when set
+  Given a User model with columns (name, email, bio) and search_fields=["name", "email"]
+  When  adapter.list(search="alice") is called
+  Then  the WHERE clause ILIKEs name AND email
+  And   the WHERE clause does NOT ILIKE bio
+
+Scenario: search_fields=None uses string-columns-minus-pk heuristic
+  Given a User model and search_fields=None on AdminOptions
+  When  adapter.list(search="alice") is called
+  Then  every string column except the primary key participates in the ILIKE OR-chain
+
+Scenario: search_fields=[] disables search entirely
+  Given AdminOptions(search_fields=[])
+  When  adapter.list(search="alice") is called
+  Then  no ILIKE predicate is added to the WHERE clause
+  And   the search box renders as disabled in the list view
+```
+
+### A3 — COUNT cache (#223, #224, #225)
+
+```
+Scenario: count_cache_ttl=0 disables caching (BC default)
+  Given AdminOptions() with count_cache_ttl=0
+  When  two consecutive list requests with identical filters arrive
+  Then  the database receives two COUNT(*) queries
+
+Scenario: cache hit within TTL serves total without DB round trip
+  Given AdminOptions(count_cache_ttl=30)
+  And   a previous list() populated the cache 5 seconds ago
+  When  list() is called again with identical filters/search/queryset_filters
+  Then  no COUNT(*) query is issued
+  And   the cached total is returned
+
+Scenario: cache miss on differing filters issues a fresh COUNT
+  Given a populated cache for filters={"status": "active"}
+  When  list() is called with filters={"status": "archived"}
+  Then  a COUNT(*) query is issued for the new filter set
+
+Scenario: create/update/delete invalidates the model's count cache
+  Given a populated cache for the Product model
+  When  adapter.create({...}) is called
+  Then  all cache entries scoped to Product are evicted
+  And   the next list() issues a fresh COUNT(*)
+```
+
+### A4 — Keyset cursor pagination (#226, #227, #228, #229, #230)
+
+```
+Scenario: pagination_mode="offset" preserves current behaviour
+  Given AdminOptions(pagination_mode="offset")
+  When  list() is called with page=2, page_size=10
+  Then  the SQL uses OFFSET 10 LIMIT 10
+  And   the response includes total
+
+Scenario: pagination_mode="cursor" uses keyset on (sort_col, pk)
+  Given AdminOptions(pagination_mode="cursor") and order_by="-created_at"
+  When  list_paginated(cursor=None, page_size=10) is called
+  Then  no OFFSET is used
+  And   the WHERE clause is "(created_at, id) < (sentinel, sentinel) ORDER BY created_at DESC, id DESC LIMIT 11"
+  And   the response includes next_cursor and has_next
+
+Scenario: cursor decodes to (pk, sort_col, direction)
+  Given a previous response returned next_cursor="eyJrIjpbNDIs..."
+  When  list_paginated(cursor=next_cursor, page_size=10) is called
+  Then  the WHERE clause filters rows after the cursor's (sort_col, pk) tuple
+  And   results follow the previous page contiguously
+
+Scenario: cursor mode returns total=None
+  Given AdminOptions(pagination_mode="cursor")
+  When  list_paginated() is called
+  Then  the ListResult.total field is None
+  And   the template hides the "X of Y" label
+  And   prev/next links use cursors instead of page numbers
+
+Scenario: cursor mode falls back to offset when sort is non-deterministic
+  Given AdminOptions(pagination_mode="cursor") and no explicit sort
+  And   the model has no obvious deterministic order
+  When  list_paginated() is called
+  Then  the adapter logs a warning
+  And   it transparently uses OFFSET pagination
+
+Scenario: invalid/tampered cursor returns 400
+  Given a malformed cursor "not-base64"
+  When  GET /admin/product?cursor=not-base64
+  Then  the response is 400 with "Invalid pagination cursor"
+```
+
+## Design
+
+### Architecture
+
+```
+                       ┌─────────────────────────────────────┐
+                       │         core/cache.py (NEW)         │
+                       │   CountCache Protocol               │
+                       │   InMemoryTTLCache (default impl)   │
+                       │   (shared with epic #213 SDD —      │
+                       │    filter-choice-scalability.md)    │
+                       └─────────────────────────────────────┘
+                                       ▲
+                                       │ injected into adapters
+                                       │ via AdminOptions
+                                       │
+   ┌──────────────────┐    ┌───────────┴──────────────────┐
+   │ core/options.py  │    │       core/adapters.py       │
+   │ + list_select_   │    │  ListResult dataclass        │
+   │   related        │────► CursorCodec helpers          │
+   │ + detail_select_ │    │ + list_paginated()  (NEW)    │
+   │   related        │    │   list() (DEPRECATED tuple)  │
+   │ + auto_select_   │    │  estimate_row_count()        │
+   │   related        │    │   (epic #213, sibling)       │
+   │ + search_fields  │    └──────────────┬───────────────┘
+   │   (existing)     │                   │
+   │ + count_cache_   │                   │ implements
+   │   ttl            │                   │
+   │ + pagination_    │                   ▼
+   │   mode           │    ┌──────────────────────────────┐
+   └──────────┬───────┘    │ adapters/sqlmodel.py         │
+              │            │ adapters/sqlalchemy.py       │
+              │ consumed   │  (A1) opt-in selectinload    │
+              ▼            │  (A2) honour search_fields   │
+   ┌──────────────────┐    │  (A3) wrap COUNT in cache    │
+   │ views/dynamic.py │    │  (A4) keyset SQL builder     │
+   │ list_view:       │    └──────────────┬───────────────┘
+   │  - calls         │                   │ produces
+   │    list_paginated│                   ▼
+   │  - decodes       │    ┌──────────────────────────────┐
+   │    cursor query  │    │ templates/components/        │
+   │    param         │    │   table.html                 │
+   │  - passes        │◄───│   pagination.html  (UPDATED) │
+   │    select_related│    │   - cursor links when        │
+   └──────────────────┘    │     ListResult.total is None │
+                           │   - page links otherwise     │
+                           └──────────────────────────────┘
+```
+
+The change spans 4 modules (`core/`, `adapters/`, `views/`, `templates/`) but each work item
+A1-A4 layers cleanly on top of the previous one. Implementation order matches the planning
+playbook: `core` → adapters → views → templates.
+
+#### Relationship to sibling SDDs
+
+| SDD | Owns | Shared surface |
+|---|---|---|
+| `adapter-query-performance.md` (this) | `BaseAdapter.list_paginated()`, `count(filters)` (cached, exact), `CountCache` protocol consumer | `core/cache.py` |
+| `filter-choice-scalability.md` (epic #213) | `BaseAdapter.estimate_row_count()` (approximate, no filters), `core/cache.py` module ownership | `core/cache.py` |
+
+`count()` (this SDD) and `estimate_row_count()` (#213 SDD) are intentionally **two different
+methods** — exact-with-filters vs approximate-without-filters — so callers pick the right
+trade-off explicitly. They coexist on the protocol.
+
+### Data Model Changes
+
+No data model changes. Every change is in adapter / view / template code or in-memory caches.
+
+### API / Protocol Changes
+
+#### A1 — Configurable selectinload
+
+`BaseAdapter.list()` and the new `BaseAdapter.list_paginated()` (see A4) accept
+`load_relations: list[str] | None = None`:
+
+```python
+# core/adapters.py
+async def list_paginated(
+    self,
+    *,
+    page: int = 1,
+    page_size: int = 10,
+    cursor: str | None = None,
+    search: str | None = None,
+    filters: dict[str, Any] | None = None,
+    order_by: str | None = None,
+    search_fields: list[str] | None = None,
+    load_relations: list[str] | None = None,
+) -> ListResult: ...
+```
+
+Adapter behaviour:
+
+- `load_relations is None` → **no** `selectinload`. (BREAKING for list path.)
+- `load_relations == []` → no `selectinload` (explicit form of the same).
+- `load_relations == ["category", "vendor"]` → `selectinload(Model.category)`,
+  `selectinload(Model.vendor)`. Unknown relation names raise `ValueError`.
+
+Detail (`get()`) keeps current behaviour — auto-detects FK relations needed by `__str__`
+rendering — controlled separately by `detail_select_related` (semantics: `None` = auto-detect,
+`[]` = none, `[...]` = explicit).
+
+`auto_select_related=True` on `AdminOptions` makes the view layer derive `load_relations` from
+`column_list` entries containing `.` (relation accessors, e.g. `"category.name"` →
+`load_relations=["category"]`).
+
+#### A2 — Configurable search_fields
+
+No protocol change — `search_fields` already lives on `BaseAdapter.list()`. The fix is in
+`SQLAlchemyAdapter.list()` only:
+
+```python
+# adapters/sqlalchemy.py — replace silent ignore
+if search:
+    fields = search_fields if search_fields is not None else self._default_search_fields()
+    if fields:
+        clauses = [getattr(self.model, f).ilike(f"%{search}%") for f in fields]
+        where_conditions.append(or_(*clauses))
+```
+
+`_default_search_fields()` returns string columns excluding PK (matches `SQLModelAdapter._detect_search_fields()` — share the implementation via a small mixin in `adapters/_search.py`).
+
+#### A3 — COUNT cache
+
+New module `src/hyperadmin/core/cache.py` (shared with epic #213):
+
+```python
+@runtime_checkable
+class CountCache(Protocol):
+    async def get(self, key: tuple) -> int | None: ...
+    async def set(self, key: tuple, value: int, ttl: int) -> None: ...
+    async def invalidate_model(self, model_qualname: str) -> None: ...
+
+class InMemoryTTLCache:  # ships in v0.7.0
+    def __init__(self, max_entries: int = 1024) -> None: ...
+    # implements CountCache
+
+# RedisCountCache — declared, NOT shipped in v0.7.0 (deferred to v0.8)
+```
+
+**Cache key shape:**
+```python
+key = (
+    model_qualname,                            # str
+    frozenset((filters or {}).items()),        # frozenset of (col, value)
+    search or "",                              # str — empty string when unset
+    frozenset(queryset_filters.items()),       # RLS / tenant filters
+)
+```
+`page`, `page_size`, `order_by`, `cursor` are **excluded** — they don't affect the count.
+Frozensets require all values to be hashable; non-hashable filter values bypass cache and
+log a debug message.
+
+`BaseAdapter.count(filters=...)` (existing internal — promoted to public) consults the cache
+when `count_cache_ttl > 0`. Adapters call `cache.invalidate_model(self.model.__qualname__)`
+inside `create()`, `update()`, `delete()`. A `BaseAdapter.invalidate_count_cache()` hook lets
+applications clear manually after bulk operations they performed outside the adapter.
+
+#### A4 — Keyset cursor pagination
+
+New `ListResult` dataclass (replaces the `(items, total)` tuple for paginated paths):
+
+```python
+@dataclass
+class ListResult:
+    items: list[Any]
+    total: int | None          # None when pagination_mode == "cursor"
+    next_cursor: str | None
+    prev_cursor: str | None
+    has_next: bool
+    has_prev: bool
+```
+
+**Cursor format** — opaque to clients, versioned for future changes:
+```python
+# JSON payload:
+{"k": [pk_value, sort_col_value], "d": "next" | "prev", "v": 1}
+# Encoded as base64-urlsafe(JSON.dumps(payload).encode()) with no padding.
+```
+Helpers `encode_cursor()` / `decode_cursor()` live in `core/adapters.py` (or
+`core/pagination.py` if the cursor codec grows). Decode raises `InvalidCursorError` on
+malformed input → view layer maps to HTTP 400.
+
+**SQL shape** (cursor mode, ASC sort):
+```sql
+SELECT ... FROM model
+WHERE (sort_col, pk) > (cursor.sort_col, cursor.pk)
+  AND <queryset_filters>
+  AND <user filters>
+  AND <search predicates>
+ORDER BY sort_col ASC, pk ASC
+LIMIT page_size + 1   -- +1 row to detect has_next without an extra query
+```
+
+Fetch `page_size + 1` rows; if the extra row is present, `has_next=True` and the last
+returned row's `(pk, sort_col)` becomes `next_cursor`. `prev_cursor` is the first returned
+row's tuple (with direction `"prev"`).
+
+**Fallback to OFFSET** when:
+- `order_by` is `None` and the model has no obvious deterministic primary sort, OR
+- the sort column is nullable and contains NULLs in a way that breaks tuple ordering, OR
+- `pagination_mode == "offset"` (explicit).
+
+The fallback path emits a `warnings.warn(KeysetFallbackWarning)` so operators learn about it.
+
+### Configuration Changes
+
+New / clarified `AdminOptions` fields:
+
+| Field | Type | Default | BC | Notes |
+|---|---|---|---|---|
+| `list_select_related` | `list[str] \| None` | `None` | **BREAKING** | `None` now = "load nothing" on list path (was "auto-load all"). Document loudly in CHANGELOG. |
+| `detail_select_related` | `list[str] \| None` | `None` | BC | `None` = "auto-detect FK relations needed by `__str__`". Existing implicit behaviour, now explicit. |
+| `auto_select_related` | `bool` | `False` | BC | When `True`, view layer derives `list_select_related` from dotted entries in `column_list`. |
+| `search_fields` | `list[str] \| None` | `None` (existing) | BC | Was a parity bug in `SQLAlchemyAdapter` (silently ignored). After A2, both adapters honour it. |
+| `count_cache_ttl` | `int` (seconds) | `0` | BC | `0` = caching disabled. Must be >= 0. |
+| `pagination_mode` | `Literal["offset", "cursor"]` | `"offset"` | BC | `"cursor"` opts into keyset pagination. |
+
+New global on `Admin()` / `HyperAdminSettings`:
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `count_cache` | `CountCache \| None` | `None` (auto-creates `InMemoryTTLCache` if any model has `count_cache_ttl > 0`) | Inject your own (Redis impl in v0.8) |
+
+No environment-variable surface added in v0.7.0.
+
+### Tests
+
+- **Unit:** `tests/unit/test_selectinload_options.py`, `tests/unit/test_search_fields_parity.py`,
+  `tests/unit/test_count_cache.py`, `tests/unit/test_keyset_pagination.py`.
+  Each file maps 1:1 to one A-track. Coverage target: 99% on new code (per `testing.md`).
+- **E2E:** `tests/e2e/test_keyset_pagination.py` covers pagination_mode="cursor" end-to-end
+  (HTMX page-flip via cursor links). Other tracks are pure-backend and stay unit-tested.
+- **Performance smoke:** A new fixture seeds 10K rows and asserts query counts for A1
+  (≤1 SELECT) and execution-time bounds for A4 (cursor page-100 < 50ms vs offset > 200ms).
+  Full 10M-row validation lives in the sibling Locust epic, not in CI.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| `load_relations=["does_not_exist"]` | Adapter raises `ValueError("Unknown relation: does_not_exist")` at request time. |
+| `auto_select_related=True` with no dotted entries in `column_list` | Derives empty list — no relations loaded. Same as `[]`. |
+| `count_cache_ttl > 0` but `count_cache is None` on `Admin()` | `Admin.__init__` constructs a single `InMemoryTTLCache` instance and binds it to all models. |
+| Cache key contains non-hashable filter value (e.g., a list) | Cache lookup is skipped; a `logger.debug` line records the miss. Correctness > caching. |
+| Cache invalidation across processes | Not supported in v0.7.0 — TTL is the only multi-process correctness boundary. Documented in the migration guide. Redis backend (v0.8) lifts this constraint. |
+| `get_queryset()` (RLS) returns different filters per request | Already part of the cache key — different RLS scopes get different cache entries. No cross-tenant leakage. |
+| Cursor on non-unique sort column | Tuple `(sort_col, pk)` ensures determinism — pk is the tiebreaker. |
+| Cursor on nullable sort column with NULLs | Falls back to OFFSET pagination + warning (NULLs break tuple ordering across DBs differently). |
+| Cursor + `get_queryset()` (RLS) | `get_queryset()` is re-applied on every request — cursor decoding does not bypass RLS. |
+| Cursor encoding mismatch (`v: 2` from a future version) | `decode_cursor` raises `InvalidCursorError` → 400. Forward-compat is via the `v` field. |
+| Many-to-many in `list_select_related` | Supported; SQLAlchemy `selectinload` handles M2M via the secondary table. Documented as opt-in. |
+| User changes `pagination_mode` mid-session | Old in-flight cursor URLs return 400 — acceptable. Documented. |
+| Search across columns of mixed types when `search_fields=None` | Heuristic only picks string-typed columns — non-string columns are silently skipped. |
+
+## Migration & Backward Compatibility
+
+### A1 — selectinload default change is BREAKING (minor-bump justified)
+
+Switching list-view default from "auto-load all relations" to "load nothing" is observably
+different: any template that walks a relation off a list-view item without that relation in
+`list_select_related` will issue a lazy-load (or, with async sessions, raise
+`MissingGreenlet` / `DetachedInstanceError`). Mitigations:
+
+1. **CHANGELOG note** at the top of v0.7.0:
+   *"BREAKING: list views no longer eagerly load all model relations. Add
+   `list_select_related=[...]` (or `auto_select_related=True`) to `AdminOptions` for any
+   relation rendered in `column_list` or list-view templates."*
+2. **Migration guide section** in `docs/migration/v0.7.0.md` walking through the
+   one-line fix per registered model.
+3. **`auto_select_related=True`** as the recommended drop-in for users who do not want to
+   audit each `column_list` manually.
+
+Detail views are **not** affected — `detail_select_related=None` keeps current behaviour.
+
+### A2 — pure bugfix, no migration needed
+
+`SQLAlchemyAdapter` users who relied on the (undocumented) "search every string column"
+behaviour will now see search scoped to `search_fields`. If they had `search_fields=None`,
+the new heuristic ("string columns minus PK") is functionally identical to the old behaviour
+**minus the PK** — operators rarely want to ILIKE-search numeric PKs anyway. Documented in
+the upgrade notes.
+
+### A3 — fully BC (default `count_cache_ttl=0` disables caching)
+
+### A4 — fully BC (default `pagination_mode="offset"`)
+
+### Adapter contract evolution
+
+`BaseAdapter.list()` is **deprecated** in v0.7.0 — it keeps working (returns the same
+`(items, total)` tuple) and emits a `DeprecationWarning` redirecting to `list_paginated()`.
+Removal scheduled for v1.0. Third-party adapters get one cycle to migrate.
+
+`list_paginated()` is added with a default implementation on `BaseAdapter` that calls
+`self.list()` and wraps the tuple in `ListResult(total=..., next_cursor=None,
+prev_cursor=None, has_next=False, has_prev=False)`. Built-in adapters override it with the
+keyset-aware implementation. Third-party adapters keep working unchanged but lose access to
+cursor mode until they override.
+
+## Open Questions
+
+- [ ] **Should `column_list` containing relation accessors auto-trigger
+      `auto_select_related=True`?** Recommended yes for ergonomics — a user writing
+      `column_list=["category.name"]` clearly wants `category` loaded. But silently flipping
+      a default contradicts the BREAKING note we are already issuing for A1. **Proposal:**
+      keep `auto_select_related=False` as the default in v0.7.0 (explicit-is-better-than-
+      implicit), revisit for v0.8 once the explicit migration has settled.
+- [ ] **Cache eviction policy for `InMemoryTTLCache`.** TTL alone or LRU+TTL? On a large
+      site with many distinct filter combinations, pure TTL can balloon. **Proposal:**
+      LRU+TTL with `max_entries=1024` default — bounded memory; tunable via `Admin()`.
+- [ ] **Cursor signing.** Cursors are opaque base64 today but **not signed**. A motivated
+      attacker could craft a tuple to peek at rows ordered around any value. RLS
+      (`get_queryset()`) still applies, so this is not an authz bypass — only a
+      enumeration aid. **Proposal:** ship unsigned in v0.7.0; add HMAC signing in v0.7.1
+      behind a `pagination_cursor_secret` setting if user feedback raises it.
+- [ ] **Should `BaseAdapter.list()` be removed in v1.0 or kept indefinitely?** Removal is
+      cleaner but third-party adapters benefit from a stable shim. **Proposal:** decide at
+      v0.9 retro based on third-party adapter survey.
+
+These must be settled before Status → Approved.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Single umbrella SDD covering A1-A4 | All four touch `BaseAdapter.list()` / `list_paginated()` — splitting would require duplicating the protocol surface across 4 specs. | 4 separate SDDs (rejected — overlapping surface, hard to keep in sync) |
+| List default = "load nothing" (BREAKING) | The status quo is the bug — 5 unconditional SELECTs on every list request is the #1 named bottleneck in the milestone. A pure-additive opt-in fixes nothing for existing users. | Keep "load all" default + add opt-out flag (rejected — does not fix the actual scalability problem; users would not migrate) |
+| Detail default kept as auto-detect | `__str__` rendering breaks if FK relations are not loaded; many users rely on this implicitly. | Apply same BREAKING change to detail (rejected — too disruptive, low scalability payoff vs list path) |
+| `auto_select_related` opt-in (default False) | Avoids a second silently-flipped default; users who want it can flip one boolean. | Default True (rejected — see Open Question 1) |
+| A3 ships in-memory only; Redis deferred to v0.8 | YAGNI — most v0.7.0 deployments are single-process or behind a load balancer with sticky sessions. Redis adds an infra dependency we can't justify yet. | Ship Redis in v0.7.0 (rejected — scope creep; protocol declaration is enough seam) |
+| Cache key excludes pagination params | Pagination doesn't change the count — including page would shatter the cache pointlessly. | Include page (rejected — every page-flip would miss) |
+| `pagination_mode="offset"` default | Cursor changes pagination URL semantics; flipping default would break every bookmarked admin URL. | Default cursor (rejected — observable URL change) |
+| `ListResult` dataclass alongside tuple shape | Lets us evolve the response without re-breaking the tuple contract; `total: None` is the natural cursor-mode signal. | Reuse tuple `(items, total)` with sentinel (rejected — `(items, -1)` is uglier than `total: None`) |
+| Versioned cursor (`v: 1` field) | Forward-compat — we will tighten the shape (signing, additional sort cols) without breaking deployed cursors. | Bare base64 of `(pk, sort_col)` (rejected — no upgrade path) |
+| `count()` and `estimate_row_count()` coexist | Two different trade-offs (exact-with-filters vs approximate-without). One method can't be both. | Single overloaded method (rejected — confusing call site) |
+| `core/cache.py` module shared with epic #213 | Both epics need a generic TTL cache; one module avoids duplication. The module is owned by #213's SDD; this SDD declares only the consumer-facing `CountCache` Protocol shape. | Two separate cache modules (rejected — duplicate eviction logic) |
+| Deprecate `list()` in v0.7.0, remove in v1.0 | One-cycle deprecation respects third-party adapter authors and is the project's stated semver discipline. | Hard-remove in v0.7.0 (rejected — too aggressive for a `0.x.0` minor) |
+| Pagination template logic in `components/pagination.html` | Existing partial included from `components/table.html:44`; cleanest place for cursor/page branching. | New `cursor_pagination.html` partial (rejected — duplicates surrounding markup) |

--- a/docs/specs/filter-choice-scalability.md
+++ b/docs/specs/filter-choice-scalability.md
@@ -1,0 +1,480 @@
+# SDD: Filter & Choice Scalability (FK preload threshold, filter cache)
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | #213 |
+| Milestone | v0.7.0 — High-Volume & High-Load Scalability |
+| Created | 2026-05-05 |
+| Last updated | 2026-05-05 |
+
+---
+
+## Problem
+
+Two long-standing defaults make HyperAdmin unusable on databases of even moderate size, well
+before any "big data" thresholds are reached:
+
+1. **`SelectFieldMeta.preload=True` is the default for FK columns** (see
+   `src/hyperadmin/core/fields.py` line ~154 and `src/hyperadmin/core/choices.py` line ~35).
+   Whenever a form contains a FK to a table with thousands of rows, the entire table is
+   serialised into `<option>` tags inside a single `<select>`. With 50 000 rows this produces a
+   ~2 MB HTML payload and locks the browser for several seconds; with 500 000 rows the page
+   simply never finishes rendering. The HTMX autocomplete widget already exists (epic #159) and
+   `RelationSelectWidget(preload=False)` already supports lazy loading
+   (`src/hyperadmin/views/forms.py` lines 154–200) — but nothing decides *when* to use it.
+
+2. **`build_filter_metadata()` re-fetches all FK reference rows on every list request.**
+   `src/hyperadmin/core/discovery.py` line ~82 calls `target_adapter.list(page_size=1000)` for
+   every FK field declared in `list_filter`, on every render of `list_view`
+   (`src/hyperadmin/views/dynamic.py` line 221). A list page with three FK filters issues
+   3 × `LIMIT 1000` queries against unrelated tables before the actual list query runs —
+   independent of pagination, search, or filters. This metadata is effectively static and
+   identical across users in a single process.
+
+The combined effect is that HyperAdmin's perceived "slow page" cliff arrives at a few thousand
+related rows rather than at any actual scalability bottleneck. Both fixes are local and
+backwards-compatible if defaults are chosen carefully.
+
+## Goals
+
+- **Smart FK preload (C1).** No FK widget renders more than ~500 `<option>` tags by default.
+  When a target table exceeds the configured threshold, the widget transparently downgrades to
+  the existing HTMX autocomplete (`preload=False`) without any change to model definitions or
+  templates.
+- **Filter metadata cache (C2).** `build_filter_metadata()` for a given `(model, fields)` pair
+  is fetched **at most once per TTL window** per process. With the default 60 s TTL, a model
+  list page reloaded ten times in a minute issues zero extra FK reference queries after the
+  first.
+- **One shared cache utility.** A single `src/hyperadmin/core/cache.py` module provides the
+  `cachetools.TTLCache` wrapper used by this epic and by epic #211 (adapter query
+  performance), avoiding two near-identical caches in two different layers.
+- **Operator opt-out is one keyword.** `AdminOptions(preload_threshold=None)` and
+  `AdminOptions(filter_cache_ttl=0)` each restore pre-v0.7.0 behaviour exactly.
+- **No new widgets, no template churn.** All UI changes go through code paths that already
+  exist (`RelationSelectWidget(preload=False)` autocomplete, shipped in epic #159).
+
+## Non-Goals
+
+- **Per-user / per-tenant cache scoping.** Out of scope for v0.7.0; the filter metadata cache
+  is process-global and identical for all users. Multi-tenant filter scoping waits until the
+  multi-tenancy epic provides a `get_queryset()` seam for `build_filter_metadata`.
+- **Distributed cache (Redis / memcached).** Per-process `cachetools.TTLCache` only;
+  Redis-backed cache is deferred to v0.8 alongside other multi-worker primitives.
+- **Search-server integration** (Elasticsearch / Meilisearch / Typesense) for FK autocomplete.
+  Lives behind a separate adapter in a later milestone.
+- **Query-level count caching** for `adapter.list()` / `adapter.count(filters=...)` — owned by
+  epic #211 (story A3). This SDD only ships the table-wide `estimate_row_count()`.
+- **Per-field `SelectFieldMeta.preload_threshold` override.** Model-wide
+  `AdminOptions.preload_threshold` only in v0.7.0; per-field is a forward-compatible additive
+  follow-up.
+- **MySQL `estimate_row_count()` implementation.** Stub raises and falls back to preload — see
+  Open Questions for the deferred work item.
+
+## BDD Scenarios
+
+Aggregated from the v0.7.0 stories under
+`.meta/epics/epic-filter-choice-scalability-fk-preload-threshold-filter-c/stories/`. The story
+files remain the canonical per-task spec; this section is the integration-level view.
+
+```
+Scenario: small FK target table preloads inline
+  Given a model with an FK to a Country table containing 50 rows
+  And   AdminOptions.preload_threshold = 500 (default)
+  When  the create form is rendered
+  Then  the response contains a <select> with 50 <option> tags
+  And   no /choices/ HTMX endpoint is called
+
+Scenario: large FK target table downgrades to HTMX autocomplete
+  Given a model with an FK to a User table containing 50_000 rows
+  And   AdminOptions.preload_threshold = 500 (default)
+  When  the create form is rendered
+  Then  the rendered widget is the lazy RelationSelectWidget (preload=False)
+  And   the response contains zero <option> tags from the User table
+  And   the widget has hx-get pointing at /<model>/choices/<rel>
+
+Scenario: opt-out preserves pre-v0.7.0 behaviour
+  Given a model with an FK to a User table containing 50_000 rows
+  And   AdminOptions.preload_threshold = None
+  When  the create form is rendered
+  Then  all 50_000 users are emitted as <option> tags
+  And   no estimate_row_count query is issued for the User table
+
+Scenario: adapter without estimate_row_count falls back to preload
+  Given a custom out-of-tree adapter that does not override estimate_row_count
+  When  _build_relation_widgets resolves a relation widget for that adapter
+  Then  estimate_row_count raises NotImplementedError
+  And   the widget is built with preload=True (assume small)
+  And   no exception propagates to the request handler
+
+Scenario: filter metadata is cached within the TTL window
+  Given AdminOptions.filter_cache_ttl = 60
+  And   list_view has been rendered once for OrderAdmin
+  When  list_view is rendered again 30 seconds later
+  Then  build_filter_metadata is NOT called a second time
+  And   the cached metadata is reused
+
+Scenario: filter metadata is refreshed after TTL expiry
+  Given AdminOptions.filter_cache_ttl = 60
+  And   list_view has been rendered once for OrderAdmin
+  When  list_view is rendered again 90 seconds later
+  Then  build_filter_metadata is called a second time
+  And   the cache entry is replaced
+
+Scenario: filter cache disabled bypasses lookup entirely
+  Given AdminOptions.filter_cache_ttl = 0
+  When  list_view is rendered twice in succession
+  Then  build_filter_metadata is called twice
+  And   no entry is written to the TTL cache
+
+Scenario: estimate_row_count never-analyzed Postgres table falls back to COUNT(*)
+  Given a freshly created Postgres table with reltuples = -1
+  When  estimate_row_count() is awaited on its adapter
+  Then  the adapter executes SELECT COUNT(*) FROM <table>
+  And   the returned value is the exact row count
+```
+
+## Design
+
+### Architecture
+
+```
+                       ┌──────────────────────────────────────┐
+                       │       core/cache.py    (NEW)         │
+                       │  cachetools.TTLCache wrapper         │
+                       │  - filter_metadata_cache (this SDD)  │
+                       │  - count_cache           (epic #211) │
+                       │  - clear_*() helpers                 │
+                       └──────────┬───────────────────────────┘
+                                  │ used by
+                ┌─────────────────┴─────────────────────────┐
+                │                                           │
+                ▼                                           ▼
+   ┌──────────────────────────────┐         ┌──────────────────────────────┐
+   │   core/discovery.py          │         │   core/options.py            │
+   │   build_filter_metadata()    │         │   AdminOptions               │
+   │   wrapped with TTLCache      │         │   + preload_threshold: int|None│
+   │   key=(model_qualname,       │         │   + filter_cache_ttl: int    │
+   │        tuple(sorted(fields)))│         └──────────────────────────────┘
+   └──────────────┬───────────────┘                       │
+                  │ called by                             │ read by
+                  ▼                                       ▼
+       ┌──────────────────────────────────────────────────────────┐
+       │                  views/dynamic.py                        │
+       │  list_view → _get_filter_metadata (cached)               │
+       │  _build_relation_widgets:                                │
+       │    1. resolve target_adapter via adapter_registry        │
+       │    2. count = await target_adapter.estimate_row_count()  │
+       │       (per-request memo dict[model, int])                │
+       │    3. if meta.preload and threshold and count >= threshold:│
+       │           meta = replace(meta, preload=False)            │
+       └──────────────────────────────────┬───────────────────────┘
+                                          │ uses
+                                          ▼
+       ┌────────────────────────────────────────────────────────┐
+       │                core/adapters.py                        │
+       │  BaseAdapter.estimate_row_count() -> int               │
+       │  default: raise NotImplementedError                    │
+       └──────────────────────────────────┬─────────────────────┘
+                                          │ overridden by
+            ┌─────────────────────────────┼─────────────────────────────┐
+            ▼                             ▼                             ▼
+   adapters/sqlmodel.py        adapters/sqlalchemy.py        third-party adapters
+   - Postgres: pg_class.       (mirrors sqlmodel impl)        (no override = fallback)
+     reltuples (regclass)
+     fallback COUNT(*) if -1
+   - SQLite:  COUNT(*)
+   - MySQL:   raise NotImpl
+              (deferred)
+```
+
+The two stories within this epic are independent in the dependency graph — C1 and C2 touch
+disjoint code paths and ship in either order. They share `core/cache.py` only via C2; C1 does
+not require the cache at all (`estimate_row_count` is invoked once per relation per request).
+
+### Data Model Changes
+
+No data model changes. No migrations. `estimate_row_count` reads system catalogs
+(`pg_class`) on Postgres and runs a plain `COUNT(*)` on SQLite — no application schema is
+touched.
+
+### API / Protocol Changes
+
+#### `core/cache.py` (new module)
+
+Single utility module shared with epic #211. Module-level singletons; no class hierarchy.
+
+```python
+# src/hyperadmin/core/cache.py
+from __future__ import annotations
+
+from typing import Any
+from cachetools import TTLCache
+
+# Filter metadata cache (this SDD). Default TTL=60s; AdminOptions.filter_cache_ttl
+# overrides per-request via the wrapper helper, not by mutating the TTLCache.
+_FILTER_METADATA_MAXSIZE = 128
+filter_metadata_cache: TTLCache[tuple[str, tuple[str, ...]], list[dict[str, Any]]] = TTLCache(
+    maxsize=_FILTER_METADATA_MAXSIZE,
+    ttl=60,
+)
+
+def clear_filter_metadata_cache() -> None:
+    """Drop all cached filter metadata. Used by tests and admin tooling."""
+    filter_metadata_cache.clear()
+
+# Count cache slot reserved for epic #211 (adapter query performance / story A3).
+# Declared here so the two epics share one module rather than duplicating wrappers.
+```
+
+The cache is a single module-level `TTLCache` instance. `cachetools.TTLCache` is not natively
+asyncio-aware; we rely on `asyncio.run`'s single-threaded event-loop semantics — every cache
+mutation happens inside the running coroutine on the loop's thread (no executor offload), so
+no lock is required for one uvicorn worker. Multi-worker deployments get one cache per worker
+(documented; pluggable backend deferred to v0.8).
+
+#### `BaseAdapter.estimate_row_count()`
+
+Distinct from epic #211's `BaseAdapter.count(filters=...)`. The two methods serve different
+purposes and must not be confused:
+
+| Method | Scope | Accuracy | Cost | Purpose |
+|---|---|---|---|---|
+| `estimate_row_count()` (this SDD) | whole table | approximate (planner stats) | O(1) | preload-vs-autocomplete decision |
+| `count(filters=...)` (epic #211) | filtered query | exact | O(rows scanned) | pagination total |
+
+```python
+# src/hyperadmin/core/adapters.py
+class BaseAdapter(ABC):
+    ...
+    async def estimate_row_count(self) -> int:
+        """Return an approximate row count for ``self.model``'s underlying table.
+
+        Used to decide whether an FK widget should preload all options or fall back
+        to lazy HTMX autocomplete. Implementations should prefer cheap planner
+        statistics (e.g. PostgreSQL ``pg_class.reltuples``) over a real ``COUNT(*)``,
+        and may return -1 or raise :class:`NotImplementedError` when no estimate is
+        available.
+
+        The default implementation raises :class:`NotImplementedError` so that
+        third-party adapters that do not override it preserve pre-v0.7.0 behaviour
+        (the view layer falls back to ``preload=True``).
+
+        Returns:
+            An approximate, non-negative row count. Callers must treat the value as
+            advisory only and not depend on exactness.
+        """
+        raise NotImplementedError
+```
+
+##### Postgres implementation (`adapters/sqlmodel.py`, mirrored in `adapters/sqlalchemy.py`)
+
+```python
+async def estimate_row_count(self) -> int:
+    table = self.model.__tablename__
+    async with self.engine.connect() as conn:
+        # Use parameterized regclass cast — never f-string the table name into SQL.
+        result = await conn.execute(
+            text("SELECT reltuples::bigint FROM pg_class WHERE oid = :tbl::regclass"),
+            {"tbl": table},
+        )
+        row = result.scalar_one_or_none()
+        if row is None or row < 0:
+            # reltuples = -1 on never-analyzed tables; fall back to exact count.
+            result = await conn.execute(text(f"SELECT COUNT(*) FROM {quoted(table)}"))
+            return int(result.scalar_one())
+        return int(row)
+```
+
+The `quoted(table)` step uses SQLAlchemy's `Identifier`-equivalent quoting via
+`sa.sql.quoted_name(table, quote=True)` — never raw f-string interpolation. SQLite uses a
+plain `SELECT COUNT(*)` (it has no row-estimate catalog and reference tables on SQLite are
+small enough that the linear scan is acceptable for dev workflows). MySQL is deliberately not
+implemented: the default `NotImplementedError` triggers the safe-preload fallback for any
+deployment we do not yet support.
+
+#### `_build_relation_widgets` integration
+
+```python
+# src/hyperadmin/views/dynamic.py
+async def _build_relation_widgets(
+    self,
+    field_names: list[str],
+    selected_values: dict[str, Any] | None = None,
+) -> dict[str, HtmxWidget]:
+    threshold = self.options.preload_threshold  # int | None
+    row_count_memo: dict[type, int | None] = {}  # per-request cache
+    ...
+    for name, field_info in self.model.model_fields.items():
+        ...
+        if meta.preload and threshold is not None:
+            target_model = _resolve_target_model(self.model, name)  # via mapper
+            if target_model is not None:
+                count = row_count_memo.get(target_model, _SENTINEL)
+                if count is _SENTINEL:
+                    target_adapter_cls = adapter_registry.find_adapter_for_model(target_model)
+                    target_adapter = target_adapter_cls(target_model, self.adapter.engine)
+                    try:
+                        count = await target_adapter.estimate_row_count()
+                    except NotImplementedError:
+                        count = None
+                    row_count_memo[target_model] = count
+                if count is not None and count >= threshold:
+                    meta = replace(meta, preload=False)
+        ...
+```
+
+Memoising per request keeps `_build_relation_widgets` O(distinct relation targets) for the
+estimate call rather than O(fields), which matters for forms with many FKs to the same model.
+
+#### `build_filter_metadata` cache wrapper
+
+```python
+# src/hyperadmin/core/discovery.py
+async def build_filter_metadata(
+    model: Any,
+    field_names: list[str],
+    adapter: Any,
+    *,
+    cache_ttl: int = 60,
+) -> list[dict[str, Any]]:
+    if cache_ttl == 0:
+        return await _build_filter_metadata_uncached(model, field_names, adapter)
+
+    key = (f"{model.__module__}.{model.__qualname__}", tuple(sorted(field_names)))
+    cached = filter_metadata_cache.get(key)
+    if cached is not None:
+        return cached
+    metadata = await _build_filter_metadata_uncached(model, field_names, adapter)
+    filter_metadata_cache[key] = metadata
+    return metadata
+```
+
+The signature gains a single keyword-only `cache_ttl` argument; the body of the original
+function is renamed to `_build_filter_metadata_uncached`. Callers in `views/dynamic.py` pass
+`self.options.filter_cache_ttl`. `cache_ttl=0` short-circuits both the cache lookup and the
+write — no entry is created, no TTL fires, the call behaves exactly like pre-v0.7.0.
+
+Cache key choice (`model_qualname`, `tuple(sorted(field_names))`) intentionally **does not**
+include request-scoped state (user, query params, session). The metadata is the same for all
+users — every FK target list is fetched up to 1000 rows regardless of caller — so per-user
+keys would only fragment the cache. When multi-tenant filter scoping arrives, this key
+becomes `(model_qualname, fields, tenant_id)` via a project-supplied scope function; the
+extension is additive.
+
+### Configuration Changes
+
+Two new fields on `AdminOptions`:
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `preload_threshold` | `int \| None` | `500` | If a relation target table has at least this many rows, the FK widget switches from preload to lazy HTMX. `None` disables the auto-downgrade and preserves pre-v0.7.0 behaviour. Units = rows. |
+| `filter_cache_ttl` | `int` | `60` | Seconds to cache `build_filter_metadata` output per `(model, fields)`. `0` disables the cache (lookup is skipped entirely — short-circuit). |
+
+Per-`SelectFieldMeta` overrides (`preload_threshold` per field) are deliberately deferred —
+the field already has `preload: bool`, and a later release can extend it with
+`preload_threshold: int | None = None` (additive, no BC break).
+
+`pyproject.toml` gains one runtime dependency:
+
+```toml
+dependencies = [
+  ...
+  "cachetools>=5",
+]
+```
+
+`cachetools>=5` is a tiny pure-Python package (~30 KB) with no transitive deps; the lower
+bound matches the API used (`TTLCache.maxsize`, `TTLCache.ttl`).
+
+### Tests
+
+- **Unit:**
+  - `tests/unit/test_estimate_row_count.py` — Postgres `reltuples`, never-analyzed fallback,
+    SQLite count, MySQL stub, `BaseAdapter` raises by default.
+  - `tests/unit/test_preload_threshold.py` — small/large/opt-out paths, per-request memo,
+    fallback to preload on `NotImplementedError`.
+  - `tests/unit/test_filter_metadata_cache.py` — cache hit within TTL, refresh after TTL,
+    `cache_ttl=0` skip path, key = `(qualname, sorted_fields)`, `clear_filter_metadata_cache`.
+- **E2E:** `tests/e2e/test_fk_preload_threshold.py` — large FK renders autocomplete; small FK
+  renders inline `<select>`; `data-testid` selectors only; opt-out scenario.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Postgres `reltuples = -1` (never analyzed) | Fallback to exact `SELECT COUNT(*)` once; result returned as the estimate. Cost is bounded because this only happens on tables that have never been written to. |
+| `pg_class` regclass cast failure (table dropped, schema mismatch) | `NotImplementedError`-equivalent — the `_build_relation_widgets` try/except path treats it as "estimate unavailable" and keeps `preload=True`. Logs a warning. |
+| Table name with mixed case / quoted identifier | Use SQLAlchemy `quoted_name(..., quote=True)` for the COUNT(*) fallback; the `:tbl::regclass` parameterised cast handles the lookup correctly. Never f-string `__tablename__` into SQL. |
+| Multi-tenant `get_queryset` filters not applied to filter metadata | **Known limitation.** `build_filter_metadata` fetches up to 1000 of every FK target globally, ignoring the caller's `get_queryset` scope. Tracked for the multi-tenancy epic; documented in the changelog and adapter docstring. Practical impact in v0.7.0: a tenant-scoped filter dropdown may show options the user cannot actually filter to. Mitigation today: set `list_filter=[]` on tenant-scoped models. |
+| Adapter without `estimate_row_count` (out-of-tree custom adapter) | Default `BaseAdapter.estimate_row_count` raises `NotImplementedError`. View catches and treats the relation as "assume small" → `preload=True`. Behaviour is identical to v0.6.x for these adapters. |
+| `preload_threshold=None` set globally | Skip the `estimate_row_count` call entirely (zero-overhead opt-out). Existing `preload` defaults are honoured. |
+| `filter_cache_ttl=0` | Short-circuit both the cache lookup and write; no entry is created and nothing expires. Behaviour identical to v0.6.x. |
+| TTLCache thread-safety in async context | `cachetools.TTLCache` is not lock-free, but a single uvicorn worker runs one event loop on one thread, and all cache mutations happen on coroutine resumption (no `run_in_executor`). Single-worker deployments are safe; multi-worker deployments get one cache per worker (acceptable — staleness window already ≤ TTL). |
+| Cache key collision across module reloads / hot reload | Key includes `model.__module__ + model.__qualname__`, so a reload that produces a fresh class object generates a fresh key automatically. Stale entries from the previous class age out within TTL. |
+| Mutations to FK reference tables during a TTL window | **Not invalidated.** Staleness is bounded by `filter_cache_ttl` (default 60 s). Documented; mutation-driven invalidation deferred (see Decision Log). |
+| `find_adapter_for_model` returns `None` for the relation target | Treat as "estimate unavailable" → keep `preload=True`. Already the contract followed by `discovery.py`. |
+| Concurrent first writes to the cache (cold cache, two requests in parallel) | Both compute and both write the same value; last-writer-wins. Outcome is correct, cost is one redundant query per cold start. Acceptable. |
+
+## Migration & Backward Compatibility
+
+- **One behavioural default changes.** With `preload_threshold=500` (the new default), an FK
+  to a table with ≥ 500 rows now renders as an HTMX autocomplete widget instead of a giant
+  `<select>`. The autocomplete widget already shipped in epic #159 (v0.4.x) — this SDD only
+  reaches it via the threshold logic. UI styling, DOM structure, and data-testid IDs of the
+  autocomplete are unchanged.
+- **Opt-out is one keyword.** `AdminOptions(preload_threshold=None)` restores pre-v0.7.0
+  behaviour exactly. Documented prominently in the v0.7.0 CHANGELOG.
+- **No DB migration.** No new columns, no new tables, no new indexes.
+- **No public API removals or renames.** `__init__.py` exports gain no new symbols (the cache
+  utility is private to `core/`). The new `BaseAdapter.estimate_row_count` lands with a
+  default that raises `NotImplementedError`, so out-of-tree adapters keep working — the view
+  layer detects the exception and falls back to today's preload behaviour.
+- **`cachetools` becomes a runtime dependency.** Single new dep, ~30 KB, pure-Python, zero
+  transitive deps. Lower bound `>=5` matches the API used.
+- **`SelectFieldMeta.preload` default stays `True`.** No widget defaults change. The
+  threshold logic operates *over* `meta.preload` and only narrows it from `True` to `False`
+  when warranted; widgets that opt into `preload=False` directly are untouched.
+- **No semver-major bump.** Behaviour change is opt-out and additive; everything else is
+  additive. Targeted at the v0.7.0 minor release.
+
+## Open Questions
+
+- [ ] **MySQL `estimate_row_count` implementation.** `information_schema.TABLES.TABLE_ROWS`
+      is the obvious source on MySQL/MariaDB but is famously inaccurate on InnoDB (off by
+      orders of magnitude on busy tables). Two options:
+      (a) ship the InnoDB approximation now with a documented caveat; or
+      (b) leave the stub raising `NotImplementedError` and file a follow-up.
+      **Proposal:** (b) — defer until a concrete user reports needing it, since the safe
+      fallback (assume small, preload) preserves correctness.
+- [ ] **`filter_cache_ttl=0` semantics: short-circuit vs immediate-expire?** Current proposal
+      is short-circuit (skip lookup and write entirely). Alternative is to set TTL=0 on the
+      cache and rely on `cachetools`' eviction. Short-circuit is preferable: it is one fewer
+      hash op, makes the disabled path obviously zero-overhead, and prevents the cache from
+      ever holding entries an operator believes are disabled. **Proposal:** short-circuit.
+- [ ] **Should `filter_cache_ttl` also gate per-relation FK option fetches?**
+      `build_filter_metadata` itself calls `target_adapter.list(page_size=1000)` per FK; the
+      proposed cache wraps the *outer* function so all FK fetches are amortised together. A
+      finer-grained cache (per FK target) would help models that share FK targets across
+      filters. **Proposal:** ship the outer cache only; revisit if profiling shows benefit.
+
+These must be settled (or explicitly deferred) before Status → Approved.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| New module `src/hyperadmin/core/cache.py` owned by this SDD, shared with epic #211 | Avoids two near-identical TTLCache wrappers in two layers; single place to evolve cache semantics (Redis backend, instrumentation). Decided here so #211 (count cache) plugs in additively. | Per-feature cache modules (more duplication, two test fixtures, two docs sections) |
+| `cachetools>=5` as a runtime dep | ~30 KB pure-Python, zero transitive deps, battle-tested `TTLCache` with the exact semantics needed. Writing our own TTL eviction is gratuitous. | Hand-rolled `dict` + monotonic timestamps (more code, more bugs); `functools.lru_cache` (no TTL) |
+| `AdminOptions.preload_threshold: int \| None = 500`, model-wide only | Single dial covers the 95% case (form-wide policy). Per-field override is purely additive on `SelectFieldMeta` and can land later without a BC break. | Per-field `SelectFieldMeta.preload_threshold` (more surface, no concrete user need today); global `HyperAdminSettings` knob (too coarse, hard to opt model in/out) |
+| Default threshold = 500 | 500 `<option>` tags is roughly the upper bound of "still snappy" in modern browsers; below it, preload is faster than the HTMX round-trip. Conservative enough to be safe; tight enough to actually fire on the problem cases. | 100 (too aggressive — common FK tables hit it); 1000 (matches the page_size cap but doesn't actually solve the slow-page problem) |
+| `BaseAdapter.estimate_row_count()` default raises `NotImplementedError` | Out-of-tree adapters that pre-date v0.7.0 keep working unchanged (view layer catches and falls back to preload). Forces tree adapters to opt in. | Default returning `0` (would silently force everyone into autocomplete); abstract method (would break existing custom adapters on upgrade) |
+| Postgres impl uses `pg_class.reltuples` with `:tbl::regclass` parameterised cast | O(1), no table scan, accurate enough for the threshold decision. Parameterised regclass cast eliminates SQL injection from `__tablename__`. Fallback to `COUNT(*)` only when `reltuples = -1` (never analyzed) preserves correctness on fresh tables. | `COUNT(*)` always (defeats the optimisation); `pg_stat_user_tables.n_live_tup` (similar but requires stats collector to be running, less universally available) |
+| `estimate_row_count` is distinct from epic #211's `count(filters=...)` | Different scope (whole table vs filtered query), different accuracy (approximate vs exact), different cost (O(1) vs O(rows)). Conflating them would either force exact counts here (slow) or approximate counts there (incorrect pagination). | Single `count()` method (rejected — semantics conflict) |
+| Filter metadata cache key = `(model_qualname, tuple(sorted(field_names)))` | `build_filter_metadata` does not vary on user, query params, or filters today — every render fetches up to 1000 of every FK target globally. Per-user keys would only fragment the cache without changing output. Sorted field names normalise call ordering. | Include user/tenant in the key (no current variance, would be cache pollution); include query params (same — no variance) |
+| Time-based invalidation only; no mutation hooks | Mutation-driven invalidation requires hooking every adapter `create`/`update`/`delete` for every FK target — a significant invasion for a 60 s staleness window that is already shorter than typical reference-data churn. Operators who need fresher data set `filter_cache_ttl` lower. | Hook into adapter mutations to evict (more complex, leaks coupling between adapter and discovery); event-bus (out of scope) |
+| Per-process cache (one `TTLCache` per uvicorn worker) | Single-worker deployments are unaffected; multi-worker deployments get N independent caches with bounded staleness ≤ TTL — same correctness guarantee, just more redundant queries on cold start. Distributed cache is a v0.8 concern alongside other shared-state primitives. | Redis-backed cache (out of scope; deferred); inter-process shared memory (operationally heavy, brittle on restart) |
+| `filter_cache_ttl=0` short-circuits the lookup | Operationally clearest semantics: "0 = off, no entries created, no TTL ever fires". One hash op cheaper than the `TTL=0` eviction path. | Set TTL to 0 on the underlying cache (entries created and immediately evicted — same end result, more code paths) |
+| Per-request `dict[model, int]` memo for `estimate_row_count` in `_build_relation_widgets` | Forms with multiple FKs to the same target (e.g. two `created_by` / `updated_by` user FKs) issue one estimate call rather than N. Per-request scope avoids cross-request leakage. | No memo (re-issues the catalog query per FK — cheap on Postgres but not free); module-level cache for `estimate_row_count` (longer staleness, harder to test) |
+| MySQL impl deferred (raise) | Safe fallback (assume small, preload) preserves correctness; no current user has reported needing it; `information_schema.TABLES.TABLE_ROWS` is famously inaccurate on InnoDB and would need a tunable fallback. | Ship a best-effort impl now (more surface, more edge cases, no concrete demand) |

--- a/docs/specs/synthetic-data-generator.md
+++ b/docs/specs/synthetic-data-generator.md
@@ -1,0 +1,392 @@
+# SDD: Synthetic Data Generator (Faker + Bulk Inserts for 10M+ Records)
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | #246 |
+| Milestone | v0.7.1 — Load Testing & Synthetic Data |
+| Created | 2026-05-05 |
+| Last updated | 2026-05-05 |
+
+---
+
+## Problem
+
+The current `examples/erp/seed.py` script issues per-row inserts via the SQLModel session. In
+practice this clocks in at **~10–50 inserts/sec** on PostgreSQL — so seeding even a single
+million rows takes hours, and 10M is a non-starter. That is fine for a "five demo invoices"
+dev fixture, but it is the wrong tool for the workloads now coming online in v0.7.0:
+
+- **#211 (server-side pagination at 1M+ rows)** needs realistic, non-trivially-distributed
+  datasets to expose query-plan regressions and pagination edge cases.
+- **#213 (admin list-view scalability targets)** asks for `<200 ms` p95 on tables of 10M rows.
+  Both issues need a way to *produce* such tables in CI and on developer machines without
+  borrowing production data.
+
+There is no second concern bigger than throughput: foreign-key referential integrity has to
+hold across millions of rows, and the distribution of FK references must be **skewed** (a few
+"hot" parents own most of the children, mirroring real systems) so the benchmarks remain
+representative. A uniform-random FK pool would understate index seek cost and cache pressure.
+
+Without a dedicated bulk seeder, every scalability story in v0.7.0 either invents an ad-hoc
+script or runs against unrealistic data. Both paths waste agent time and produce benchmark
+numbers we cannot trust.
+
+## Goals
+
+- **Throughput:** sustained **50K–100K inserts/sec on PostgreSQL** as the aspirational target.
+  The SQLAlchemy Core baseline (~30K/s on a developer laptop) is the **acceptable v0.7.1
+  ship floor**; faster fast-paths are deferred (see Decision Log).
+- **FK referential integrity:** every child row references a parent row that exists, even when
+  parents and children are inserted in separate batches.
+- **Realistic skew:** FK references follow a **Pareto distribution** (`a=1.16`, ≈80/20 rule)
+  so a small subset of accounts owns most invoices, mirroring real ERP shapes.
+- **Resumability:** Ctrl-C or process kill can be resumed from the last completed batch
+  without producing duplicate rows or leaving orphan FKs.
+- **Observability:** Rich progress UI with per-table progress bars, ETA, throughput
+  (rows/sec), and total elapsed time.
+- **CLI ergonomics:** a single `hyperadmin seed --count N` command drives the full plan; no
+  per-table invocation.
+- **Determinism:** default RNG seed = `42` so CI runs are byte-reproducible.
+- **No new runtime dependencies:** numpy is a *soft* dependency with a stdlib fallback;
+  Faker is already a dev dep.
+
+## Non-Goals
+
+- **Auto-discovery of arbitrary user models** from SQLModel metadata. v0.7.1 ships a
+  hard-coded ERP plan; generic discovery is deferred to **v0.8**.
+- **MySQL / MariaDB tuning.** PostgreSQL is the v0.7.0/v0.7.1 reference target. SQLite is
+  supported via param-limit shrinking but is not benchmarked.
+- **UI-triggered seeds.** The seeder is a CLI/operator tool. There is no `/admin/seed` button.
+- **Replacing the superuser bootstrap.** `examples/erp/seed.py` keeps its existing role of
+  creating the demo superuser; the bulk seeder is *additive*.
+- **COPY / `psycopg.copy_expert` fast path** in v0.7.1. Considered and deferred (see
+  Decision Log).
+- **Spill-to-disk FK pools** for >100M-row parents. Pools are in-memory `dict[str, list[int]]`
+  in v0.7.1; a DB-backed pool is future work if benchmarks demand it.
+- **Multi-process / multi-worker parallel seeding.** Single-process producer/consumer is
+  enough to hit the throughput floor; parallelism is deferred.
+
+## BDD Scenarios
+
+```
+Scenario: bulk seed produces N rows across the ERP plan
+  Given a fresh PostgreSQL database with the ERP schema migrated
+  When  `hyperadmin seed --count 10000 --batch-size 5000` is run
+  Then  the process exits 0
+  And   each ERP table contains its planned share of the 10000 rows
+  And   the Rich progress UI reports a final throughput >= 10000 rows / elapsed_seconds
+
+Scenario: foreign-key integrity is preserved across batches
+  Given the ERP plan inserts Accounts before Invoices
+  When  the seeder commits an Invoices batch
+  Then  every invoice.account_id row exists in the Accounts table
+  And   no batch is committed before its parents' FK pool is populated
+
+Scenario: Ctrl-C mid-run resumes from the last completed batch
+  Given the seeder is mid-run with 6 of 20 batches committed
+  When  the operator sends SIGINT
+  And   re-runs `hyperadmin seed --count N --resume`
+  Then  the run continues from batch 7
+  And   the final row count equals N (no duplicates, no gaps)
+  And   `.hyperadmin-seed.json` is removed on clean completion
+
+Scenario: FK reference distribution follows the configured Pareto skew
+  Given a seed with 1000 Accounts and 100000 Invoices
+  When  invoice.account_id values are tallied
+  Then  the top 20% of accounts own ~80% of invoices (within +/- 5%)
+  And   no account_id is referenced more often than mathematically possible
+
+Scenario: schema-drift on resume aborts cleanly
+  Given a checkpoint file written for plan_hash A
+  And   the loaded plan now hashes to B
+  When  `hyperadmin seed --resume` is invoked
+  Then  the seeder exits non-zero with a clear "plan hash mismatch" message
+  And   no rows are written
+
+Scenario: unique-constraint exhaustion does not deadlock the run
+  Given a column with a UNIQUE constraint and a small Faker value space
+  When  a generated batch would collide with an existing row
+  Then  the batch is regenerated with a per-batch sequence prefix
+  And   the run continues without manual intervention
+```
+
+## Design
+
+### Architecture
+
+A new top-level module `src/hyperadmin/loadtest/` owns the seeder. It is independent of the
+admin core (no `Admin()` coupling) and consumed only by the new Typer subcommand and by
+`examples/erp/seed.py`'s superuser bootstrap.
+
+```
+src/hyperadmin/
+├── loadtest/                          (NEW MODULE)
+│   ├── __init__.py                    # Public API: BulkSeeder, SeedPlan, FKPool
+│   ├── plan.py                        # SeedPlan, TablePlan dataclasses + plan_hash()
+│   ├── pool.py                        # FKPool with Pareto sampling
+│   ├── batch.py                       # BulkSeeder: generator → batch → insert loop
+│   ├── progress.py                    # Rich progress wrapper (lazy import)
+│   ├── checkpoint.py                  # JSON state file: write/read/validate
+│   └── generators/
+│       ├── __init__.py
+│       ├── erp.py                     # Hard-coded ERP plan (Accounts → ... → Lines)
+│       └── auth.py                    # Auth tables plan (Users, Groups)
+│
+├── management/
+│   └── commands/
+│       └── seed.py                    # Typer subcommand `hyperadmin seed`
+│
+tests/
+├── unit/loadtest/
+│   ├── test_pool.py                   # #250 — Pareto distribution, FK pool ops
+│   ├── test_batch.py                  # #248 — batch generator unit tests
+│   ├── test_checkpoint.py             # #252 — resumable seeding
+│   └── test_plan.py                   # plan_hash determinism
+└── e2e/
+    └── test_seed_integration.py       # #255 — seed 1K rows, verify FK integrity
+
+examples/erp/seed.py                   # #256 — keeps superuser bootstrap; new async wrapper
+                                       #         calls BulkSeeder.run() in a thread
+```
+
+**Sub-issue mapping:**
+
+| Sub-issue | Module / file |
+|---|---|
+| #248 test: unit tests for bulk insert batch generator | `tests/unit/loadtest/test_batch.py` |
+| #249 feat(loadtest): batch data generator with Faker + SQLAlchemy Core | `loadtest/batch.py` |
+| #250 test: unit tests for FK relationship pool and Pareto distribution | `tests/unit/loadtest/test_pool.py` |
+| #251 feat(loadtest): FK ID pool manager with Pareto distribution | `loadtest/pool.py` |
+| #252 test: unit tests for progress reporting and resumable seeding | `tests/unit/loadtest/test_checkpoint.py` |
+| #253 feat(loadtest): Rich progress bar and resumable seeding | `loadtest/progress.py`, `loadtest/checkpoint.py` |
+| #254 feat(loadtest): Typer CLI `hyperadmin seed` subcommand | `management/commands/seed.py` |
+| #255 test: integration test — seed 1K records, verify FK integrity | `tests/e2e/test_seed_integration.py` |
+| #256 refactor(examples): migrate seed.py to use bulk seeder | `examples/erp/seed.py` |
+
+**Flow diagram:**
+
+```
+        ┌─────────────────────────┐
+        │  hyperadmin seed CLI    │
+        │  (Typer, management/)   │
+        └────────────┬────────────┘
+                     │ flags + plan_hash
+                     ▼
+        ┌─────────────────────────┐      ┌─────────────────────┐
+        │   BulkSeeder.run()      │◄────►│  CheckpointStore    │
+        │   (loadtest/batch.py)   │      │  .hyperadmin-       │
+        └────┬────────────┬───────┘      │   seed.json         │
+             │            │              └─────────────────────┘
+             │            │                       ▲
+             │            │ insert().values(batch)│ fsync per 100 batches
+             │            ▼                       │
+             │   ┌─────────────────┐              │
+             │   │ SQLA Core engine│              │
+             │   │  (PG / SQLite)  │              │
+             │   └─────────────────┘              │
+             │                                    │
+             │ sample()                           │
+             ▼                                    │
+        ┌─────────────┐    feeds parent IDs       │
+        │   FKPool    │◄──────────────────────────┘
+        │ (in-memory) │
+        └──────┬──────┘
+               │ Pareto(a=1.16)
+               ▼
+        ┌─────────────────────┐
+        │ Faker + sequence    │
+        │  prefix → row dict  │
+        └─────────────────────┘
+                  │
+                  ▼
+           Rich Progress UI
+        (loadtest/progress.py)
+```
+
+The seeding order is fixed by `generators/erp.py`:
+
+```
+Accounts → Contacts → Invoices → InvoiceItems → Bills → BillItems
+                                            ↘ JournalEntries → JournalLines
+Auth tables (Users, Groups) seed independently of the ERP chain.
+```
+
+Parents must complete before children begin so the FK pool is fully populated when the child
+table starts. This is encoded in `SeedPlan.tables` ordering and validated at plan-build time.
+
+### Data Model Changes
+
+**No DB schema changes.** The seeder only consumes the existing ERP and auth schemas.
+
+The only new on-disk artifact is the **checkpoint state file**:
+
+```json
+{
+  "plan_hash": "sha256:<64 hex chars>",
+  "rng_seed": 42,
+  "started_at": "2026-05-05T10:15:00Z",
+  "tables": {
+    "accounts":     {"target": 1000,   "completed": 1000,  "last_pk": 1000},
+    "invoices":     {"target": 100000, "completed": 35000, "last_pk": 35000},
+    "invoice_items": {"target": 500000, "completed": 0,    "last_pk": null}
+  }
+}
+```
+
+Default location: `./.hyperadmin-seed.json` (cwd-relative). Override with `--state-file PATH`.
+Removed on clean completion. `plan_hash` covers `(table_order, target_counts, fk_distribution,
+schema_column_names_per_table)` — any drift triggers a hard abort on `--resume`.
+
+### API / Protocol Changes
+
+**New public exports** from `hyperadmin.loadtest`:
+
+```python
+# loadtest/plan.py
+@dataclass(frozen=True)
+class TablePlan:
+    name: str
+    target_count: int
+    row_factory: Callable[[FKPool, random.Random, int], dict[str, Any]]
+    fk_parents: tuple[str, ...] = ()  # parent table names; FKPool must contain these
+    unique_columns: tuple[str, ...] = ()  # columns that need sequence-prefix mitigation
+
+@dataclass(frozen=True)
+class SeedPlan:
+    tables: tuple[TablePlan, ...]  # order matters: parents before children
+
+    def hash(self) -> str: ...     # sha256 over canonical JSON of the plan + schema columns
+```
+
+```python
+# loadtest/pool.py
+class FKPool:
+    """In-memory FK ID store with Pareto-skewed sampling."""
+
+    def __init__(self, *, pareto_a: float = 1.16, rng: random.Random | None = None) -> None: ...
+    def extend(self, table: str, pks: Iterable[int]) -> None: ...
+    def sample(self, table: str) -> int: ...      # Pareto-weighted draw
+    def sample_many(self, table: str, n: int) -> list[int]: ...
+    def __len__(self) -> int: ...                 # total IDs across all tables
+    def size(self, table: str) -> int: ...
+```
+
+```python
+# loadtest/batch.py
+class BulkSeeder:
+    def __init__(
+        self,
+        *,
+        plan: SeedPlan,
+        engine: sqlalchemy.Engine,         # sync Core engine
+        batch_size: int = 5000,
+        rng_seed: int = 42,
+        state_file: pathlib.Path = pathlib.Path(".hyperadmin-seed.json"),
+        resume: bool = False,
+        progress: ProgressReporter | None = None,
+    ) -> None: ...
+
+    def run(self) -> SeedSummary: ...      # blocking; signal-handled
+```
+
+`BulkSeeder.run()` is **synchronous** by design — `insert().values(batch)` is a sync API and
+async would force a thread bridge anyway. The async wrapper for `examples/erp/seed.py` runs
+`BulkSeeder.run()` via `asyncio.to_thread()`.
+
+**CLI surface** (`management/commands/seed.py`):
+
+| Flag | Type | Default | Purpose |
+|---|---|---|---|
+| `--count N` | `int` | required | Total target rows across the ERP plan; per-table targets are derived proportionally from the plan. |
+| `--batch-size` | `int` | `5000` | Rows per `INSERT ... VALUES (...)` batch. Auto-shrunk on SQLite to respect SQLITE_MAX_VARIABLE_NUMBER. |
+| `--database-url` | `str` | env `DATABASE_URL` | SQLAlchemy URL. PostgreSQL recommended. |
+| `--resume` | `flag` | `False` | Resume from `.hyperadmin-seed.json`. Aborts on plan-hash mismatch. |
+| `--seed S` | `int` | `42` | RNG seed. CI uses default for reproducibility. |
+| `--state-file PATH` | `Path` | `./.hyperadmin-seed.json` | Override checkpoint location (e.g. for parallel CI runs). |
+| `--plan` | `str` | `erp` | Plan name; v0.7.1 supports `erp` and `auth`. |
+| `--no-progress` | `flag` | `False` | Disable Rich UI (for plain CI logs). |
+
+No changes to `Admin()`, `AdminOptions`, `HyperAdminSettings`, or any existing public API.
+
+### Configuration Changes
+
+**No new `Admin()` or settings parameters.** All knobs live on the CLI subcommand. This keeps
+the load-test surface out of the runtime admin configuration — operators never accidentally
+ship a seeder hook into production.
+
+The only environment variable consulted is the standard `DATABASE_URL` (already used by
+`examples/erp/seed.py`).
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Empty FK pool when child batch starts | Hard error at plan validation (parent must precede child). At runtime the pool is asserted non-empty before sampling — raises `EmptyPoolError` with the offending child/parent names. |
+| Unique-constraint exhaustion | Each batch carries a per-batch sequence prefix (`f"{table}-{batch_no:08d}-{row_no:04d}"`) appended to Faker output for unique columns. Collisions become mathematically improbable. On the rare retryable `IntegrityError`, the batch is regenerated with a fresh prefix once; a second failure aborts. |
+| Partial-batch resume | Checkpoints are written *after* each successful `commit()`. A crash mid-batch loses only that uncommitted batch — on `--resume`, the seeder re-derives the next batch from `tables[name].completed` and re-runs it. No partial commits. |
+| SQLite parameter limit | SQLite caps host params at 32766 (modern) or 999 (legacy). The seeder inspects the dialect at startup and shrinks `batch_size` to `floor(limit / max_columns_in_plan)` if needed, logging the adjustment. |
+| Pareto duplicates in FK references | **Expected and desired** — that is the whole point of the skew. Documented; not an error. |
+| Plan-hash mismatch on `--resume` | Seeder exits 2 with a message naming the drift (e.g. "table `invoices` target changed: 100000 → 200000"). User must `rm .hyperadmin-seed.json` to start fresh — the seeder will not silently overwrite. |
+| SIGINT / SIGTERM mid-run | Signal handler flushes the in-progress batch's checkpoint (if and only if its commit succeeded) and exits 130. The next `--resume` picks up cleanly. |
+| numpy unavailable | `try: import numpy` falls back to `random.paretovariate(a)` — slower per-call but correct. Performance delta is logged at startup. |
+| Progress UI in non-TTY (CI) | Rich auto-detects; if no TTY, the progress reporter degrades to one line per batch (`table=invoices completed=35000/100000 rate=28.4K/s`). `--no-progress` forces the plain mode. |
+| Checkpoint fsync cost | Per-batch JSON write is cheap (small file), but `os.fsync` after every batch caps throughput. Compromise: write JSON every batch, `fsync` every 100 batches; signal handler also fsyncs. Recovery loses at most 100 batches × `batch_size` rows on a power-loss event — acceptable for a load-test tool. |
+| Engine pool exhaustion under load | Seeder uses a single connection (single-threaded inserts); pool size is irrelevant. Documented. |
+| FK pool memory ceiling | Pools store ints (~28 bytes/elem in CPython). 10M parent PKs ≈ 280 MB. Above ~50M PKs the pool is the dominant memory cost; a warning is logged. Spill-to-disk is deferred (Open Questions). |
+
+## Migration & Backward Compatibility
+
+**Backward compatible — no migration required.**
+
+- `examples/erp/seed.py` keeps its existing entrypoint and superuser bootstrap. The new
+  `BulkSeeder` is invoked from a new async wrapper that uses `asyncio.to_thread`; calling
+  the script with no arguments still produces the demo superuser as before. `--bulk N` (or
+  `python -m hyperadmin seed --count N`) opts into bulk seeding.
+- `src/hyperadmin/loadtest/` is a brand-new package. No existing imports change.
+- `__init__.py` exports of the top-level `hyperadmin` package are **unchanged**.
+  `loadtest` is intentionally not re-exported at the top level — operators import it
+  explicitly (`from hyperadmin.loadtest import BulkSeeder`).
+- numpy stays out of `[project.dependencies]`. It is added to the **dev** extra so the
+  fast-path is exercised in CI.
+- No semver bump required.
+
+## Open Questions
+
+- [ ] **Sprint sequencing in v0.7.0:** should #246 land *before* or *after* #211
+      (server-side pagination)? **Proposal:** ship #246 first so #211's benchmark suite has
+      a 10M-row dataset to test against from day one. Otherwise #211 ends up shipping with
+      hand-rolled fixtures that #246 then has to retrofit.
+- [ ] **Spill-to-disk FK pools for >100M-row parents.** Above ~50M parent PKs, the in-memory
+      `list[int]` becomes the dominant cost (≈1.4 GB at 50M). Options: SQLite-backed pool,
+      mmap'd packed `array.array("q")`, or chunked sampling with a smaller hot subset.
+      **Deferred** — revisit when v0.7.0 benchmarks demand it; not in v0.7.1 scope.
+- [ ] **Auto-discovery of user models from SQLModel metadata.** v0.7.1 hard-codes the ERP
+      plan. Users with custom schemas have no path beyond writing their own `SeedPlan` in
+      Python. Generic discovery (introspect `SQLModel.metadata.tables`, infer FK edges,
+      pick Faker generators by column type) is **deferred to v0.8** — non-trivial design,
+      and we want one ERP-shaped plan to validate the architecture first.
+- [ ] **Per-table target derivation from `--count N`.** Currently the plan defines fixed
+      ratios (1 account : 100 invoices : 5 items/invoice). `--count` scales those ratios.
+      Should we expose `--count-table accounts=10000` overrides? **Proposal:** defer to
+      v0.7.2 — single `--count` covers the v0.7.0 benchmark needs.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Module location: `src/hyperadmin/loadtest/` (new top-level) | Independent of admin core; no `Admin()` coupling; easy to omit from production deploys via `[loadtest]` extra later. | Nest under `examples/` (would prevent reuse from a published wheel); nest under `core/` (pollutes the framework core with operator tooling) |
+| **SQLAlchemy Core `insert().values(batch)` baseline only — no COPY fast path in v0.7.1** | ~30K/s on a developer laptop is a clean baseline that ships now and meets v0.7.1 BDD scenarios; COPY adds psycopg2-specific code, complicates rollback semantics, and is not needed unless benchmarks prove it blocks v0.7.0 scalability targets. **Revisit if benchmark shows it blocks v0.7.0 scalability targets.** | `psycopg.copy_expert` / `COPY FROM STDIN` (faster, ~200K/s, but PG-only and complicates resume); `executemany` (slower than `values()`); SQLAlchemy ORM `bulk_save_objects` (slowest, defeats the point) |
+| numpy as a **soft** dependency with stdlib `random.paretovariate` fallback | Avoids forcing a 20+ MB transitive dep on every HyperAdmin install for a tool 99% of users never run. CI tests both code paths. | Hard runtime dep on numpy (rejected — bloats install); remove numpy entirely (rejected — measurable speedup at 10M+ samples) |
+| Pareto distribution `a=1.16` (≈80/20 skew) | Industry-standard skew shape for "few dominant entities" datasets; matches real ERP customer/invoice ratios; well-known tail behaviour. | Zipf (similar shape, more parameters to explain); uniform (rejected — defeats the purpose) |
+| FK pool: in-memory `dict[str, list[int]]` | Simplest correct data structure; supports random-index sampling in O(1); CPython int-list memory is tolerable up to ~50M entries. | DB-backed pool (slower, more code); `array.array("q")` (faster but overkill at v0.7.1 scales) |
+| Resumability via JSON state file at `.hyperadmin-seed.json` | Human-readable, diff-able, no extra infra; cwd-relative is intuitive for one-off ops; `--state-file` covers parallel CI lanes. | DB-resident checkpoint table (couples to the schema being seeded); SQLite sidecar (more code, no readability benefit) |
+| Checkpoint: per-batch JSON write, `fsync` every 100 batches | Per-batch write is cheap; bulk fsync gives ~100× throughput vs per-batch fsync; signal handler always fsyncs on Ctrl-C so worst-case loss is bounded by what crashed. | fsync every batch (kills throughput); fsync only on signal (loses too much on power-loss) |
+| `plan_hash` validated on `--resume` | Schema drift mid-run silently corrupts results — hard abort is the only safe behaviour. Hash covers table order, targets, FK edges, and column names so any meaningful change is caught. | Trust the user (rejected — silent corruption); hash only table names (misses target / FK changes) |
+| Default RNG seed = `42` | Deterministic, well-known sentinel; CI runs are byte-reproducible; users override with `--seed`. | Time-based seed (rejected — non-reproducible CI); no default (rejected — forces every user to think about it) |
+| Hard-coded ERP plan in `loadtest/generators/erp.py` for v0.7.1 | Lets us validate the architecture against one realistic schema before generalizing; auto-discovery is a meaningfully different design problem. | Auto-discovery from SQLModel metadata (deferred to v0.8); user-supplied YAML plan files (deferred — adds parser surface area) |
+| CLI: `hyperadmin seed --count N --batch-size 5000 --database-url URL [--resume] [--seed S] [--state-file PATH]` | One subcommand, clear flags, follows existing Typer conventions in `management/commands/`. | Standalone `hyperadmin-seed` script (rejected — splits the entry-point surface); per-table subcommands (rejected — bad ergonomics for plan-driven seeding) |
+| `examples/erp/seed.py` keeps async wrapper that runs `BulkSeeder.run()` in a thread | Existing example is async (FastAPI flavour); `BulkSeeder` is sync because `insert().values()` is sync; `asyncio.to_thread` is the standard bridge with zero behavioural surprises. | Make `BulkSeeder` async (rejected — fights the SQLA Core API); rewrite `seed.py` as sync (rejected — diverges from the rest of the example) |
+| `BulkSeeder.run()` is synchronous | Underlying `insert().values()` is sync; an async wrapper would only add a `to_thread` layer; keeping it sync makes signal handling and checkpoint flush trivial. | Async-first API (rejected — adds complexity for no throughput gain) |
+| Soft-import Rich; degrade to plain logs without TTY | CI logs stay readable; developers get the rich UI; `--no-progress` is the explicit escape hatch. | Always-on Rich (rejected — garbled CI logs); always-plain (rejected — bad dev UX) |


### PR DESCRIPTION
## Summary

Three SDD drafts kicking off the v0.7.0 / v0.7.1 scalability work. All `Status: Draft` — opens the human review gate before any implementation sub-issue starts (per `.claude/rules/sdd-conventions.md`).

| SDD | Epic | Milestone | Size |
|---|---|---|---|
| `docs/specs/adapter-query-performance.md` | #211 (umbrella for A1–A4) | v0.7.0 | 30.1K · 17 BDD scenarios |
| `docs/specs/filter-choice-scalability.md` | #213 | v0.7.0 | 31.2K · 8 BDD scenarios |
| `docs/specs/synthetic-data-generator.md` | #246 | v0.7.1 | 24.7K · 6 BDD scenarios |

## Cross-cutting decisions

- **Shared `src/hyperadmin/core/cache.py`** owned by #213 SDD; #211/A3 (count cache) reuses it. Adds `cachetools>=5` to runtime deps.
- **Two distinct count primitives** on `BaseAdapter`:
  - `estimate_row_count() -> int` (#213, approximate, table-wide, via `pg_class.reltuples`)
  - `count(filters=...) -> int` (#211/A3, exact, optionally TTL-cached)
- **Semver: v0.7.0 = minor.** Dual-shape `list()` / `list_paginated() -> ListResult`; deprecate tuple return for one cycle, collapse in v1.0.
- **A1 BC**: list views default `list_select_related=None` (load nothing — flagged BREAKING in CHANGELOG); detail views keep auto-detect. Opt-in `auto_select_related=True` derives from `column_list`.
- **#246 = enabler** for #211/#213 benchmarks. Recommend land first within v0.7.0 sprint sequence.

## Resolved trade-offs

- Redis cache backend → deferred v0.8 (in-memory only ships in v0.7.0)
- `preload_threshold` → model-wide only (per-field deferred, additive)
- numpy → soft dep with stdlib `random.paretovariate` fallback
- COPY-based bulk insert fast path → deferred; SQLAlchemy Core baseline (~30K/s) accepted
- Bulk-seed checkpoint → JSON state file (no DB schema pollution)

## Test plan

- [ ] Human reviewer reads each SDD top-to-bottom and resolves Open Questions
- [ ] Confirm cross-references between SDDs are consistent (esp. `core/cache.py` ownership and count primitive disambiguation)
- [ ] Approve → flip Status to `Approved` → unblock impl sub-issues per each epic's first sub-task