### PR TITLE
docs(meta): plan v0.8.0 — Plugin Registry + hyperadmin-logfire

### DIFF
--- a/.meta/epics/epic-plugin-logfire-first-plugin/epic.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/epic.md
@@ -1,0 +1,107 @@
+---
+type: epic
+id: Plo-enMpTWhB
+title: "epic(plugin-logfire): hyperadmin-logfire — first official plugin"
+status: todo
+priority: high
+owner: null
+labels:
+  - size:L
+  - planned
+  - plugins
+  - observability
+milestone_ref:
+  id: XnHVJphQRoMf
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Overview
+
+Ship `hyperadmin-logfire` — a separate package that instruments HyperAdmin with
+Pydantic Logfire for per-model CRUD spans, query performance, validation
+failure rates, and auth event tracing. **The first official HyperAdmin plugin
+and the proof-of-concept for the plugin registry contract.**
+
+If this plugin requires changes to `src/hyperadmin/core/` beyond the hooks
+defined in the registry SDD, the registry SDD must be revised. That is the
+design pressure on this work.
+
+**Repo layout:** monorepo subpath `plugins/hyperadmin-logfire/` with its own
+`pyproject.toml` and PyPI release pipeline.
+
+**SDD:** [`docs/specs/plugin-logfire.md`](../../../docs/specs/plugin-logfire.md)
+(required — separate package + cross-repo coordination + new hooks).
+
+## Tracks
+
+### Track A: Package scaffold
+- `plugins/hyperadmin-logfire/pyproject.toml` with `[project.entry-points."hyperadmin.plugins"]`.
+- Source layout: `src/hyperadmin_logfire/{__init__.py, plugin.py, adapter_spans.py, auth_events.py, _config_check.py}`.
+- Workspace integration: root `pyproject.toml` adds `plugins/hyperadmin-logfire` to `[tool.uv.workspace.members]`.
+
+### Track B: Adapter + HTTP + SQL spans
+- `LogfirePlugin.on_before_adapter_call` opens `admin.adapter.<op>` span (carried in `contextvars`).
+- `on_after_adapter_call` closes the span with the result.
+- `instrument_admin(admin)` calls `logfire.instrument_fastapi(admin.app)` and
+  `logfire.instrument_sqlalchemy(admin.engine)` — HTTP and SQL spans nested under adapter spans.
+
+### Track C: Validation + auth events
+- `on_validation_error` (new hook in registry SDD) emits `admin.validation_error` events.
+- `on_auth_event` (new hook in registry SDD) emits `admin.auth.{login_success,login_failure,logout,permission_denied}` events.
+
+### Track D: CI + docs
+- `.github/workflows/*.yml` — add `plugins/hyperadmin-logfire` to test matrix.
+- README + main-docs link.
+
+## Scenarios
+
+**Scenario: instrument_admin attaches the plugin and emits adapter spans**
+  Given logfire is configured to capture spans in a test sink
+  And   instrument_admin(admin) has been called
+  When  the admin.products list view is requested
+  Then  the test sink contains a span named "admin.adapter.list" with attribute model="Product"
+
+**Scenario: validation failure emits a structured event**
+  Given logfire is configured to capture events
+  When  POST /admin/products/create with an invalid payload
+  Then  the sink contains an event "admin.validation_error" with attributes model="Product" and field_errors non-empty
+
+**Scenario: failed login emits an auth event**
+  Given logfire is configured to capture events
+  When  POST /admin/login with username=alice password=wrong
+  Then  the sink contains an event "admin.auth.login_failure" with attribute username="alice"
+
+**Scenario: plugin no-ops when logfire is not configured**
+  Given logfire.configure() was NOT called
+  When  Admin is constructed and a list view is requested
+  Then  no exceptions are raised
+  And   a single warning log mentions hyperadmin-logfire requires logfire.configure()
+
+**Scenario: plugin is not loaded when disabled**
+  Given hyperadmin-logfire is installed
+  When  Admin(app, engine=engine, disabled_plugins=["logfire"]) is constructed
+  Then  no admin.adapter.* spans are emitted on subsequent requests
+
+## Acceptance Criteria
+
+- [ ] `instrument_admin(admin)` attaches plugin and emits adapter spans
+- [ ] Validation failure emits a structured `admin.validation_error` event
+- [ ] Failed login emits a `admin.auth.login_failure` event
+- [ ] Plugin no-ops with a one-shot warning when `logfire.configure()` not called
+- [ ] Plugin is not loaded when disabled via `disabled_plugins=["logfire"]`
+- [ ] Unit + E2E tests for all five scenarios
+- [ ] Package published to PyPI as `hyperadmin-logfire`
+- [ ] README and main-docs link
+- [ ] **Zero changes to `src/hyperadmin/core/`** beyond the hooks added to the registry SDD
+
+## Cross-epic dependency
+
+This epic adds two new hooks (`on_validation_error`, `on_auth_event`) to the
+registry SDD. They must be added before the registry SDD is approved. If they
+slip, this epic re-plans how validation/auth events get emitted (likely option:
+direct middleware listener, ugly).
+
+## Blocked by
+
+- `epic-plugins-registry-and-lifecycle-hooks` (Plugin contract must exist)

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/chore-scaffold-pluginshyperadmin-logfire-package.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/chore-scaffold-pluginshyperadmin-logfire-package.md
@@ -1,0 +1,60 @@
+---
+type: story
+id: LrSvJLyCHmOl
+title: "chore: scaffold plugins/hyperadmin-logfire package"
+status: todo
+priority: high
+assignee: null
+labels:
+  - chore
+  - size:S
+  - planned
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Create the empty package skeleton for `hyperadmin-logfire` under
+`plugins/hyperadmin-logfire/`. Wire it into the uv workspace so it installs
+locally during development.
+
+**Spec:** [`docs/specs/plugin-logfire.md`](../../../../docs/specs/plugin-logfire.md)
+
+## Files to Change
+
+- **New:** `plugins/hyperadmin-logfire/pyproject.toml`
+  - `name = "hyperadmin-logfire"`, `version = "0.1.0"`
+  - `dependencies = ["hyper-admin>=0.8.0", "logfire>=4.0"]`
+  - `[project.entry-points."hyperadmin.plugins"] logfire = "hyperadmin_logfire:LogfirePlugin"`
+- **New:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/__init__.py` —
+  re-export `LogfirePlugin`, `instrument_admin`
+- **New:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/plugin.py` — empty
+  `LogfirePlugin` class with `name = "logfire"` and a no-op `on_register`
+- **New:** `plugins/hyperadmin-logfire/README.md`
+- **Modified:** root `pyproject.toml` — add `plugins/hyperadmin-logfire` to
+  `[tool.uv.workspace.members]` (or equivalent for whatever workspace tooling is in use)
+- **Modified:** root `pyproject.toml` — add optional extra
+  `[project.optional-dependencies].logfire = ["hyperadmin-logfire>=0.1"]` (pending
+  SDD review confirmation)
+
+## Acceptance Criteria
+
+- [ ] `uv sync --all-extras` from repo root installs the new package in editable mode
+- [ ] `python -c "import hyperadmin_logfire; print(hyperadmin_logfire.LogfirePlugin)"` succeeds
+- [ ] `hyperadmin plugins list` (after Epic 1 stories are merged) shows `logfire` as discovered
+- [ ] `poe lint` passes against the new package source
+- [ ] `git ls-files plugins/hyperadmin-logfire/` lists exactly the files above
+
+## Blocked by
+
+- `reviewspec-approve-sdd-for-plugin-logfire`
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/ci-add-plugins-hyperadmin-logfire-to-test-matrix.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/ci-add-plugins-hyperadmin-logfire-to-test-matrix.md
@@ -1,0 +1,51 @@
+---
+type: story
+id: 7fh6lg_zbkke
+title: "ci: add plugins/hyperadmin-logfire to test matrix"
+status: todo
+priority: medium
+assignee: null
+labels:
+  - ci
+  - size:S
+  - planned
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Run lint + unit + e2e for `plugins/hyperadmin-logfire` in CI on every PR.
+Publish to TestPyPI on tag push, real PyPI on manual workflow dispatch.
+
+**Spec:** [`docs/specs/plugin-logfire.md`](../../../../docs/specs/plugin-logfire.md)
+
+## Files to Change
+
+- **Modified:** `.github/workflows/test.yml` — add `plugins/hyperadmin-logfire`
+  to the matrix entry that runs `poe lint && poe test:unit`. Add an extra E2E
+  job step that targets the plugin's E2E suite specifically.
+- **New:** `.github/workflows/publish-hyperadmin-logfire.yml` — workflow that
+  builds and publishes the package to TestPyPI on `v*` tag, real PyPI on manual
+  dispatch with explicit version input.
+
+## Acceptance Criteria
+
+- [ ] Plugin lint + unit + E2E run on every PR
+- [ ] CI fails if any of the plugin tests fail (no exclusion via `continue-on-error`)
+- [ ] TestPyPI publish workflow tested on a pre-release tag (`v0.1.0a1` or similar)
+- [ ] Real PyPI workflow gated behind manual dispatch with confirmation
+- [ ] Publishing uses Trusted Publishing (OIDC), no long-lived tokens
+
+## Blocked by
+
+- `chore-scaffold-pluginshyperadmin-logfire-package`
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/docs-publish-hyperadmin-logfire-readme-and-link-from-main-docs.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/docs-publish-hyperadmin-logfire-readme-and-link-from-main-docs.md
@@ -1,0 +1,66 @@
+---
+type: story
+id: mhoRScF5hYQN
+title: "docs: publish hyperadmin-logfire README and link from main docs"
+status: todo
+priority: medium
+assignee: null
+labels:
+  - documentation
+  - size:S
+  - planned
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Polish the package README and link it from the main HyperAdmin docs site so
+new users can discover the plugin.
+
+**Spec:** [`docs/specs/plugin-logfire.md`](../../../../docs/specs/plugin-logfire.md)
+
+## Files to Change
+
+- **Modified:** `plugins/hyperadmin-logfire/README.md` — full content
+- **New:** `docs/plugins/logfire.md` — short page on the main docs site
+- **Modified:** `mkdocs.yml` — add the page under the "Plugins" nav (the section
+  added by Epic 1's `docs-plugin-author-guide-and-hook-reference` story)
+
+## Content Outline
+
+### `plugins/hyperadmin-logfire/README.md`
+- One-paragraph pitch
+- Install: `pip install hyperadmin-logfire` or `pip install hyperadmin[logfire]`
+- Usage: 5-line example with `logfire.configure()` + `instrument_admin(admin)`
+- What it captures: adapter spans, HTTP, SQL, validation events, auth events
+- Configuration: link to Logfire docs for `logfire.configure()` options
+- Disable: `Admin(disabled_plugins=["logfire"])` and env var
+- Example dashboard screenshots (optional, defer if not ready)
+- License: same as parent (MIT)
+
+### `docs/plugins/logfire.md`
+- Short summary + link to GitHub README
+- Span / event schema reference (names + attributes)
+- Comparison table: vs django-silk, vs Sentry, vs raw OpenTelemetry
+
+## Acceptance Criteria
+
+- [ ] Package README complete and renders correctly on PyPI
+- [ ] Main-docs page renders under `/plugins/logfire/`
+- [ ] `poe docs:build` succeeds
+- [ ] No broken links
+
+## Blocked by
+
+- `test-e2e-end-to-end-spans-and-events-against-test-sink` (so docs match
+  shipped behaviour)
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/docsspec-sdd-for-plugin-logfire.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/docsspec-sdd-for-plugin-logfire.md
@@ -1,0 +1,51 @@
+---
+type: story
+id: knE8pAvm9TB7
+title: "docs(spec): SDD for hyperadmin-logfire plugin"
+status: done
+priority: high
+assignee: null
+labels:
+  - documentation
+  - size:S
+  - planned
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Write the Software Design Document for the `hyperadmin-logfire` plugin epic.
+
+**Output:** `docs/specs/plugin-logfire.md` (Status: Draft)
+
+## Scope
+
+The SDD must cover:
+- Repo layout decision: monorepo subpath vs separate repo (decided: monorepo subpath)
+- `instrument_admin(admin)` API surface and idempotency
+- Hook usage table — which Epic 1 hooks are consumed, which are net-new
+- Span context propagation between `on_before_adapter_call` / `on_after_adapter_call`
+  using `contextvars`
+- Failure modes: `logfire` not configured, not installed, double-instrument
+- CI: workspace `pyproject.toml` integration, separate test matrix entry
+- PyPI publication strategy (separate package, optional `hyperadmin[logfire]` extra)
+- Decision log entries with rejected alternatives
+
+## Acceptance Criteria
+
+- [x] SDD follows `docs/specs/TEMPLATE.md` structure
+- [x] BDD scenarios synced with epic body
+- [x] Status set to "Draft"
+- [x] Repo layout decision recorded
+- [x] Hook dependency on Epic 1 SDD made explicit (two new hooks listed)
+- [x] Open Questions enumerated for review
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/featpluginlogfire-emit-auth-events.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/featpluginlogfire-emit-auth-events.md
@@ -1,0 +1,114 @@
+---
+type: story
+id: MD1z52Kl1dil
+title: "feat(plugin-logfire): emit admin.auth.* events"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:S
+  - planned
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Wire `LogfirePlugin.on_auth_event` to emit
+`admin.auth.{login_success,login_failure,logout,permission_denied}` events.
+
+**Spec:** [`docs/specs/plugin-logfire.md`](../../../../docs/specs/plugin-logfire.md)
+
+## Files to Change
+
+- **Modified:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/plugin.py` —
+  add `on_auth_event` method
+- **New:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/auth_events.py`
+
+**Cross-epic dependency:** the `on_auth_event` hook must be defined and fired
+by core. That is added as part of the **Epic 1 SDD revision** triggered by this
+epic. The fire sites live in:
+- `src/hyperadmin/auth/` middleware (login_success, login_failure, logout)
+- `src/hyperadmin/views/dynamic.py` (permission_denied — when a request hits a
+  view but the model-level or object-level permission check returns False)
+
+## Design
+
+```python
+# auth_events.py
+import logfire
+
+EVENT_NAMES = {
+    "login_success": "admin.auth.login_success",
+    "login_failure": "admin.auth.login_failure",
+    "logout": "admin.auth.logout",
+    "permission_denied": "admin.auth.permission_denied",
+}
+
+
+def emit(event_type: str, *, user, **ctx) -> None:
+    name = EVENT_NAMES.get(event_type)
+    if name is None:
+        return  # unknown event type — silently ignore (forward compatible)
+    attrs = {"user": getattr(user, "username", None) if user else None, **ctx}
+    if event_type == "login_failure":
+        logfire.warn(name, **attrs)
+    else:
+        logfire.info(name, **attrs)
+```
+
+```python
+# plugin.py — addition
+class LogfirePlugin:
+    ...
+    def on_auth_event(self, admin, event_type, user, **ctx):
+        from .auth_events import emit
+        emit(event_type, user=user, **ctx)
+```
+
+## Scenarios
+
+**Scenario: failed login emits an auth event**
+  Given logfire is configured to capture events
+  When  POST /admin/login with username=alice password=wrong
+  Then  the sink contains an event "admin.auth.login_failure" with attribute username="alice"
+
+**Scenario: successful login emits an auth event**
+  Given logfire is configured to capture events
+  When  POST /admin/login with valid credentials for alice
+  Then  the sink contains an event "admin.auth.login_success" with attribute user="alice"
+
+**Scenario: permission denied emits an auth event with codename context**
+  Given alice does not have the "delete" permission for Product
+  When  POST /admin/products/1/delete
+  Then  the sink contains an event "admin.auth.permission_denied" with attributes user="alice", codename="delete", model="Product"
+
+**Scenario: unknown event_type is silently ignored**
+  Given a future core version emits on_auth_event with event_type="something_new"
+  When  the plugin is the current version
+  Then  no exception is raised
+  And   no logfire event is emitted
+
+## Acceptance Criteria
+
+- [ ] All four event types (`login_success`, `login_failure`, `logout`, `permission_denied`) emitted with appropriate level (warn for failure, info for others)
+- [ ] User attribute always present (None for failure pre-resolution)
+- [ ] Unknown event types ignored (forward compatibility)
+- [ ] Unit test for each event type
+
+## Blocked by
+
+- `featpluginlogfire-implement-logfireplugin-and-instrumentadmin`
+- Epic 1: `on_auth_event` fire sites added (covered by Epic 1 view-hooks story
+  + auth-middleware additions, both gated behind the Epic 1 SDD update for the
+  two new hooks)
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/featpluginlogfire-emit-validation-error-events.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/featpluginlogfire-emit-validation-error-events.md
@@ -1,0 +1,91 @@
+---
+type: story
+id: k0Q9LnzMo_GA
+title: "feat(plugin-logfire): emit admin.validation_error events"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:S
+  - planned
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Wire `LogfirePlugin.on_validation_error` to emit a structured
+`admin.validation_error` event whenever an admin form fails validation. Enables
+dashboards: validation failure rate per model, most-failing fields, error
+message distribution.
+
+**Spec:** [`docs/specs/plugin-logfire.md`](../../../../docs/specs/plugin-logfire.md)
+
+## Files to Change
+
+- **Modified:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/plugin.py` —
+  add `on_validation_error` method
+
+**Cross-epic dependency:** the `on_validation_error` hook must be defined and
+fired by core. That is added as part of the **Epic 1 SDD revision** triggered
+by this epic. The fire site lives in `src/hyperadmin/views/dynamic.py` (or
+wherever `PydanticForm.validate()` is called) and follows the
+`featviews-fire-onbeforeafter-create-update-delete-around-views` story's
+pattern.
+
+## Design
+
+```python
+# plugin.py — addition
+import logfire
+
+class LogfirePlugin:
+    ...
+    def on_validation_error(self, admin, model, field_errors):
+        # field_errors is a dict[str, list[str]] (field_name -> [messages])
+        logfire.warn(
+            "admin.validation_error",
+            model=model.__name__,
+            field_errors=_stringify(field_errors),
+            error_count=sum(len(v) for v in field_errors.values()),
+        )
+
+def _stringify(errors: dict) -> dict:
+    """Coerce non-serialisable values to strings."""
+    return {k: [str(m) for m in v] for k, v in errors.items()}
+```
+
+## Scenarios
+
+**Scenario: validation failure emits a structured event**
+  Given logfire is configured to capture events
+  When  POST /admin/products/create with an invalid payload
+  Then  the sink contains an event "admin.validation_error" with attributes model="Product" and field_errors non-empty
+
+**Scenario: non-serialisable error values are stringified**
+  Given a field validator raises a custom exception with __str__ output
+  When  the form fails validation
+  Then  the recorded field_errors values are all strings (no non-serialisable objects)
+
+## Acceptance Criteria
+
+- [ ] `admin.validation_error` event emitted on every form validation failure
+- [ ] Event attributes: `model`, `field_errors`, `error_count`
+- [ ] Non-serialisable values stringified
+- [ ] Unit test using logfire test sink
+
+## Blocked by
+
+- `featpluginlogfire-implement-logfireplugin-and-instrumentadmin`
+- Epic 1: `featviews-fire-onbeforeafter-create-update-delete-around-views`
+  (where `on_validation_error` is fired from)
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/featpluginlogfire-implement-logfireplugin-and-instrumentadmin.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/featpluginlogfire-implement-logfireplugin-and-instrumentadmin.md
@@ -1,0 +1,135 @@
+---
+type: story
+id: xbcCPwi1Ikew
+title: "feat(plugin-logfire): implement LogfirePlugin and instrument_admin()"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:M
+  - planned
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Implement the core `LogfirePlugin` class and the `instrument_admin(admin)`
+public function. `instrument_admin` is the user's one-call setup; `LogfirePlugin`
+is the entry-point class that the registry discovers automatically.
+
+**Spec:** [`docs/specs/plugin-logfire.md`](../../../../docs/specs/plugin-logfire.md)
+
+## Files to Change
+
+- **Modified:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/plugin.py`
+- **Modified:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/__init__.py`
+- **New:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/_config_check.py`
+
+## Design
+
+```python
+# plugin.py
+import logging
+import logfire
+
+log = logging.getLogger("hyperadmin_logfire")
+
+class LogfirePlugin:
+    name = "logfire"
+
+    def on_register(self, admin) -> None:
+        # No instrumentation here — that happens in instrument_admin().
+        # on_register is just confirmation that the plugin loaded.
+        log.info("hyperadmin-logfire plugin registered (call instrument_admin to enable)")
+```
+
+```python
+# __init__.py
+from ._config_check import is_logfire_configured, warn_if_not_configured
+from .plugin import LogfirePlugin
+import logfire
+
+def instrument_admin(admin) -> None:
+    """One-call setup. Idempotent.
+
+    1. Verify the plugin is loaded (not disabled).
+    2. logfire.instrument_fastapi(admin.app)
+    3. logfire.instrument_sqlalchemy(admin.engine)
+    """
+    if "logfire" not in admin.plugins:
+        log.warning(
+            "instrument_admin called but the logfire plugin is disabled "
+            "or not installed; HTTP/SQL instrumentation skipped"
+        )
+        return
+    warn_if_not_configured()  # one-shot WARNING if logfire.configure() not called
+    logfire.instrument_fastapi(admin.app)
+    logfire.instrument_sqlalchemy(engine=admin.engine)
+```
+
+```python
+# _config_check.py
+_warned = False
+
+def is_logfire_configured() -> bool:
+    # heuristic: logfire's get_baggage / current span APIs all rely on a global
+    # tracer provider being installed; check that. Concrete API call to be
+    # picked at implementation time after consulting logfire docs.
+    ...
+
+def warn_if_not_configured() -> None:
+    global _warned
+    if _warned or is_logfire_configured():
+        return
+    _warned = True
+    log.warning(
+        "hyperadmin-logfire requires logfire.configure() to be called before "
+        "instrument_admin(); no spans or events will be emitted"
+    )
+```
+
+## Scenarios
+
+**Scenario: instrument_admin attaches the plugin and emits adapter spans**
+  Given logfire is configured to capture spans in a test sink
+  And   instrument_admin(admin) has been called
+  When  the admin.products list view is requested
+  Then  the test sink contains a span named "admin.adapter.list" with attribute model="Product"
+
+**Scenario: plugin no-ops when logfire is not configured**
+  Given logfire.configure() was NOT called
+  When  Admin is constructed and a list view is requested
+  Then  no exceptions are raised
+  And   a single warning log mentions hyperadmin-logfire requires logfire.configure()
+
+**Scenario: instrument_admin is a no-op when plugin is disabled**
+  Given Admin(disabled_plugins=["logfire"]) is constructed
+  When  instrument_admin(admin) is called
+  Then  no logfire.instrument_fastapi / instrument_sqlalchemy is called
+  And   a WARNING log is emitted
+
+## Acceptance Criteria
+
+- [ ] `LogfirePlugin` discoverable via entry point (proven by `hyperadmin plugins list`)
+- [ ] `instrument_admin(admin)` calls `logfire.instrument_fastapi` and `instrument_sqlalchemy`
+- [ ] One-shot warning on missing `logfire.configure()`
+- [ ] No-op when plugin is disabled
+- [ ] Idempotent: calling `instrument_admin` twice doesn't double-instrument
+  (defer to logfire's idempotency)
+
+## Blocked by
+
+- `chore-scaffold-pluginshyperadmin-logfire-package`
+- Epic 1: `featcore-wire-plugin-discovery-into-admin-init` (so plugin is discoverable)
+- Epic 1: `featcore-implement-app-level-hook-dispatcher` (so dispatch exists)
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/featpluginlogfire-instrumentedadapter-via-onbeforeafter-adapter-call.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/featpluginlogfire-instrumentedadapter-via-onbeforeafter-adapter-call.md
@@ -1,0 +1,132 @@
+---
+type: story
+id: UheQE0jlCmFL
+title: "feat(plugin-logfire): InstrumentedAdapter spans via on_before/after_adapter_call"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:M
+  - planned
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Implement adapter span emission. `LogfirePlugin.on_before_adapter_call` opens a
+`admin.adapter.<op>` span and stashes it in a `contextvar`;
+`on_after_adapter_call` retrieves and closes it. Span attributes include
+`model` and `op` plus per-op kwargs (paging, search, filters).
+
+**Spec:** [`docs/specs/plugin-logfire.md`](../../../../docs/specs/plugin-logfire.md)
+
+## Files to Change
+
+- **New:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/adapter_spans.py`
+- **Modified:** `plugins/hyperadmin-logfire/src/hyperadmin_logfire/plugin.py` —
+  add `on_before_adapter_call` / `on_after_adapter_call` methods
+
+## Design
+
+```python
+# adapter_spans.py
+from contextvars import ContextVar
+import logfire
+
+# Stack of open spans — supports nested adapter calls (e.g. get_related from list)
+_open_spans: ContextVar[list] = ContextVar("hyperadmin_logfire_open_spans", default=None)
+
+
+def _safe_attrs(op: str, kwargs: dict) -> dict:
+    """Whitelist of attrs per op to avoid leaking PII or huge payloads."""
+    if op == "list":
+        return {
+            "page": kwargs.get("page"),
+            "page_size": kwargs.get("page_size"),
+            "search": kwargs.get("search"),
+            "has_filters": bool(kwargs.get("filters")),
+        }
+    if op in ("get", "delete"):
+        return {"pk": str(kwargs.get("pk"))}
+    if op in ("create", "update"):
+        return {"field_count": len(kwargs.get("data", {}))}
+    if op == "get_choices":
+        return {"field": kwargs.get("field"), "limit": kwargs.get("limit")}
+    return {}
+
+
+def open_span(*, model, op, kwargs):
+    span = logfire.span(f"admin.adapter.{op}", model=model.__name__, **_safe_attrs(op, kwargs))
+    span.__enter__()
+    stack = _open_spans.get() or []
+    stack = [*stack, span]
+    _open_spans.set(stack)
+
+
+def close_span(*, model, op, result):
+    stack = _open_spans.get() or []
+    if not stack:
+        log.warning("logfire adapter span close called but no open span found", extra={"model": model.__name__, "op": op})
+        return
+    span = stack[-1]
+    _open_spans.set(stack[:-1])
+    if op == "list" and isinstance(result, (list, tuple)):
+        span.set_attribute("result_count", len(result))
+    span.__exit__(None, None, None)
+```
+
+```python
+# plugin.py — additions
+class LogfirePlugin:
+    name = "logfire"
+
+    def on_before_adapter_call(self, admin, model, op, kwargs):
+        from .adapter_spans import open_span
+        open_span(model=model, op=op, kwargs=kwargs)
+
+    def on_after_adapter_call(self, admin, model, op, result):
+        from .adapter_spans import close_span
+        close_span(model=model, op=op, result=result)
+```
+
+## Scenarios
+
+**Scenario: adapter span emitted with model attribute**
+  Given logfire test sink active and instrument_admin(admin) called
+  When  GET /admin/products/ is requested
+  Then  the sink contains a span "admin.adapter.list" with attributes model="Product", page=1, page_size=10
+
+**Scenario: nested adapter call produces nested spans**
+  Given instrument_admin(admin) is called
+  When  the list view triggers a get_choices for an FK field on the same request
+  Then  the sink contains an "admin.adapter.list" span with a child "admin.adapter.get_choices" span
+
+**Scenario: missing close span is logged but does not crash**
+  Given the contextvar stack is empty
+  When  on_after_adapter_call is called manually
+  Then  a WARNING log is emitted
+  And   no exception is raised
+
+## Acceptance Criteria
+
+- [ ] Spans named `admin.adapter.<op>` for all 9 BaseAdapter operations
+- [ ] Span attributes: `model`, plus op-specific safe attrs (no PII / large payloads)
+- [ ] Nested calls produce nested spans (contextvar stack)
+- [ ] Missing-stack edge case logged, not crashed
+- [ ] Unit tests using a logfire test sink — see next story
+
+## Blocked by
+
+- `featpluginlogfire-implement-logfireplugin-and-instrumentadmin`
+- Epic 1: `featadapters-wrap-baseadapter-with-onbeforeafter-adapter-call-hooks`
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/reviewspec-approve-sdd-for-plugin-logfire.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/reviewspec-approve-sdd-for-plugin-logfire.md
@@ -1,0 +1,52 @@
+---
+type: story
+id: ZmEtqRqTuUZE
+title: "review(spec): approve SDD for hyperadmin-logfire"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - needs-human
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+**Human gate** — review and approve the SDD at `docs/specs/plugin-logfire.md`.
+
+## Checklist
+
+- [ ] Problem statement and goals are clear
+- [ ] Non-goals prevent over-engineering (dashboard widget, OTel-generic deferred)
+- [ ] BDD scenarios cover happy path + ≥1 failure path (logfire-not-configured)
+- [ ] Repo layout decision is sound (monorepo subpath)
+- [ ] Hook dependency on Epic 1 is explicit (two new hooks listed)
+- [ ] No core changes required beyond the new hooks
+- [ ] `instrument_admin` is idempotent and degrades gracefully
+- [ ] PyPI publishing strategy is acceptable (separate package, optional extra)
+- [ ] Open Questions resolved
+
+## Open Questions to resolve at review
+
+1. Add `[project.optional-dependencies].logfire = ["hyperadmin-logfire>=0.1"]` to root?
+2. Span name convention: `admin.adapter.list` vs `hyperadmin.adapter.list` (recommend former).
+3. Include `logfire.instrument_pydantic()`? (recommend no — too noisy)
+4. Verify Logfire test sink fixture works under our pytest-asyncio setup.
+
+## Blocked by
+
+- `docsspec-sdd-for-plugin-logfire` (SDD draft committed)
+- `reviewspec-approve-sdd-for-plugin-registry` (Epic 1 SDD must be approved with the
+  two new hooks `on_validation_error` and `on_auth_event` added)
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/test-e2e-end-to-end-spans-and-events-against-test-sink.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/test-e2e-end-to-end-spans-and-events-against-test-sink.md
@@ -1,0 +1,87 @@
+---
+type: story
+id: CgOAggzt_Geh
+title: "test(e2e): end-to-end spans and events against logfire test sink"
+status: todo
+priority: high
+assignee: null
+labels:
+  - testing
+  - size:M
+  - planned
+  - plugins
+  - observability
+  - e2e
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+End-to-end Playwright tests that drive a real admin (with `instrument_admin`
+called) and assert spans and events land in a Logfire test sink. Proves the
+full pipeline: HTTP → view → adapter wrapper → plugin hook → logfire span.
+
+**Spec:** [`docs/specs/plugin-logfire.md`](../../../../docs/specs/plugin-logfire.md)
+
+## Files to Change
+
+- **New:** `plugins/hyperadmin-logfire/tests/e2e/test_end_to_end_spans.py`
+- **New:** `plugins/hyperadmin-logfire/tests/e2e/test_disabled_plugin.py`
+- **Modified:** `tests/e2e/conftest.py` — extend `app` fixture to optionally call
+  `instrument_admin` when a `logfire_sink` fixture is in scope
+
+## Test Functions (1:1 with epic scenarios)
+
+```python
+async def test_instrument_admin_attaches_plugin_and_emits_adapter_spans(
+    page, logfire_sink, products_seeded
+):
+    """
+    Scenario: instrument_admin attaches the plugin and emits adapter spans
+      Given logfire is configured to capture spans in a test sink
+      And   instrument_admin(admin) has been called
+      When  the admin.products list view is requested
+      Then  the test sink contains a span named "admin.adapter.list" with attribute model="Product"
+    """
+
+async def test_validation_failure_emits_a_structured_event(
+    page, logfire_sink, products_seeded
+):
+    """Scenario: validation failure emits a structured event"""
+
+async def test_failed_login_emits_an_auth_event(
+    page, logfire_sink, alice_user
+):
+    """Scenario: failed login emits an auth event"""
+
+async def test_plugin_no_ops_when_logfire_is_not_configured(
+    page, products_seeded, caplog
+):
+    """Scenario: plugin no-ops when logfire is not configured"""
+
+async def test_plugin_is_not_loaded_when_disabled(
+    page, logfire_sink, products_seeded, admin_with_disabled_logfire
+):
+    """Scenario: plugin is not loaded when disabled"""
+```
+
+## Acceptance Criteria
+
+- [ ] All five E2E tests above implemented and passing
+- [ ] `logfire_sink` fixture stitched into the existing E2E `app` fixture
+- [ ] Inline `# Given / # When / # Then` comments in every test
+- [ ] Tests run as part of `poe test:e2e` and CI
+
+## Blocked by
+
+- `featpluginlogfire-instrumentedadapter-via-onbeforeafter-adapter-call`
+- `featpluginlogfire-emit-validation-error-events`
+- `featpluginlogfire-emit-auth-events`
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugin-logfire-first-plugin/stories/test-unit-instrumentedadapter-spans-and-noconfig-noop.md
+++ b/.meta/epics/epic-plugin-logfire-first-plugin/stories/test-unit-instrumentedadapter-spans-and-noconfig-noop.md
@@ -1,0 +1,74 @@
+---
+type: story
+id: kq5T3v-StZC6
+title: "test(unit): adapter spans, validation/auth events, no-config no-op"
+status: todo
+priority: high
+assignee: null
+labels:
+  - testing
+  - size:M
+  - planned
+  - plugins
+  - observability
+estimate: null
+epic_ref:
+  id: Plo-enMpTWhB
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Unit tests for `LogfirePlugin` using Logfire's test sink utility. No real
+admin app — just direct hook invocation against the plugin instance.
+
+**Spec:** [`docs/specs/plugin-logfire.md`](../../../../docs/specs/plugin-logfire.md)
+
+## Files to Change
+
+- **New:** `plugins/hyperadmin-logfire/tests/unit/test_plugin.py`
+- **New:** `plugins/hyperadmin-logfire/tests/unit/test_adapter_spans.py`
+- **New:** `plugins/hyperadmin-logfire/tests/unit/test_no_logfire_config.py`
+- **New:** `plugins/hyperadmin-logfire/tests/unit/conftest.py` — `logfire_sink` fixture
+
+## Test Cases
+
+```python
+# test_plugin.py
+def test_plugin_name_attribute(): ...
+def test_on_register_logs_info(caplog): ...
+def test_runtime_checkable_protocol_satisfaction(): ...
+
+# test_adapter_spans.py
+def test_open_close_emits_admin_adapter_op_span(logfire_sink, fake_model): ...
+def test_span_includes_model_and_op_attrs(logfire_sink, fake_model): ...
+def test_safe_attrs_for_list_op_includes_paging(logfire_sink, fake_model): ...
+def test_nested_calls_produce_nested_spans(logfire_sink, fake_model): ...
+def test_close_with_empty_stack_logs_warning_no_crash(caplog): ...
+def test_validation_error_event_emitted_with_field_errors(logfire_sink, fake_model): ...
+def test_non_serialisable_field_errors_stringified(logfire_sink, fake_model): ...
+def test_auth_login_failure_emitted_at_warn_level(logfire_sink): ...
+def test_auth_login_success_emitted_at_info_level(logfire_sink): ...
+def test_unknown_auth_event_type_ignored(logfire_sink): ...
+
+# test_no_logfire_config.py
+def test_warning_emitted_once_when_logfire_not_configured(caplog): ...
+def test_no_spans_emitted_when_logfire_not_configured(caplog): ...
+def test_instrument_admin_skips_when_plugin_disabled(mock_admin_disabled): ...
+```
+
+## Acceptance Criteria
+
+- [ ] All test cases above implemented and passing
+- [ ] `logfire_sink` fixture works under pytest-asyncio (smoke-tested in SDD review)
+- [ ] Coverage for `hyperadmin_logfire/` ≥ 90%
+- [ ] `poe test:unit` includes the new package
+
+## Blocked by
+
+- `featpluginlogfire-instrumentedadapter-via-onbeforeafter-adapter-call`
+
+## Parent
+
+- Epic: `epic-plugin-logfire-first-plugin`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/epic.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/epic.md
@@ -1,0 +1,96 @@
+---
+type: epic
+id: um1zqB0-b2AZ
+title: "epic(plugins): Plugin Registry & Lifecycle Hooks"
+status: todo
+priority: high
+owner: null
+labels:
+  - size:L
+  - planned
+  - plugins
+milestone_ref:
+  id: XnHVJphQRoMf
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Overview
+
+Introduce the foundational plugin contract for HyperAdmin: entry-point discovery,
+a runtime-checkable `Plugin` protocol, app-level lifecycle hooks, a disable
+mechanism, and a `hyperadmin plugins list` CLI introspection command. This epic
+unblocks every other v0.8.0+ extension workstream (`hyperadmin-logfire`, future
+ORM adapters, AI features) and is the first required piece of the milestone.
+
+**SDD:** [`docs/specs/plugin-registry.md`](../../../docs/specs/plugin-registry.md)
+(required — touches `core/`, `adapters/` boundary, `views/`, CLI).
+
+## Tracks
+
+### Track A: Discovery & Plugin protocol
+- New module `src/hyperadmin/core/plugins.py` — `Plugin` protocol, `PluginRegistry`.
+- `importlib.metadata.entry_points(group="hyperadmin.plugins")` discovery.
+- `Admin(disabled_plugins=...)` constructor arg + `HYPERADMIN_DISABLED_PLUGINS` env var.
+- `Admin.plugins` attribute, `Admin.dispatch_hook(name, **kwargs)` proxy.
+
+### Track B: Lifecycle hooks
+- `on_model_register` fired from `SiteRegistry.register()`.
+- `on_before_create` / `on_after_create` / `on_before_update` / `on_after_update` /
+  `on_before_delete` / `on_after_delete` fired from `DynamicModelView` create/update/
+  delete handlers.
+- `on_before_adapter_call` / `on_after_adapter_call` fired by an `_AdapterHookWrapper`
+  that wraps adapters at `SiteRegistry.register()` boundary — no concrete adapter
+  changes.
+- Failure isolation: hook exceptions logged at ERROR per-plugin, never raised.
+
+### Track C: CLI & docs
+- `hyperadmin plugins list` subcommand — prints discovered plugins, class paths, disabled state.
+- Plugin author guide + hook reference under `docs/`.
+
+## Scenarios
+
+**Scenario: plugin discovered via entry point on Admin construction**
+  Given a package "demo_plugin" exposes [project.entry-points."hyperadmin.plugins"] demo = "demo_plugin:DemoPlugin"
+  When  Admin(app, engine=engine) is constructed
+  Then  admin.plugins["demo"] is an instance of DemoPlugin
+  And   demo.on_register(admin) was called exactly once
+
+**Scenario: disabled plugin is not loaded**
+  Given the same demo_plugin is installed
+  When  Admin(app, engine=engine, disabled_plugins=["demo"]) is constructed
+  Then  "demo" is not in admin.plugins
+  And   DemoPlugin.on_register was not called
+
+**Scenario: on_before_create hook fires before adapter create**
+  Given a plugin registers an on_before_create hook that appends model_name to a list
+  When  POST /admin/products/create with valid data
+  Then  the hook list contains "Product" before the row exists in the DB
+
+**Scenario: hook exception is logged and does not break the request**
+  Given a plugin's on_after_update hook always raises RuntimeError
+  When  POST /admin/products/1/update with valid data
+  Then  the response is 302 (success redirect)
+  And   a structured log record at level ERROR mentions the plugin name and the hook
+
+**Scenario: hyperadmin plugins list CLI prints discovered plugins**
+  Given demo_plugin is installed
+  When  the user runs `hyperadmin plugins list`
+  Then  stdout contains "demo" and the plugin's class path
+
+**Scenario: adapter call hooks wrap every CRUD operation**
+  Given a plugin records (op, model) tuples in on_before_adapter_call / on_after_adapter_call
+  When  the list, create, update, delete views are exercised once each for Product
+  Then  the recorded tuples include ("list","Product"), ("create","Product"), ("update","Product"), ("delete","Product") in order
+  And   each "before" precedes its matching "after"
+
+## Acceptance Criteria
+
+- [ ] Plugin discovered via entry point on Admin construction
+- [ ] Disabled plugin is not loaded (ctor + env var)
+- [ ] `on_before_create` hook fires before adapter create
+- [ ] Hook exception is logged and does not break the request
+- [ ] `hyperadmin plugins list` CLI prints discovered plugins
+- [ ] Adapter call hooks wrap every CRUD operation in correct order
+- [ ] Unit + E2E tests for all six scenarios
+- [ ] Plugin author guide published under `docs/`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/docs-plugin-author-guide-and-hook-reference.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/docs-plugin-author-guide-and-hook-reference.md
@@ -1,0 +1,70 @@
+---
+type: story
+id: RxpZ4QbslvR5
+title: "docs: plugin author guide and hook reference"
+status: todo
+priority: medium
+assignee: null
+labels:
+  - documentation
+  - size:S
+  - planned
+  - plugins
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Publish a plugin author guide and hook reference under the docs site.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **New:** `docs/plugins/index.md` — overview, installation, disable mechanism
+- **New:** `docs/plugins/authoring.md` — step-by-step "your first plugin"
+- **New:** `docs/plugins/hooks.md` — table of all hooks, signatures, fire timing
+- **Modified:** `mkdocs.yml` — add a "Plugins" nav section
+
+## Content Outline
+
+### `docs/plugins/index.md`
+- What HyperAdmin plugins are
+- How to install (`pip install hyperadmin-foo`)
+- How to disable (`Admin(disabled_plugins=...)`, env var)
+- How to introspect (`hyperadmin plugins list`)
+
+### `docs/plugins/authoring.md`
+- Minimal plugin (5-line example with `Plugin` Protocol)
+- Declaring the entry point in `pyproject.toml`
+- Implementing `on_register`
+- Adding a hook handler (with the `name` attribute requirement)
+- Testing a plugin (using `monkeypatch` on `entry_points`)
+- Common pitfalls (per-request state, sync-only contract, exception isolation)
+
+### `docs/plugins/hooks.md`
+- Full hook reference table from SDD `### API / Protocol Changes` section
+- Fire timing: when, from which module, in what order
+- Hook ordering between plugins: alphabetical by entry-point name
+- Synchronous contract: hooks run in the request flow
+
+## Acceptance Criteria
+
+- [ ] All three doc pages published
+- [ ] `mkdocs.yml` nav updated
+- [ ] `poe docs:build` succeeds
+- [ ] `poe docs:serve` renders the new section locally
+- [ ] Internal links between pages work (no 404s)
+
+## Blocked by
+
+- `test-e2e-plugin-hook-firing-and-failure-isolation` (so docs match the
+  shipped behaviour, not the SDD draft)
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/docsspec-sdd-for-plugin-registry.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/docsspec-sdd-for-plugin-registry.md
@@ -1,0 +1,50 @@
+---
+type: story
+id: rJGg9GraxS4D
+title: "docs(spec): SDD for plugin registry & lifecycle hooks"
+status: done
+priority: high
+assignee: null
+labels:
+  - documentation
+  - size:S
+  - planned
+  - plugins
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Write the Software Design Document for the Plugin Registry & Lifecycle Hooks epic.
+
+**Output:** `docs/specs/plugin-registry.md` (Status: Draft)
+
+## Scope
+
+The SDD must cover:
+- `Plugin` protocol design (runtime-checkable, optional hook methods, `name` attribute)
+- `PluginRegistry` design — discovery via `importlib.metadata.entry_points`, disable
+  mechanism (ctor + env var), failure isolation
+- App-level hook list and signatures (`on_model_register`, `on_before_create`,
+  `on_after_create`, `on_before_update`, `on_after_update`, `on_before_delete`,
+  `on_after_delete`, `on_before_adapter_call`, `on_after_adapter_call`)
+- Adapter wrapping strategy (decided: wrap at `SiteRegistry.register()` boundary)
+- Edge cases: import failures, hook exceptions, name collisions, async hooks (deferred)
+- Backward compatibility: pure addition, no semver major bump
+- Decision log entries with rejected alternatives
+
+## Acceptance Criteria
+
+- [x] SDD follows `docs/specs/TEMPLATE.md` structure
+- [x] BDD scenarios synced with epic body
+- [x] Status set to "Draft"
+- [x] Adapter wrapping strategy decided and recorded in Decision Log
+- [x] Open Questions enumerated for review
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featadapters-wrap-baseadapter-with-onbeforeafter-adapter-call-hooks.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featadapters-wrap-baseadapter-with-onbeforeafter-adapter-call-hooks.md
@@ -1,0 +1,108 @@
+---
+type: story
+id: mzMHxg0eqXhQ
+title: "feat(adapters): wrap BaseAdapter with on_before/after_adapter_call hooks"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:M
+  - planned
+  - plugins
+  - adapters
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Introduce `_AdapterHookWrapper(BaseAdapter)` that delegates every method to an
+inner adapter and dispatches `on_before_adapter_call` / `on_after_adapter_call`
+around each call. Wrap at `SiteRegistry.register()` boundary so concrete adapters
+(`SQLModelAdapter`, `SQLAlchemyAdapter`) stay clean.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/core/plugins.py` — add `_AdapterHookWrapper`
+- **Modified:** `src/hyperadmin/core/registry.py:20-69` — wrap adapter at registration
+
+## Design
+
+```python
+# core/plugins.py
+class _AdapterHookWrapper(BaseAdapter):
+    def __init__(self, *, inner: BaseAdapter, admin: "Admin", model: type) -> None:
+        self._inner = inner
+        self._admin = admin
+        self._model = model
+
+    async def list(self, **kwargs):
+        self._admin.dispatch_hook(
+            "on_before_adapter_call",
+            admin=self._admin, model=self._model, op="list", kwargs=kwargs,
+        )
+        result = await self._inner.list(**kwargs)
+        self._admin.dispatch_hook(
+            "on_after_adapter_call",
+            admin=self._admin, model=self._model, op="list", result=result,
+        )
+        return result
+
+    # similar wrappers for: get, create, update, delete, get_related,
+    # get_choices, save_inline_rows, get_schema, get_queryset
+```
+
+Methods that mutate state (`create`, `update`, `delete`, `save_inline_rows`) fire
+`before` then `after`. Read methods (`list`, `get`, `get_related`, `get_choices`,
+`get_schema`, `get_queryset`) also fire both — observability shouldn't be
+read/write-asymmetric.
+
+Zero-overhead path: if `not self._admin.plugins` → `SiteRegistry.register` skips
+the wrap entirely, returning the bare adapter.
+
+```python
+# core/registry.py — inside register()
+adapter = adapter_cls(model, engine=...)
+if self._admin.plugins:
+    adapter = _AdapterHookWrapper(inner=adapter, admin=self._admin, model=model)
+self._models[model] = (adapter, options)
+```
+
+## Scenarios
+
+**Scenario: adapter call hooks wrap every CRUD operation**
+  Given a plugin records (op, model) tuples in on_before_adapter_call / on_after_adapter_call
+  When  the list, create, update, delete views are exercised once each for Product
+  Then  the recorded tuples include ("list","Product"), ("create","Product"), ("update","Product"), ("delete","Product") in order
+  And   each "before" precedes its matching "after"
+
+**Scenario: wrapper is transparent when no plugins are loaded**
+  Given Admin is constructed with no entry points present
+  When  SiteRegistry.register(Product) is called
+  Then  _models[Product][0] is the bare adapter, not _AdapterHookWrapper
+
+**Scenario: inner adapter exception still bubbles, but on_after still fires** (decision: NO — see Decision Log in SDD)
+  *Removed — exceptions short-circuit on_after to mirror sync semantics. Document in design.*
+
+## Acceptance Criteria
+
+- [ ] `_AdapterHookWrapper` covers all 9 `BaseAdapter` methods
+- [ ] Wrapping is conditional on `bool(admin.plugins)` — zero overhead path verified
+- [ ] Hook order: before → inner → after; if inner raises, after does NOT fire
+- [ ] `model` and `op` attributes attached to every hook call
+- [ ] No regression in any adapter test
+- [ ] Coverage for `_AdapterHookWrapper` ≥ 95%
+
+## Blocked by
+
+- `featcore-implement-app-level-hook-dispatcher`
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcli-add-hyperadmin-plugins-list-command.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcli-add-hyperadmin-plugins-list-command.md
@@ -1,0 +1,97 @@
+---
+type: story
+id: 4ET1aIsAtQUl
+title: "feat(cli): add `hyperadmin plugins list` command"
+status: todo
+priority: medium
+assignee: null
+labels:
+  - dx
+  - size:S
+  - planned
+  - plugins
+  - cli
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Add a `hyperadmin plugins list` Typer subcommand that introspects discovered
+plugins and prints them as a table. Mirrors the existing `createsuperuser`
+command pattern at `src/hyperadmin/management/commands/createsuperuser.py`.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/management/commands/plugins.py`
+- **Modified:** `src/hyperadmin/__main__.py` — register the `plugins` subapp
+
+## Design
+
+```python
+# management/commands/plugins.py
+import typer
+from importlib.metadata import entry_points
+
+app = typer.Typer(help="Manage HyperAdmin plugins")
+
+
+@app.command("list")
+def list_plugins() -> None:
+    """List all discovered hyperadmin.plugins entry points."""
+    eps = entry_points(group="hyperadmin.plugins")
+    if not eps:
+        typer.echo("No plugins discovered.")
+        raise typer.Exit(0)
+
+    disabled = {
+        n.strip() for n in os.environ.get("HYPERADMIN_DISABLED_PLUGINS", "").split(",")
+        if n.strip()
+    }
+
+    typer.echo(f"{'NAME':<24} {'CLASS':<48} STATUS")
+    for ep in sorted(eps, key=lambda e: e.name):
+        status = "disabled" if ep.name in disabled else "active"
+        typer.echo(f"{ep.name:<24} {ep.value:<48} {status}")
+```
+
+`__main__.py` registers via `app.add_typer(plugins.app, name="plugins")`.
+
+## Scenarios
+
+**Scenario: hyperadmin plugins list CLI prints discovered plugins**
+  Given demo_plugin is installed
+  When  the user runs `hyperadmin plugins list`
+  Then  stdout contains "demo" and the plugin's class path
+
+**Scenario: hyperadmin plugins list shows disabled status**
+  Given demo_plugin is installed
+  And   HYPERADMIN_DISABLED_PLUGINS=demo
+  When  the user runs `hyperadmin plugins list`
+  Then  the row for "demo" shows "disabled"
+
+**Scenario: hyperadmin plugins list with no plugins**
+  Given no entry points exist for hyperadmin.plugins
+  When  the user runs `hyperadmin plugins list`
+  Then  stdout is "No plugins discovered." and exit code is 0
+
+## Acceptance Criteria
+
+- [ ] `hyperadmin plugins list` registered as Typer subcommand
+- [ ] Output table includes name, class path, status (active/disabled)
+- [ ] Sorted alphabetically by entry-point name
+- [ ] No discovery errors short-circuit the listing (skip + warn)
+- [ ] Unit tests using Typer's `CliRunner`
+
+## Blocked by
+
+- `featcore-wire-plugin-discovery-into-admin-init`
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcore-add-plugin-protocol-and-registry-module.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcore-add-plugin-protocol-and-registry-module.md
@@ -1,0 +1,112 @@
+---
+type: story
+id: qLiduVMFCQew
+title: "feat(core): add Plugin protocol and PluginRegistry module"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:M
+  - planned
+  - plugins
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Introduce the `Plugin` protocol and `PluginRegistry` class in a new module
+`src/hyperadmin/core/plugins.py`. This is the foundation that everything else in the
+epic depends on. No wiring yet — just the contract.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/core/plugins.py`
+- **Modified:** `src/hyperadmin/core/__init__.py` — export `Plugin`, `PluginRegistry`
+- **Modified:** `src/hyperadmin/__init__.py` — re-export `Plugin` for plugin authors
+
+## Design
+
+```python
+# src/hyperadmin/core/plugins.py
+from __future__ import annotations
+import logging
+import os
+from importlib.metadata import entry_points
+from typing import TYPE_CHECKING, Any, Callable, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from hyperadmin.core.app import Admin
+
+log = logging.getLogger("hyperadmin.plugins")
+
+
+@runtime_checkable
+class Plugin(Protocol):
+    name: str
+
+    def on_register(self, admin: "Admin") -> None: ...
+
+
+class PluginRegistry:
+    def __init__(self) -> None:
+        self._plugins: dict[str, Plugin] = {}
+
+    @classmethod
+    def discover(
+        cls,
+        *,
+        admin: "Admin",
+        disabled: set[str] | None = None,
+    ) -> "PluginRegistry": ...
+
+    def __contains__(self, name: str) -> bool: ...
+    def __getitem__(self, name: str) -> Plugin: ...
+    def __bool__(self) -> bool: ...
+    def names(self) -> list[str]: ...
+
+    def dispatch(self, hook: str, /, **kwargs: Any) -> None:
+        """Call every registered handler for `hook`. Exceptions logged, not raised."""
+```
+
+`disabled` is the union of the constructor argument (caller passes
+`set(admin.disabled_plugins)`) and `HYPERADMIN_DISABLED_PLUGINS` parsed from env.
+Entries skipped during discovery are NOT added to `self._plugins`.
+
+`dispatch` iterates all plugins, calls `getattr(plugin, hook, None)`, invokes if
+callable, catches `Exception`, logs at ERROR with `plugin`, `hook`, exc info.
+
+## Scenarios
+
+**Scenario: protocol is runtime-checkable**
+  Given a class with `name: str` and `on_register(self, admin) -> None`
+  When  `isinstance(instance, Plugin)` is evaluated
+  Then  result is True
+
+**Scenario: registry is empty by default**
+  Given no entry points exist for "hyperadmin.plugins"
+  When  PluginRegistry.discover(admin=mock, disabled=set()) is called
+  Then  the returned registry has names() == []
+  And   bool(registry) is False
+
+## Acceptance Criteria
+
+- [ ] `Plugin` protocol defined and runtime-checkable
+- [ ] `PluginRegistry` class with `discover` / `dispatch` / `names` / `__contains__` / `__getitem__` / `__bool__`
+- [ ] Imports lazy: `core/plugins.py` uses `TYPE_CHECKING` for `Admin` import
+- [ ] Exported from `hyperadmin.core.__init__` and `hyperadmin.__init__`
+- [ ] `poe lint` passes
+
+## Blocked by
+
+- `reviewspec-approve-sdd-for-plugin-registry` (SDD approved)
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcore-fire-onmodelregister-from-siteregistry.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcore-fire-onmodelregister-from-siteregistry.md
@@ -1,0 +1,77 @@
+---
+type: story
+id: pjMf5_ic9HU3
+title: "feat(core): fire on_model_register from SiteRegistry"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:S
+  - planned
+  - plugins
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Fire the `on_model_register` hook from `SiteRegistry.register()` after a model
++ adapter + options has been successfully attached. Plugins receive
+`(admin, model, options)` and can index models, pre-warm caches, register custom
+spans, etc.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/core/registry.py:20-69` — `SiteRegistry.register`
+
+## Design
+
+After successful registration, before returning, dispatch:
+
+```python
+self._admin.dispatch_hook(
+    "on_model_register",
+    admin=self._admin,
+    model=model,
+    options=options,
+)
+```
+
+`SiteRegistry` already holds a back-reference to `Admin`; if not, add it during
+the `Admin.__init__` story.
+
+Hook fires once per `register()` call. If the same model is registered twice (an
+existing error path), the hook only fires for the successful first call.
+
+## Scenarios
+
+**Scenario: on_model_register fires for each registered model**
+  Given a plugin records (model_name) into a list in on_model_register
+  When  Admin auto-registers User and Product models
+  Then  the list contains "User" and "Product" exactly once each
+
+**Scenario: on_model_register fires after adapter is attached**
+  Given a plugin's on_model_register reads admin.site._models[model][0] (the adapter)
+  When  the hook fires for Product
+  Then  the read succeeds and returns a non-None adapter
+
+## Acceptance Criteria
+
+- [ ] Hook fires exactly once per successful `SiteRegistry.register()` call
+- [ ] Hook fires AFTER adapter and options are stored (plugins can read them)
+- [ ] Hook does NOT fire on duplicate-register error
+- [ ] Unit test added under `tests/unit/core/test_plugin_hooks.py`
+
+## Blocked by
+
+- `featcore-implement-app-level-hook-dispatcher`
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcore-implement-app-level-hook-dispatcher.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcore-implement-app-level-hook-dispatcher.md
@@ -1,0 +1,83 @@
+---
+type: story
+id: QWzNA81Jovue
+title: "feat(core): implement app-level hook dispatcher with failure isolation"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:S
+  - planned
+  - plugins
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Implement the dispatch loop on `PluginRegistry`. For a given hook name, iterate all
+plugins, call the matching method if defined, catch and log any exception. This is
+the contract every other story in the epic relies on.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/core/plugins.py` — implement `PluginRegistry.dispatch`
+
+## Design
+
+```python
+def dispatch(self, hook: str, /, **kwargs: Any) -> None:
+    for name, plugin in self._plugins.items():
+        handler = getattr(plugin, hook, None)
+        if handler is None or not callable(handler):
+            continue
+        try:
+            handler(**kwargs)
+        except Exception:
+            log.exception(
+                "plugin hook raised",
+                extra={"plugin": name, "hook": hook},
+            )
+```
+
+Iteration order is insertion order of `self._plugins` (Python dict, sorted by
+entry-point name during `discover`).
+
+`structlog`-friendly: `extra={"plugin": ..., "hook": ...}` so structured backends
+can index by plugin/hook name.
+
+## Scenarios
+
+**Scenario: hook exception is logged and does not break the request**
+  Given a plugin's on_after_update hook always raises RuntimeError
+  When  POST /admin/products/1/update with valid data
+  Then  the response is 302 (success redirect)
+  And   a structured log record at level ERROR mentions the plugin name and the hook
+
+**Scenario: dispatch with no handlers is a no-op**
+  Given a registry with two plugins, neither defines on_xyz
+  When  registry.dispatch("on_xyz", foo=1) is called
+  Then  no log records are emitted
+  And   the call returns in O(plugins) without raising
+
+## Acceptance Criteria
+
+- [ ] `dispatch` iterates all plugins, catches exceptions, logs at ERROR
+- [ ] Log record includes `plugin` and `hook` in `extra` for structured logging
+- [ ] No-handler hooks are O(plugins) and silent
+- [ ] Subsequent handlers fire even if an earlier one raised
+- [ ] Unit tests passing (covered by `test-unit-tests-for-plugin-discovery-and-disable-mechanism`)
+
+## Blocked by
+
+- `featcore-wire-plugin-discovery-into-admin-init`
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcore-wire-plugin-discovery-into-admin-init.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featcore-wire-plugin-discovery-into-admin-init.md
@@ -1,0 +1,91 @@
+---
+type: story
+id: UExbEq_t2pV_
+title: "feat(core): wire plugin discovery into Admin.__init__"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:S
+  - planned
+  - plugins
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Wire `PluginRegistry.discover()` into `Admin.__init__` and add the
+`disabled_plugins` constructor argument. Plugins are discovered eagerly on
+construction; `on_register` fires for each.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/core/app.py:23-417` — `Admin.__init__`
+
+## Design
+
+```python
+class Admin:
+    def __init__(
+        self,
+        app: FastAPI,
+        engine: ...,
+        ...,
+        disabled_plugins: Iterable[str] = (),
+    ) -> None:
+        ...
+        # late in __init__, after self.app/self.engine are set,
+        # before any model registration:
+        env_disabled = {
+            n.strip() for n in os.environ.get("HYPERADMIN_DISABLED_PLUGINS", "").split(",")
+            if n.strip()
+        }
+        self.plugins = PluginRegistry.discover(
+            admin=self,
+            disabled=set(disabled_plugins) | env_disabled,
+        )
+```
+
+`Admin.dispatch_hook(name, **kwargs)` is a thin proxy:
+
+```python
+def dispatch_hook(self, hook: str, /, **kwargs: Any) -> None:
+    self.plugins.dispatch(hook, **kwargs)
+```
+
+## Scenarios
+
+**Scenario: plugin discovered via entry point on Admin construction**
+  Given a package "demo_plugin" exposes [project.entry-points."hyperadmin.plugins"] demo = "demo_plugin:DemoPlugin"
+  When  Admin(app, engine=engine) is constructed
+  Then  admin.plugins["demo"] is an instance of DemoPlugin
+  And   demo.on_register(admin) was called exactly once
+
+**Scenario: disabled plugin is not loaded**
+  Given the same demo_plugin is installed
+  When  Admin(app, engine=engine, disabled_plugins=["demo"]) is constructed
+  Then  "demo" is not in admin.plugins
+  And   DemoPlugin.on_register was not called
+
+## Acceptance Criteria
+
+- [ ] `Admin(disabled_plugins=...)` argument added (keyword-only, default empty)
+- [ ] `Admin.plugins` populated before any auto-registration happens
+- [ ] `Admin.dispatch_hook` proxy method available
+- [ ] No regression in existing `Admin` tests
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `featcore-add-plugin-protocol-and-registry-module`
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featviews-fire-onbeforeafter-create-update-delete-around-views.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/featviews-fire-onbeforeafter-create-update-delete-around-views.md
@@ -1,0 +1,97 @@
+---
+type: story
+id: EUbD-9hQBaVC
+title: "feat(views): fire on_before/after_create/update/delete around CRUD views"
+status: todo
+priority: high
+assignee: null
+labels:
+  - backend
+  - size:M
+  - planned
+  - plugins
+  - views
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Fire app-level `on_before_create` / `on_after_create` / `on_before_update` /
+`on_after_update` / `on_before_delete` / `on_after_delete` hooks from
+`DynamicModelView` create, update, and delete handlers. These complement (not
+replace) the model-level `before_save` / `after_save` hooks on
+`HyperAdminModel` — model-level hooks remain for per-model logic; app-level hooks
+are for cross-cutting plugins.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/views/dynamic.py` — `create_view`, `update_view`,
+  `delete_view` handlers
+
+## Design
+
+In each handler, after validation succeeds and before the adapter call:
+
+```python
+# create_view
+self._admin.dispatch_hook(
+    "on_before_create", admin=self._admin, model=self._model, data=validated_data,
+)
+instance = await self._adapter.create(validated_data)
+self._admin.dispatch_hook(
+    "on_after_create", admin=self._admin, model=self._model, instance=instance,
+)
+```
+
+Update / delete follow the same pattern with their respective signatures
+(see SDD hook table). All hooks fire SYNCHRONOUSLY in the request flow; failure
+isolation comes from `dispatch` itself.
+
+If the adapter call raises, `on_after_*` does NOT fire (mirrors the
+adapter-wrapper semantics).
+
+## Scenarios
+
+**Scenario: on_before_create hook fires before adapter create**
+  Given a plugin registers an on_before_create hook that appends model_name to a list
+  When  POST /admin/products/create with valid data
+  Then  the hook list contains "Product" before the row exists in the DB
+
+**Scenario: on_after_update hook receives the updated instance**
+  Given a plugin records the instance.id in on_after_update
+  When  POST /admin/products/42/update with valid data
+  Then  the recorded id is 42
+
+**Scenario: on_before_delete fires before delete; on_after_delete fires after**
+  Given a plugin records hook order
+  When  POST /admin/products/42/delete
+  Then  the recorded order is ["before_delete", "after_delete"]
+
+**Scenario: validation failure prevents on_before_create from firing**
+  Given POST /admin/products/create with invalid data (returns 400)
+  When  the request completes
+  Then  on_before_create was not called
+  And   the validation_error event will be wired in the next story (deferred)
+
+## Acceptance Criteria
+
+- [ ] All six hooks fire from the correct handlers in `views/dynamic.py`
+- [ ] `before` fires only after validation succeeds
+- [ ] `after` fires only after the adapter call succeeds
+- [ ] Hook signatures match the SDD's hook table exactly
+- [ ] No regression in existing CRUD view tests
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `featcore-implement-app-level-hook-dispatcher`
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/reviewspec-approve-sdd-for-plugin-registry.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/reviewspec-approve-sdd-for-plugin-registry.md
@@ -1,0 +1,51 @@
+---
+type: story
+id: NXipXCqMh_dL
+title: "review(spec): approve SDD for plugin registry"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - needs-human
+  - plugins
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+**Human gate** — review and approve the SDD at `docs/specs/plugin-registry.md`.
+
+## Checklist
+
+- [ ] Problem statement is clear and scoped
+- [ ] Goals are measurable (can be verified by acceptance criteria)
+- [ ] Non-goals prevent over-engineering (explicit defer list)
+- [ ] BDD scenarios cover happy path + ≥1 failure path (failure: hook raises)
+- [ ] `Plugin` Protocol is backward compatible (no inheritance forced on plugins)
+- [ ] Adapter wrapping doesn't break existing `BaseAdapter` contract
+- [ ] Hook signatures are observer-only (no mutation in v1) — confirm
+- [ ] No async hook support in v1 — confirm acceptable
+- [ ] CLI subcommand pattern matches existing `createsuperuser`
+- [ ] Backward compatible — no semver major bump required
+- [ ] Open Questions resolved (`dispatch_hook` return values, async, naming, short-circuit)
+
+## Open Questions to resolve at review
+
+1. Should `dispatch_hook` allow handlers to return values (veto / mutate)?
+2. Async hooks — defer to v0.8.1, or design from the start?
+3. Naming: `on_before_adapter_call` vs `on_adapter_call_start` (recommend former).
+4. Wrapper short-circuit: implicit in `dispatch` or explicit `has_handlers(name)`?
+
+## Blocked by
+
+- `docsspec-sdd-for-plugin-registry` (SDD draft committed)
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/test-e2e-plugin-hook-firing-and-failure-isolation.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/test-e2e-plugin-hook-firing-and-failure-isolation.md
@@ -1,0 +1,86 @@
+---
+type: story
+id: cGk6vHhW7bZC
+title: "test(e2e): plugin hook firing and failure isolation through full request flow"
+status: todo
+priority: high
+assignee: null
+labels:
+  - testing
+  - size:M
+  - planned
+  - plugins
+  - e2e
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+End-to-end Playwright tests that exercise plugin hooks through real HTTP
+requests against a running admin. Uses an in-test plugin registered via a
+pytest fixture that monkeypatches `entry_points`.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **New:** `tests/e2e/test_plugin_hooks.py`
+- **New:** `tests/e2e/_plugin_fixtures.py` — shared `RecordingPlugin` and `BrokenPlugin`
+  classes plus a `plugins_registered` fixture that monkeypatches `entry_points`
+
+## Test Functions (1:1 with epic scenarios)
+
+```python
+async def test_plugin_discovered_via_entry_point_on_admin_construction(
+    page, recording_plugin
+):
+    """
+    Scenario: plugin discovered via entry point on Admin construction
+      Given a package "demo_plugin" exposes [project.entry-points."hyperadmin.plugins"] demo = "demo_plugin:DemoPlugin"
+      When  Admin(app, engine=engine) is constructed
+      Then  admin.plugins["demo"] is an instance of DemoPlugin
+      And   demo.on_register(admin) was called exactly once
+    """
+
+async def test_disabled_plugin_is_not_loaded(page, recording_plugin_disabled):
+    """Scenario: disabled plugin is not loaded"""
+
+async def test_on_before_create_hook_fires_before_adapter_create(
+    page, recording_plugin
+):
+    """Scenario: on_before_create hook fires before adapter create"""
+
+async def test_hook_exception_is_logged_and_does_not_break_request(
+    page, broken_plugin, caplog
+):
+    """Scenario: hook exception is logged and does not break the request"""
+
+async def test_adapter_call_hooks_wrap_every_crud_operation(
+    page, recording_plugin
+):
+    """Scenario: adapter call hooks wrap every CRUD operation"""
+```
+
+CLI scenario lives in unit tests (no E2E browser needed for stdout check).
+
+## Acceptance Criteria
+
+- [ ] All five E2E tests above implemented
+- [ ] Use `data-testid` selectors per CLAUDE.md (no `.ha-*`)
+- [ ] Inline `# Given / # When / # Then` comments in every test
+- [ ] `poe test:e2e` passes locally and in CI
+- [ ] Visual snapshots (if any added) committed
+
+## Blocked by
+
+- `featcore-fire-onmodelregister-from-siteregistry`
+- `featadapters-wrap-baseadapter-with-onbeforeafter-adapter-call-hooks`
+- `featviews-fire-onbeforeafter-create-update-delete-around-views`
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/test-unit-tests-for-plugin-discovery-and-disable-mechanism.md
+++ b/.meta/epics/epic-plugins-registry-and-lifecycle-hooks/stories/test-unit-tests-for-plugin-discovery-and-disable-mechanism.md
@@ -1,0 +1,84 @@
+---
+type: story
+id: fY2baq9AS-fH
+title: "test(unit): plugin discovery, disable mechanism, dispatch isolation"
+status: todo
+priority: high
+assignee: null
+labels:
+  - testing
+  - size:M
+  - planned
+  - plugins
+estimate: null
+epic_ref:
+  id: um1zqB0-b2AZ
+created_at: 2026-05-05T00:00:00Z
+updated_at: 2026-05-05T00:00:00Z
+---
+
+## Summary
+
+Unit tests for `PluginRegistry`. Mock `importlib.metadata.entry_points` to inject
+fake plugins; assert discovery, disable, dispatch, and failure-isolation behaviour.
+
+**Spec:** [`docs/specs/plugin-registry.md`](../../../../docs/specs/plugin-registry.md)
+
+## Files to Change
+
+- **New:** `tests/unit/core/test_plugins.py`
+
+## Test Cases
+
+```python
+async def test_protocol_is_runtime_checkable() -> None:
+    """Scenario: protocol is runtime-checkable"""
+
+async def test_registry_empty_when_no_entry_points(monkeypatch) -> None:
+    """Scenario: registry is empty by default"""
+
+async def test_discovery_loads_plugin_and_calls_on_register(monkeypatch) -> None:
+    """Scenario: plugin discovered via entry point on Admin construction"""
+
+async def test_disabled_plugin_not_loaded_via_ctor(monkeypatch) -> None:
+    """Scenario: disabled plugin is not loaded (ctor)"""
+
+async def test_disabled_plugin_not_loaded_via_env(monkeypatch) -> None:
+    """Scenario: HYPERADMIN_DISABLED_PLUGINS env var disables plugin"""
+
+async def test_disable_ctor_and_env_take_union(monkeypatch) -> None:
+    """env-disabled plugins cannot be re-enabled by omitting from ctor list"""
+
+async def test_plugin_import_failure_skipped_and_logged(monkeypatch, caplog) -> None:
+    """import error in entry point → log ERROR, skip, continue loading others"""
+
+async def test_on_register_failure_skipped_and_logged(monkeypatch, caplog) -> None:
+    """on_register raises → log ERROR, plugin removed from registry"""
+
+async def test_dispatch_calls_all_handlers_in_definition_order(monkeypatch) -> None:
+    """two plugins for same hook → both fire in entry-point name order"""
+
+async def test_dispatch_isolates_handler_exceptions(monkeypatch, caplog) -> None:
+    """one handler raises → other handlers still fire, log ERROR records plugin+hook"""
+
+async def test_dispatch_with_no_handlers_is_noop() -> None:
+    """fast path: no entries for hook name → dispatch does not iterate"""
+
+async def test_name_collision_first_wins(monkeypatch, caplog) -> None:
+    """two plugins claim the same name → first wins, second logs WARNING"""
+```
+
+## Acceptance Criteria
+
+- [ ] All twelve test cases above implemented and passing
+- [ ] Tests use `monkeypatch` on `importlib.metadata.entry_points`, no real package install
+- [ ] Coverage for `core/plugins.py` ≥ 95%
+- [ ] `poe test:unit` passes
+
+## Blocked by
+
+- `featcore-add-plugin-protocol-and-registry-module` (PluginRegistry exists)
+
+## Parent
+
+- Epic: `epic-plugins-registry-and-lifecycle-hooks`

--- a/.meta/roadmap/milestones/v080-plugins-ai.md
+++ b/.meta/roadmap/milestones/v080-plugins-ai.md
@@ -13,4 +13,11 @@ created_at: 2026-03-29T09:35:06Z
 updated_at: 2026-03-29T09:35:06Z
 ---
 
-P3: Plugin registry with entry points + AI-powered search/suggestions + additional ORM adapters. Epics 6.1, 6.3, 6.5, 6.6.
+Re-themed for v0.8.0: ship the **Plugin Registry + lifecycle hooks** (`hyperadmin.plugins`
+entry points) and the first official plugin **hyperadmin-logfire** as proof-of-concept.
+AI-assisted features (RFC #277), additional ORM adapters (Tortoise / Piccolo / MongoDB),
+and custom non-CRUD page registration deferred to v0.8.1+.
+
+Epics:
+- `epic-plugins-registry-and-lifecycle-hooks` (size:L, SDD: `docs/specs/plugin-registry.md`)
+- `epic-plugin-logfire-first-plugin` (size:L, SDD: `docs/specs/plugin-logfire.md`, blocked by Epic 1)

--- a/docs/specs/plugin-logfire.md
+++ b/docs/specs/plugin-logfire.md
@@ -1,0 +1,205 @@
+# SDD: hyperadmin-logfire — first official plugin
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD |
+| Milestone | v0.8.0 — Plugins |
+| Created | 2026-05-05 |
+| Last updated | 2026-05-05 |
+
+---
+
+## Problem
+
+Admin perf problems hide until users complain — slow list queries, N+1, validation
+bottlenecks. There is no first-party observability story for HyperAdmin. The plugin
+registry SDD (`docs/specs/plugin-registry.md`) defines the contract; this SDD is the
+**first consumer** of that contract and the **proof-of-concept that it works without
+core modification**.
+
+If this plugin requires any change to `core/` beyond the hooks defined in the registry
+SDD, the registry SDD is wrong and must be revised. That is the design pressure on
+this work.
+
+## Goals
+
+1. **One-call setup**: `instrument_admin(admin)` wires everything.
+2. **Adapter spans**: `admin.adapter.<op>` spans with attributes `model`, `op`, paging
+   and filter context — emitted via `on_before_adapter_call` / `on_after_adapter_call`.
+3. **HTTP + SQL coverage**: leverage `logfire.instrument_fastapi(admin.app)` and
+   `logfire.instrument_sqlalchemy(admin.engine)` for transparent HTTP/SQL spans
+   parented under the adapter span.
+4. **Validation events**: structured `admin.validation_error` events when admin form
+   validation fails, with `model` and `field_errors` attributes.
+5. **Auth events**: `admin.auth.login_success`, `admin.auth.login_failure`,
+   `admin.auth.logout`, `admin.auth.permission_denied`.
+6. **No-op when unconfigured**: if `logfire.configure()` was not called, the plugin
+   logs a one-shot warning and emits nothing — never crashes.
+7. **Zero changes to `src/hyperadmin/core/`** — proves the plugin contract.
+
+## Non-Goals
+
+- **In-admin perf dashboard widget** — RFC #276 Phase 2; deferred to v0.8.1+.
+- **OTel-generic variant (`hyperadmin-otel`)** — defer until there's a user with a
+  non-Logfire OTel backend who complains.
+- **Sampling configuration** — defer; users configure sampling on their `logfire`
+  client directly.
+- **Custom span attributes per model** — `AdminOptions.observability_attrs` etc. is
+  out of scope; if a user needs this, they wrap their own adapter.
+
+## BDD Scenarios
+
+```
+Scenario: instrument_admin attaches the plugin and emits adapter spans
+  Given logfire is configured to capture spans in a test sink
+  And   instrument_admin(admin) has been called
+  When  the admin.products list view is requested
+  Then  the test sink contains a span named "admin.adapter.list" with attribute model="Product"
+
+Scenario: validation failure emits a structured event
+  Given logfire is configured to capture events
+  When  POST /admin/products/create with an invalid payload
+  Then  the sink contains an event "admin.validation_error" with attributes model="Product" and field_errors non-empty
+
+Scenario: failed login emits an auth event
+  Given logfire is configured to capture events
+  When  POST /admin/login with username=alice password=wrong
+  Then  the sink contains an event "admin.auth.login_failure" with attribute username="alice"
+
+Scenario: plugin no-ops when logfire is not configured
+  Given logfire.configure() was NOT called
+  When  Admin is constructed and a list view is requested
+  Then  no exceptions are raised
+  And   a single warning log mentions hyperadmin-logfire requires logfire.configure()
+
+Scenario: plugin is not loaded when disabled
+  Given hyperadmin-logfire is installed
+  When  Admin(app, engine=engine, disabled_plugins=["logfire"]) is constructed
+  Then  no admin.adapter.* spans are emitted on subsequent requests
+```
+
+## Design
+
+### Architecture
+
+**Repo layout decision: monorepo subpath at `plugins/hyperadmin-logfire/`** with its
+own `pyproject.toml`. Reasons:
+
+- Atomic dual-PR with Epic 1 hook changes (any missing hook can be added in the same PR).
+- Single CI matrix; no second repo to bootstrap.
+- Promote to its own GitHub repo later (after v0.8.0) if community contribution warrants.
+
+```
+plugins/hyperadmin-logfire/
+  pyproject.toml                           # name="hyperadmin-logfire", entry-point: logfire = "hyperadmin_logfire:LogfirePlugin"
+  README.md
+  src/hyperadmin_logfire/
+    __init__.py                            # exports: LogfirePlugin, instrument_admin
+    plugin.py                              # LogfirePlugin(Plugin) with all hook methods
+    adapter_spans.py                       # span helpers — pure functions
+    auth_events.py                         # auth event emit helpers
+    _config_check.py                       # one-shot warning when logfire not configured
+  tests/
+    unit/
+      test_plugin.py
+      test_adapter_spans.py
+      test_no_logfire_config.py
+    e2e/
+      test_end_to_end_spans.py
+      test_disabled_plugin.py
+```
+
+Root `pyproject.toml` adds `plugins/hyperadmin-logfire` to `[tool.uv.workspace.members]`
+so `uv sync --all-extras` picks it up for development. Published to PyPI separately.
+
+### Hook usage (consumes only Epic 1 contract)
+
+| Plugin behaviour | Hook used |
+|---|---|
+| Adapter span open + close | `on_before_adapter_call` / `on_after_adapter_call` |
+| Validation error event | New hook **not yet in registry SDD**: `on_validation_error(admin, model, field_errors)`. **Action: add to Epic 1 SDD before merging.** Alternative: emit directly from `instrument_admin` by patching `PydanticForm.validate()` — rejected (violates "no core changes"). |
+| Auth events | New hook **not yet in registry SDD**: `on_auth_event(admin, event_type, user, **context)`. **Action: add to Epic 1 SDD before merging.** Alternative: ASGI middleware that listens on the existing auth response codes — possible but fragile (can't distinguish login_success from any other 302). |
+| `instrument_admin(admin)` | Calls `logfire.instrument_fastapi(admin.app)` and `logfire.instrument_sqlalchemy(admin.engine)` directly. These are public Logfire APIs — no HyperAdmin hook needed. |
+
+**Net effect on Epic 1 SDD**: two hooks must be added (`on_validation_error`,
+`on_auth_event`) before this epic's SDD is approved. They are uncontroversial additions
+(observer-pattern hooks like the rest), but the dependency is explicit.
+
+### Data Model Changes
+
+No data model changes.
+
+### API / Protocol Changes
+
+New public API in the plugin package:
+
+```python
+# hyperadmin_logfire/__init__.py
+def instrument_admin(admin: "Admin") -> None:
+    """One-call setup. Idempotent.
+
+    1. logfire.instrument_fastapi(admin.app)
+    2. logfire.instrument_sqlalchemy(admin.engine)
+    3. (Plugin already discovered and on_register'd; no further action needed.)
+    """
+
+class LogfirePlugin:
+    name = "logfire"
+    def on_register(self, admin): ...
+    def on_before_adapter_call(self, admin, model, op, kwargs): ...
+    def on_after_adapter_call(self, admin, model, op, result): ...
+    def on_validation_error(self, admin, model, field_errors): ...
+    def on_auth_event(self, admin, event_type, user, **ctx): ...
+```
+
+The plugin uses `contextvars` to carry the open `logfire.span` between
+`on_before_adapter_call` and `on_after_adapter_call`. Failure to find an open span
+in `on_after_*` is logged at WARNING and otherwise ignored.
+
+### Configuration Changes
+
+`pip install hyperadmin-logfire` (or `pip install hyperadmin[logfire]` if we add a
+`[project.optional-dependencies].logfire = ["hyperadmin-logfire>=0.1"]` extra to root —
+recommended for discoverability).
+
+No new env vars. Logfire's own configuration (`LOGFIRE_TOKEN`, etc.) is unchanged.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| `logfire.configure()` not called | One-shot WARNING logged on first hook fire; all subsequent hooks no-op. Tracked via module-level `_warned` flag. |
+| `logfire` not installed | Plugin entry point won't import; `PluginRegistry.discover` logs ERROR and skips. (Per Epic 1 contract — no special handling here.) |
+| Open span lost (e.g. exception between before/after hook) | `on_after_adapter_call` notices missing context, logs WARNING, no-ops. |
+| `instrument_admin` called twice | Logfire's `instrument_fastapi` / `instrument_sqlalchemy` are idempotent — second call no-ops at their layer. We add no extra guard. |
+| Plugin disabled via `disabled_plugins=["logfire"]` | Per Epic 1 contract — plugin not loaded; `instrument_admin` called by user is also a no-op (we check `"logfire" in admin.plugins` before doing the FastAPI/SQLAlchemy instrumentation). |
+| Auth event fired before `admin.user` available | `user` arg may be `None` for `login_failure`; documented in the hook signature. |
+| Validation errors contain non-serialisable objects | Stringified before logging. |
+
+## Migration & Backward Compatibility
+
+Pure addition. No core changes (modulo the two new hooks added to Epic 1 SDD).
+
+## Open Questions
+
+- [ ] **Add `[project.optional-dependencies].logfire = ["hyperadmin-logfire>=0.1"]`
+      to root `pyproject.toml`?** Recommend yes — `pip install hyperadmin[logfire]`
+      is cleaner UX than two installs. Confirm at SDD review.
+- [ ] **Span name convention** — `admin.adapter.list` vs `hyperadmin.adapter.list`?
+      RFC #276 uses `admin.*`; recommend keeping that. Confirm.
+- [ ] **Should `instrument_admin` also call `logfire.instrument_pydantic()`?** Tempting
+      but noisy (instruments ALL Pydantic validation, not just admin forms). Recommend no.
+- [ ] **Test sink fixture** — Logfire ships a test capture utility; confirm it works
+      under our pytest-asyncio setup before story #8 is dispatched.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Monorepo subpath `plugins/hyperadmin-logfire/` | Atomic dual-PR with Epic 1; single CI matrix; can promote later | Separate repo from day 1 — premature, slows iteration during the proof-of-concept window |
+| Add two new hooks to Epic 1 SDD (`on_validation_error`, `on_auth_event`) | Avoids monkey-patching `PydanticForm` and parsing 302 redirects in middleware; matches the observer-hook pattern of the rest of the contract | (a) Patch `PydanticForm.validate()` — violates "no core changes"; (b) ASGI middleware sniffing auth responses — fragile, can't distinguish event types |
+| Use `contextvars` to bridge before/after adapter hooks | Async-safe, request-scoped, doesn't require passing state through the hook signature | (a) `dict` keyed on `(thread_id, model, op)` — broken under asyncio; (b) Stash on `admin` — global mutable state |
+| `instrument_admin()` does both Logfire instrumentation AND verifies plugin discovery | One call for users; clear failure mode if plugin disabled | Split into two functions — extra docs surface for no benefit |
+| No span on `on_register` | One-shot; not interesting | Span — clutter in dashboards |

--- a/docs/specs/plugin-registry.md
+++ b/docs/specs/plugin-registry.md
@@ -1,0 +1,281 @@
+# SDD: Plugin Registry & Lifecycle Hooks
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD |
+| Milestone | v0.8.0 — Plugins |
+| Created | 2026-05-05 |
+| Last updated | 2026-05-05 |
+
+---
+
+## Problem
+
+HyperAdmin has zero extension surface today. The only existing hooks are model-level
+(`HyperAdminModel.before_save / after_save / before_delete / after_delete` at
+`src/hyperadmin/core/model.py:62-71`) and adapter-level
+(`BaseAdapter.get_queryset(request)` at `src/hyperadmin/core/adapters.py:59-85`).
+There is no app-level lifecycle, no entry-point discovery, no `Plugin` contract.
+
+That blocks four near-term workstreams:
+
+- **`hyperadmin-logfire`** (RFC #276) — needs `on_before_adapter_call` /
+  `on_after_adapter_call` to wrap CRUD spans without monkey-patching.
+- **Future ORM adapters and AI features** — need a stable, discoverable place to attach.
+- **Community plugins** — currently impossible to ship without a fork.
+- **Per-deployment customisation** — operators have no clean way to add audit logging,
+  custom auth providers, or telemetry without modifying core.
+
+This SDD designs the minimal plugin contract that unblocks all of the above without
+locking in choices we will regret in v0.9+.
+
+## Goals
+
+1. **Entry-point discovery** — packages declare `[project.entry-points."hyperadmin.plugins"]`;
+   `Admin.__init__` discovers them via `importlib.metadata.entry_points`.
+2. **`Plugin` protocol** — runtime-checkable Protocol every plugin satisfies; minimal API
+   (`name`, `on_register(admin)`, optional hook methods).
+3. **App-level lifecycle hooks** — `on_model_register`, `on_before_create`,
+   `on_after_create`, `on_before_update`, `on_after_update`, `on_before_delete`,
+   `on_after_delete`, `on_before_adapter_call`, `on_after_adapter_call`.
+4. **Disable mechanism** — `Admin(disabled_plugins=[...])` constructor arg and
+   `HYPERADMIN_DISABLED_PLUGINS` env var (comma-separated names).
+5. **CLI introspection** — `hyperadmin plugins list` prints discovered plugins, their
+   import paths, and which are disabled.
+6. **Failure isolation** — a plugin that raises in any hook is logged at ERROR and
+   skipped; the request/operation continues normally.
+
+## Non-Goals
+
+- **Plugin scaffold CLI (`hyperadmin create-plugin`)** — handled by the
+  `/scaffold-plugin` slash command in RFC #275, tracked separately under the
+  `agentic-workflow` label.
+- **Custom non-CRUD page registration (`register_page()`)** — deferred to v0.8.1+.
+- **Hot-reload of plugins** — out of scope; restart required.
+- **Plugin sandboxing / capability restrictions** — plugins run with full Python access
+  in the admin process. Plugins are explicitly trusted code (the operator chose to
+  install them).
+- **Async hook fan-out via taskgroups** — synchronous fan-out only in v1; revisit if
+  any plugin needs concurrency.
+- **Versioned plugin API surface** — the public hook list is the API; we will add
+  hooks (additive) freely and remove them only with a semver major bump.
+
+## BDD Scenarios
+
+```
+Scenario: plugin discovered via entry point on Admin construction
+  Given a package "demo_plugin" exposes [project.entry-points."hyperadmin.plugins"] demo = "demo_plugin:DemoPlugin"
+  When  Admin(app, engine=engine) is constructed
+  Then  admin.plugins["demo"] is an instance of DemoPlugin
+  And   demo.on_register(admin) was called exactly once
+
+Scenario: disabled plugin is not loaded
+  Given the same demo_plugin is installed
+  When  Admin(app, engine=engine, disabled_plugins=["demo"]) is constructed
+  Then  "demo" is not in admin.plugins
+  And   DemoPlugin.on_register was not called
+
+Scenario: on_before_create hook fires before adapter create
+  Given a plugin registers an on_before_create hook that appends model_name to a list
+  When  POST /admin/products/create with valid data
+  Then  the hook list contains "Product" before the row exists in the DB
+
+Scenario: hook exception is logged and does not break the request
+  Given a plugin's on_after_update hook always raises RuntimeError
+  When  POST /admin/products/1/update with valid data
+  Then  the response is 302 (success redirect)
+  And   a structured log record at level ERROR mentions the plugin name and the hook
+
+Scenario: hyperadmin plugins list CLI prints discovered plugins
+  Given demo_plugin is installed
+  When  the user runs `hyperadmin plugins list`
+  Then  stdout contains "demo" and the plugin's class path
+
+Scenario: adapter call hooks wrap every CRUD operation
+  Given a plugin records (op, model) tuples in on_before_adapter_call / on_after_adapter_call
+  When  the list, create, update, delete views are exercised once each for Product
+  Then  the recorded tuples include ("list","Product"), ("create","Product"), ("update","Product"), ("delete","Product") in order
+  And   each "before" precedes its matching "after"
+```
+
+## Design
+
+### Architecture
+
+New module: `src/hyperadmin/core/plugins.py`. Self-contained, no upward dependencies.
+
+```
+┌───────────────────────────────────────────────────────────┐
+│  importlib.metadata.entry_points(group="hyperadmin.plugins") │
+└───────────────────────────┬───────────────────────────────┘
+                            │
+                            ▼
+       ┌─────────────────────────────────────────┐
+       │  PluginRegistry.discover(disabled=...)  │   core/plugins.py
+       │   - resolves env var + ctor disabled    │
+       │   - skips broken imports (logs)         │
+       │   - instantiates plugins                │
+       │   - calls on_register(admin)            │
+       └────────────────┬────────────────────────┘
+                        │ self.plugins
+                        ▼
+              ┌─────────────────┐
+              │   Admin (app)   │   core/app.py
+              └────────┬────────┘
+                       │ dispatch_hook(name, **kw)
+        ┌──────────────┼──────────────┬──────────────────┐
+        ▼              ▼              ▼                  ▼
+   SiteRegistry    DynamicView    AdapterWrapper    AuthMiddleware
+   (model_register) (create/upd/del) (adapter_call)  (future: auth events)
+```
+
+Dependency direction obeyed: `core/plugins.py` is leaf — it imports nothing from
+`views/`, `adapters/`, `auth/`. `Admin` imports `core/plugins.py`. Higher layers call
+`admin.dispatch_hook(...)` rather than importing the registry directly.
+
+### Data Model Changes
+
+No data model changes. All plugin state is in-memory.
+
+### API / Protocol Changes
+
+New public symbols (exported from `hyperadmin` and `hyperadmin.core`):
+
+```python
+# src/hyperadmin/core/plugins.py
+from typing import Any, Protocol, runtime_checkable
+
+@runtime_checkable
+class Plugin(Protocol):
+    name: str
+
+    def on_register(self, admin: "Admin") -> None: ...
+
+    # All hook methods are optional. Plugins implement only the ones they care about.
+    # Signatures are documented; not enforced by the Protocol.
+
+class PluginRegistry:
+    def __init__(self) -> None:
+        self._plugins: dict[str, Plugin] = {}
+        self._hooks: dict[str, list[tuple[str, Callable]]] = {}
+
+    @classmethod
+    def discover(cls, *, admin: "Admin", disabled: set[str]) -> "PluginRegistry": ...
+    def __contains__(self, name: str) -> bool: ...
+    def __getitem__(self, name: str) -> Plugin: ...
+    def names(self) -> list[str]: ...
+    def dispatch(self, hook: str, /, **kwargs: Any) -> None:
+        """Call every registered handler for `hook`. Exceptions logged, not raised."""
+```
+
+Hook signatures (documented contract — plugins type-hint explicitly):
+
+| Hook | Signature | Fired from |
+|---|---|---|
+| `on_register(admin)` | `(Admin) -> None` | `PluginRegistry.discover` |
+| `on_model_register(admin, model, options)` | `(Admin, type, AdminOptions) -> None` | `SiteRegistry.register` |
+| `on_before_create(admin, model, data)` | `(Admin, type, dict) -> None` | `DynamicModelView.create_view` |
+| `on_after_create(admin, model, instance)` | `(Admin, type, Any) -> None` | same |
+| `on_before_update(admin, model, pk, data)` | `(Admin, type, Any, dict) -> None` | `DynamicModelView.update_view` |
+| `on_after_update(admin, model, instance)` | `(Admin, type, Any) -> None` | same |
+| `on_before_delete(admin, model, pk)` | `(Admin, type, Any) -> None` | `DynamicModelView.delete_view` |
+| `on_after_delete(admin, model, pk)` | `(Admin, type, Any) -> None` | same |
+| `on_before_adapter_call(admin, model, op, kwargs)` | `(Admin, type, str, dict) -> None` | `_AdapterHookWrapper` |
+| `on_after_adapter_call(admin, model, op, result)` | `(Admin, type, str, Any) -> None` | same |
+
+`Admin` gains:
+
+```python
+admin.plugins: PluginRegistry
+admin.dispatch_hook(name: str, **kwargs) -> None  # thin proxy to plugins.dispatch
+```
+
+### Configuration Changes
+
+```python
+Admin(
+    app,
+    engine,
+    ...,
+    disabled_plugins: Iterable[str] = (),  # NEW — defaults to empty
+)
+```
+
+Env var: `HYPERADMIN_DISABLED_PLUGINS=foo,bar` — merged into the constructor set
+(union, not override) so an env-disable can't be re-enabled in code.
+
+### Adapter wrapping strategy (decided)
+
+**Decision: wrap at `SiteRegistry.register()` boundary**, not in `BaseAdapter` itself.
+
+```python
+# core/registry.py — inside SiteRegistry.register()
+adapter = adapter_cls(model, engine=...)
+if admin.plugins:
+    adapter = _AdapterHookWrapper(inner=adapter, admin=admin, model=model)
+self._models[model] = (adapter, options)
+```
+
+`_AdapterHookWrapper` lives in `core/plugins.py`, subclasses `BaseAdapter`,
+delegates every method, and fires `on_before_adapter_call` / `on_after_adapter_call`
+around each call. Concrete adapters (`SQLModelAdapter`, `SQLAlchemyAdapter`) stay
+unchanged. Zero overhead when `not admin.plugins.has_handlers("on_before_adapter_call")`
+(the wrapper short-circuits).
+
+Rejected alternatives recorded in Decision Log.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Plugin import raises (e.g. missing optional dep) | Caught in `discover`; logged ERROR with `plugin_entry_point=...`; entry skipped; remaining plugins continue loading. |
+| Plugin `on_register` raises | Caught; logged ERROR; plugin removed from registry; subsequent hooks not dispatched to it. |
+| Two plugins register the same hook | Both fire in entry-point definition order (sorted by entry-point name for determinism). |
+| Plugin hook raises | Caught per-plugin; logged ERROR with `plugin`, `hook`, `exc_type`; remaining handlers and the calling code continue. |
+| `disabled_plugins=["nonexistent"]` | Silently no-op (no log) — disable list is a request, not an assertion. |
+| Plugin name collides with another plugin | First-loaded wins; second logs WARNING and is skipped. Entry-point names are the unit of identity. |
+| Hook fired with no registered handlers | Fast path: `dispatch` is a no-op (no list iteration). |
+| Plugin uses async hook | Not supported in v1. Plugins must run sync code; if they need async, they own their own task scheduling. SDD revisit if a real plugin needs this. |
+| `HYPERADMIN_DISABLED_PLUGINS` malformed (e.g. trailing commas) | Stripped tokens, empty tokens skipped. |
+| Plugin stores per-request state on itself | Plugin author's bug; not our concern. We document "plugins are singletons; do not store per-request state". |
+
+## Migration & Backward Compatibility
+
+**Backward compatible — no migration required.**
+
+- All new symbols are additive.
+- `Admin(...)` gains one keyword-only parameter with a default; existing call sites
+  unchanged.
+- `BaseAdapter` subclasses are not modified — wrapping is external. Any third-party
+  adapter that already exists continues to work.
+- Model-level hooks (`HyperAdminModel.before_save` etc.) are untouched and remain the
+  recommended path for model-specific logic. App-level hooks are for cross-cutting
+  concerns (telemetry, audit, multi-model policies).
+- No public API removed. No semver major bump required.
+
+## Open Questions
+
+- [ ] **Should `dispatch_hook` return values?** Some hooks (`on_before_create`)
+      could in principle veto the operation. v1 says no — hooks are observers, not
+      mutators. Plugins that need to mutate data implement model-level hooks instead.
+      Confirm at SDD review.
+- [ ] **Async hooks** — defer until first real need. Confirm at SDD review.
+- [ ] **Naming: `on_before_adapter_call` vs `on_adapter_call_start`** — current
+      proposal mirrors the rest of the `on_before_*` family for consistency. Confirm.
+- [ ] **Should the wrapper short-circuit be exposed as `plugins.has_handlers(name)`
+      or computed implicitly in `dispatch`?** Implicit is simpler; explicit gives
+      adapter wrapper a faster check. Recommend implicit for v1.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Wrap adapters at `SiteRegistry.register()` boundary | Concrete adapters stay clean; zero changes to `SQLModelAdapter` / `SQLAlchemyAdapter`; one wrapper covers all current and future adapters | (a) Decorator on each `BaseAdapter` abstract method — couples concrete adapters to plugin system; (b) Inheritance via mixin — forces every adapter author to extend a specific base |
+| Synchronous fan-out, exceptions caught per-plugin | Simplest; matches "plugins must not break core" requirement; no async leakage to non-async call sites | (a) Async-aware fan-out — premature; (b) Re-raise — violates isolation |
+| Entry-point group `hyperadmin.plugins` | Convention follows pytest, FastAPI, Django plugins | `hyperadmin.extensions`, `hyperadmin_plugins` (no namespace) |
+| `Plugin` as `Protocol`, not ABC | Plugins shouldn't have to inherit from us; runtime_checkable enables `isinstance` for tests | ABC — forces inheritance and import-time coupling |
+| Disable list is union of ctor + env var | Lets ops disable a misbehaving plugin without code change; can't be silently re-enabled in code | Override (env wins / ctor wins) — surprising in either direction |
+| Hooks are observers, not mutators (in v1) | Keeps the contract simple; mutation paths exist via model hooks | Allow hooks to return modified data — opens a large surface for plugin conflicts |
+| No async hook support in v1 | YAGNI; no current consumer needs it | Async-first design — premature complexity |


### PR DESCRIPTION
## Summary

Plan-only PR. Decomposes milestone **v0.8.0 — Plugins** into two SDD-gated epics
with 23 stories total. Re-themes v0.8.0 from "Plugins & AI" to **"Plugins"** —
AI features (RFC #277), extra ORM adapters (Tortoise / Piccolo / MongoDB), and
custom non-CRUD page registration defer to v0.8.1+. Tighter milestone, ship-able,
proves the plugin architecture before AI / extensions land on top of it.

No source code, no tests, no \`pyproject.toml\` changes. Only \`.meta/\` and \`docs/specs/\`.

## What lands

- **Epic 1** (size:L) — \`epic-plugins-registry-and-lifecycle-hooks\`
  - Plugin protocol + PluginRegistry (entry-point discovery, disable mechanism)
  - 9 app-level lifecycle hooks with failure isolation
  - Adapter wrapping at \`SiteRegistry\` boundary — concrete adapters unchanged
  - \`hyperadmin plugins list\` CLI subcommand
  - 12 stories, SDD: [\`docs/specs/plugin-registry.md\`](https://github.com/yevheniidehtiar/hyper-admin/blob/feat/v080-planning-artifacts/docs/specs/plugin-registry.md)

- **Epic 2** (size:L, blocked by Epic 1) — \`epic-plugin-logfire-first-plugin\`
  - Separate package at \`plugins/hyperadmin-logfire/\` (monorepo subpath)
  - \`instrument_admin(admin)\` one-call API
  - \`InstrumentedAdapter\` via \`on_before/after_adapter_call\`
  - \`admin.validation_error\` events; \`admin.auth.*\` events
  - **Forces two new hooks into Epic 1 SDD**: \`on_validation_error\`, \`on_auth_event\`
  - 11 stories, SDD: [\`docs/specs/plugin-logfire.md\`](https://github.com/yevheniidehtiar/hyper-admin/blob/feat/v080-planning-artifacts/docs/specs/plugin-logfire.md)

Both SDDs in **Draft** status. First sub-task of each epic is \`docs(spec)\`,
second is the **human-gate** \`review(spec)\`. All implementation stories are
\`blocked_by\` SDD approval per \`.claude/rules/sdd-conventions.md\`.

Milestone roadmap file (\`.meta/roadmap/milestones/v080-plugins-ai.md\`) updated
to point at the two new epics and document the deferred scope.

## Sequencing (cross-epic)

\`\`\`
Epic1.SDD draft → Epic1.SDD review (human) → Epic1 impl stories →
                                              ▼
                                Epic2.SDD draft → Epic2.SDD review (human) → Epic2 impl
\`\`\`

Two human gates: one SDD review per epic.

## Test plan

- [x] \`./scripts/gitpm.sh validate\` passes (408 entities)
- [x] \`commitizen\` pre-commit hook passes
- [x] All 28 files render correctly in GitHub preview (epic.md, stories, SDDs, milestone)
- [ ] Reviewer skim of both SDDs — confirm scope, hook list, decisions
- [ ] After merge: \`gitpm push\` to mirror new entities to GitHub issues + project board

## Open Questions for review

The two SDDs each have an "Open Questions" section that resolves at the
\`review(spec)\` story, not in this PR. Highlights:

- Plugin Registry: should hooks be observers only (v1) or allow veto/mutate?
  Sync-only or design async-aware from the start?
- hyperadmin-logfire: add \`hyperadmin[logfire]\` extra to root \`pyproject.toml\`?
  Span name \`admin.adapter.*\` vs \`hyperadmin.adapter.*\`?

## Plan reference

Source plan: \`~/.claude/plans/i-would-like-you-glimmering-horizon.md\` (approved 2026-05-05).