### PR TITLE
docs(specs): SDD drafts for v0.5.2 / v0.5.3 / v0.5.4 / v0.6.0-OCC

### DIFF
--- a/docs/specs/dashboard-builder.md
+++ b/docs/specs/dashboard-builder.md
@@ -1,0 +1,430 @@
+# SDD: Dashboard Builder with Widgets
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | #422 (epic), #455 (review gate) |
+| Milestone | v0.5.4 — Dashboard Builder |
+| Created | 2026-05-10 |
+| Last updated | 2026-05-10 |
+
+---
+
+## Problem
+
+`Admin(app)` mounts a static welcome page at `/admin/`. There is no way to surface
+operational insight on the landing page — counts, recent items, quick actions, alert
+panels — and no way for users to customise what they see when they open the admin.
+
+This forces every host application to either:
+
+1. Live with the welcome page and link to a custom-built dashboard elsewhere, or
+2. Override the entire `/admin/` route, losing the framework's auth/MFA/i18n wiring.
+
+A first-class dashboard builder is also a prerequisite for several deferred niceties:
+real-time count updates over WebSocket (v0.6.0), per-tenant homepages (v0.5.3), and the
+plug-in marketplace direction in v0.8.0. The SDD scopes the **MVP** — composable widgets,
+drag-drop reordering, and persisted layout — without overpromising charts, dashboards-as-
+code, or live-updating tiles.
+
+## Goals
+
+- **Widget protocol.** A `DashboardWidget` Protocol with one async `render(request)`
+  method returning an HTML fragment. Built-in widgets (count, recent items, quick actions)
+  are implementations.
+- **Layout persistence.** Per-user layout stored as `DashboardLayout` (user_id, name,
+  widgets JSON). Replaces the welcome page when `Admin(dashboard=True)`.
+- **Drag-drop reordering** via `@alpinejs/sort` (no new dependency — Alpine is already
+  loaded by v0.4.0). Persisted via HTMX `POST` returning `204 No Content`.
+- **Aggregation helpers.** `BaseAdapter.count(filter)` and `BaseAdapter.aggregate(field,
+  op, filter)` where `op ∈ {"sum","avg","min","max"}`. Both honour
+  `get_queryset()` filters (so v0.5.3 multi-tenancy applies automatically).
+- **Server-side render cache.** Per-widget render output cached for `dashboard_cache_ttl_seconds`
+  (default `60`, `0` disables). Keyed by `(user_id, tenant_id, widget_id)`.
+- **i18n.** Widget titles wrap in `gettext_lazy`; built-in widget labels translate via the
+  v0.4.1 catalog pipeline.
+- **A11y.** Tab order follows visual order; drag-drop has keyboard fallback (move-up /
+  move-down buttons reachable via `Tab`).
+- **Tenant-scoped.** When v0.5.3 is enabled, layouts and widget data are filtered by tenant
+  through the same `get_queryset()` seam — no special-casing.
+- **Backward compatible.** `Admin(dashboard=False)` (default) ⇒ welcome page unchanged.
+
+## Non-Goals
+
+- Charts, sparklines, time-series. Built-in widgets are textual / list-based; chart widgets
+  are user-supplied subclasses (or v0.8.0 plugin).
+- Dashboard-per-page (multiple dashboards). Layout has a `name` field for forward
+  compatibility but the MVP renders one named `"default"`.
+- Drilldown modals, widget-specific configuration UI. Widgets are configured in code.
+- Cross-user / org-wide shared dashboards. Each user owns their layout. (Sharing is a
+  later epic.)
+- Custom SQL widgets in the UI. Custom widgets are Python subclasses.
+- Live data refresh via WebSocket. v0.6.0 adds a separate `LiveCountWidget` mixin.
+- Public dashboards (anonymous viewers). Dashboards always require authentication.
+- Widget size/layout primitives beyond a 12-column grid (no resizable tiles in MVP).
+
+## BDD Scenarios
+
+```
+Scenario: dashboard renders when enabled
+  Given Admin(dashboard=True) is configured with built-in widgets
+  When  the user navigates to /admin/
+  Then  the response renders the dashboard layout
+  And   the page contains data-testid "dashboard-grid"
+  And   the welcome page is NOT rendered
+
+Scenario: dashboard is disabled by default
+  Given Admin(dashboard=False) (default)
+  When  the user navigates to /admin/
+  Then  the response renders the welcome page
+  And   the page does NOT contain data-testid "dashboard-grid"
+
+Scenario: count widget renders the model count
+  Given a CountWidget(model=Order) is registered
+  And   there are 42 Order rows visible to the user
+  When  the dashboard renders
+  Then  the count widget shows "42"
+  And   the widget container has data-testid "widget-count-order"
+
+Scenario: count widget respects tenant filter
+  Given v0.5.3 is enabled with Order.tenant_field="tenant_id"
+  And   request.state.tenant_id = 1
+  And   there are 5 Order rows for tenant 1 and 100 for tenant 2
+  When  the dashboard renders
+  Then  the count widget shows "5"
+
+Scenario: recent items widget renders the n most recent rows
+  Given a RecentItemsWidget(model=Order, n=3) is registered
+  And   there are 10 Order rows
+  When  the dashboard renders
+  Then  the widget shows the 3 most recent items
+  And   each item links to its detail page
+
+Scenario: quick actions widget renders configured actions
+  Given a QuickActionsWidget(actions=[("Create Order", "/admin/order/create"),
+                                       ("View Reports", "/admin/reports")]) is registered
+  When  the dashboard renders
+  Then  the widget shows two action links with the correct hrefs
+
+Scenario: drag-drop persists new widget order
+  Given the user has widgets ["count-order", "recent-orders", "quick-actions"]
+  When  the user drags "quick-actions" to the first position
+  Then  the dashboard issues a POST to /admin/dashboard/layout
+  And   the response is 204 No Content
+  And   on next navigation the widget order is ["quick-actions", "count-order", "recent-orders"]
+
+Scenario: layout is per-user
+  Given alice has reordered her dashboard
+  When  bob navigates to /admin/
+  Then  bob sees the default order, not alice's order
+
+Scenario: cached widget output is reused within TTL
+  Given dashboard_cache_ttl_seconds = 60
+  And   a CountWidget(model=Order) was rendered 30 seconds ago
+  When  the same user reloads the dashboard
+  Then  the widget renders from cache without invoking adapter.count()
+
+Scenario: cache key partitions by user and tenant
+  Given dashboard_cache_ttl_seconds = 60
+  And   alice (tenant 1) just rendered the count widget
+  When  bob (tenant 2) renders the same widget
+  Then  adapter.count() is invoked again (different cache key)
+
+Scenario: keyboard reorder works without drag-drop
+  Given the user focuses the move-up button on the second widget
+  When  the user presses Enter
+  Then  the widget moves up by one position
+  And   the new order is persisted
+
+Scenario: aggregate helper computes sums over filtered rows
+  Given Orders has rows with total in {10, 20, 30, 40} and tenant_id in {1, 1, 2, 2}
+  And   request.state.tenant_id = 1
+  When  adapter.aggregate("total", "sum") is called
+  Then  the result is 30
+
+Scenario: layout reset returns to defaults
+  Given alice has a customised layout
+  When  alice POSTs /admin/dashboard/reset
+  Then  alice's DashboardLayout row is deleted
+  And   the next dashboard render uses the configured default order
+
+Scenario: missing widget id in saved layout is skipped gracefully
+  Given alice's layout references widget "deprecated-widget"
+  And   "deprecated-widget" is no longer registered
+  When  the dashboard renders
+  Then  the unknown widget is omitted
+  And   no exception is raised
+  And   a warning is logged once per process
+
+Scenario: widget render failure isolates to that widget
+  Given a custom widget raises in render()
+  When  the dashboard renders
+  Then  the failing widget shows an error placeholder with the widget id
+  And   other widgets render normally
+  And   the error is logged at ERROR with traceback
+```
+
+## Design
+
+### Architecture
+
+```
+                  /admin/  (when dashboard=True)
+                       │
+                       ▼
+               views/dashboard.py
+                       │
+                       ▼
+            dashboard/service.py
+                       │
+            ┌──────────┴────────────┐
+            ▼                       ▼
+   dashboard/registry.py     core/cache.py (request-scoped LRU)
+       │                            │
+       ▼                            │
+   widgets registered  ─────────────┘
+   (CountWidget, RecentItemsWidget,
+    QuickActionsWidget, custom)
+            │
+            ▼
+   adapter.count() / adapter.aggregate() / adapter.list()
+            │
+            ▼
+   get_queryset()  ←  v0.5.1 / v0.5.3 hooks (tenant filtering applies here)
+```
+
+Module layout:
+
+```
+src/hyperadmin/dashboard/
+├── __init__.py          — public exports
+├── models.py            — DashboardLayout SQLModel
+├── protocols.py         — DashboardWidget Protocol
+├── widgets.py           — CountWidget, RecentItemsWidget, QuickActionsWidget
+├── registry.py          — WidgetRegistry, widget id resolution
+├── service.py           — DashboardService (load, render, save, reset)
+└── cache.py             — Per-process LRU + TTL keyed render cache
+
+src/hyperadmin/views/
+└── dashboard.py         — handler endpoints
+
+src/hyperadmin/core/
+├── adapters.py          — (mod) add count(), aggregate() to BaseAdapter
+└── settings.py          — (mod) add dashboard config
+
+src/hyperadmin/adapters/
+├── sqlmodel.py          — (mod) implement count(), aggregate()
+└── sqlalchemy.py        — (mod) implement count(), aggregate()
+
+src/hyperadmin/templates/dashboard/
+├── grid.html            — overall grid + sortable wiring
+├── widget_card.html     — wrapper card with title + actions
+├── widget_count.html    — count widget body
+├── widget_recent.html   — recent items widget body
+├── widget_actions.html  — quick actions widget body
+└── widget_error.html    — error placeholder
+```
+
+Dependency direction: `dashboard/` → `core/` → `adapters/`. No reverse imports.
+`views/dashboard.py` is the only `views/` consumer.
+
+### Data Model Changes
+
+Single new framework table:
+
+```python
+# src/hyperadmin/dashboard/models.py
+class DashboardLayout(SQLModel, table=True):
+    __tablename__ = "hyperadmin_dashboard_layouts"
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="hyperadmin_users.id", index=True)
+    name: str = Field(default="default", max_length=64)
+    widgets: list[str] = Field(default_factory=list, sa_column=Column(JSON))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    __table_args__ = (UniqueConstraint("user_id", "name", name="uq_layout_user_name"),)
+```
+
+`widgets` is the ordered list of widget ids. Width / row spans are deferred — every widget
+defaults to a 4-of-12 grid column on desktop, full-width on mobile.
+
+`WidgetConfig` is **not** persisted as a row — widget configuration lives in code (Python),
+not in the DB. Persisting it would invite a half-baked admin-UI-for-widget-configuration
+that the MVP explicitly excludes.
+
+### API / Protocol Changes
+
+**`DashboardWidget` Protocol** in `dashboard/protocols.py`:
+
+```python
+@runtime_checkable
+class DashboardWidget(Protocol):
+    id: str
+    title: str | LazyString
+    grid_span: int  # 1..12, default 4
+
+    async def render(self, request: Request) -> str:
+        """Return the inner HTML for this widget. Wrapped by widget_card.html."""
+```
+
+**Built-in widgets** in `dashboard/widgets.py`:
+
+```python
+class CountWidget:
+    def __init__(self, model: type[SQLModel], *, title: str | None = None,
+                 filter: dict[str, Any] | None = None, grid_span: int = 3) -> None: ...
+
+class RecentItemsWidget:
+    def __init__(self, model: type[SQLModel], *, n: int = 5,
+                 order_by: str = "-id", grid_span: int = 6) -> None: ...
+
+class QuickActionsWidget:
+    def __init__(self, actions: list[tuple[str, str]], *, grid_span: int = 3) -> None: ...
+```
+
+**Adapter additions** on `BaseAdapter`:
+
+```python
+async def count(self, filter: dict[str, Any] | None = None,
+                request: Request | None = None) -> int: ...
+
+async def aggregate(self, field: str, op: Literal["sum","avg","min","max"], *,
+                    filter: dict[str, Any] | None = None,
+                    request: Request | None = None) -> int | float | None: ...
+```
+
+Both honour `get_queryset(request)` — the request-scoped filter is merged on top of the
+caller-supplied `filter` (caller wins on key conflict for dashboard widgets that need to
+override). `count()` exists in v0.5.1's count-for-pagination path; this exposes it on the
+public surface.
+
+**`DashboardService`** in `dashboard/service.py`:
+
+```python
+class DashboardService:
+    def __init__(self, registry: WidgetRegistry, cache: WidgetCache,
+                 layout_repo: LayoutRepository) -> None: ...
+
+    async def render_for(self, request: Request) -> str: ...
+    async def save_layout(self, request: Request, widget_ids: list[str]) -> None: ...
+    async def reset_layout(self, request: Request) -> None: ...
+```
+
+**Endpoints** registered when `dashboard=True`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET  | `/admin/`                   | Render dashboard (replaces welcome page) |
+| POST | `/admin/dashboard/layout`   | Save reordered widget list |
+| POST | `/admin/dashboard/reset`    | Delete user's saved layout |
+
+**Public exports** added to `hyperadmin.__init__`:
+
+```python
+from hyperadmin.dashboard import (
+    DashboardWidget,
+    CountWidget,
+    RecentItemsWidget,
+    QuickActionsWidget,
+    DashboardLayout,
+)
+```
+
+### Configuration Changes
+
+```python
+# HyperAdminSettings additions
+dashboard_enabled: bool = False
+dashboard_cache_ttl_seconds: int = 60
+dashboard_default_widgets: list[str] = []   # widget ids in default order
+```
+
+```python
+# Admin(...) additions
+admin = Admin(
+    app,
+    dashboard=True,
+    widgets=[
+        CountWidget(Order, title=_("Orders")),
+        RecentItemsWidget(Order, n=5),
+        QuickActionsWidget(actions=[(_("New Order"), "/admin/order/create")]),
+    ],
+)
+```
+
+The `widgets=` kwarg is the ordered default. `Admin.__init__` registers each into the
+`WidgetRegistry` and seeds `dashboard_default_widgets` if the host did not already set it
+in settings.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Widget render raises | Caught per-widget; `widget_error.html` shows widget id + minimal error; logged at ERROR |
+| Widget id collision | Registry refuses second registration with `ValueError` at startup |
+| Layout references unknown widget id | Silently skipped at render; warning logged once per id per process |
+| User has no `DashboardLayout` row | Default order used (from `dashboard_default_widgets`) |
+| Drag-drop POST receives unknown widget id | 400 Bad Request — never accept ids the server didn't render |
+| Drag-drop POST receives a different number of widgets than registered | 400 Bad Request |
+| `reset_layout` for a user with no row | Idempotent — no-op, 204 |
+| `count()`/`aggregate()` on adapter without backend support | Raise `NotImplementedError`; widget renders error placeholder |
+| Cache-key collision between sessions | Keyed by `(user_id, tenant_id or "_", widget_id)`; collisions impossible |
+| Tenant changes mid-session (admin switches tenant via header) | Cache key includes tenant id, so stale data is impossible |
+| `dashboard_cache_ttl_seconds=0` | Cache disabled; every render hits the adapter |
+| Widget grid_span > 12 | Clamped to 12 with a `WARN` at registration |
+| Widget grid_span < 1 | Clamped to 1 with a `WARN` |
+| HTMX request without `hx-request` header | Endpoint accepts plain POST (curl-friendly), returns 204 |
+| Anonymous user lands on `/admin/` | Existing auth middleware redirects to login — dashboard never renders |
+| Layout reset while drag-drop POST is in flight | Last-writer-wins on `(user_id, name)` unique key |
+| `default` layout name conflict with user-renamed layouts | Layout name is fixed to `"default"` in MVP — multi-name support is forward-only |
+
+## Migration & Backward Compatibility
+
+- **No breaking changes.** Default `dashboard=False` preserves the welcome page.
+- **DB migration owned by host app:** add `hyperadmin_dashboard_layouts`. Documented in
+  changelog.
+- **Public API is additive.** `__init__.py` gains widget classes and `DashboardLayout`.
+- **Adapters.** `count()` / `aggregate()` are new; default `BaseAdapter` raises
+  `NotImplementedError`. SQLModel and SQLAlchemy adapters implement both. Third-party
+  adapters keep working until a widget calls these methods — at which point they raise
+  cleanly with a clear error.
+
+## Open Questions
+
+- [x] Where does cache live? → **In-process `LRU` keyed by `(user_id, tenant_id,
+      widget_id)` with TTL.** No Redis required for MVP. Multi-worker deployments will see
+      duplicate hits (acceptable — TTL is short).
+- [x] Resizable tiles? → **Defer.** A 12-column grid with widget-declared `grid_span` is
+      enough for MVP.
+- [x] Multiple dashboards per user? → **Defer.** Layout name field exists; only `"default"`
+      is rendered.
+- [x] Live count updates? → **Defer to v0.6.0.** A `LiveCountWidget` mixin will subscribe
+      to model-change events when WebSocket pubsub lands.
+- [x] How are widget instances identified for layout persistence? → **`widget.id`.** Auto-
+      generated as `f"{class_name.lower()}-{model.__tablename__}"` for built-ins; custom
+      widgets must set an explicit `id`.
+- [ ] Should dashboard widgets honour object-level permission checks? → **Yes**, count and
+      list widgets must use `adapter.count(request=request)` so the v0.5.1 `get_queryset()`
+      hook applies. Object-level checks fire on detail navigation as today. Resolved on
+      approval — already implicit in the design.
+- [ ] Cache invalidation on writes? → **No** in MVP. TTL is the only invalidation. Real-
+      time invalidation arrives with v0.6.0 model-change signals. Resolved on approval.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Widget config in code, not DB | Avoids half-built admin-of-the-admin UI; widgets are typed, refactorable | Persist widget configs as JSON — invites stringly-typed configuration; widgets-as-records — same problem |
+| Single `default` dashboard per user | YAGNI for MVP; layout name field future-proofs | Ship multi-dashboard now — extra UI surface, marginal value |
+| `@alpinejs/sort` for drag-drop | Alpine already loaded; zero new JS | SortableJS — extra dep; HTML5 DnD — fragile UX |
+| Per-widget render cache (in-process) | Simple, no Redis dep; TTL-bounded | Centralised cache (Redis) — adds infra; per-template HTTP cache headers — coarse |
+| Cache key includes tenant id | v0.5.3 multi-tenancy correctness | User-only key — would leak across tenant in multi-tenant admin |
+| Widget render failure isolated | One bad widget shouldn't blank the dashboard | Hard fail — too brittle |
+| `count()` and `aggregate()` on `BaseAdapter` | Generic operations every adapter can support | Dashboard-specific adapter mixin — duplicates work |
+| Adapter default raises `NotImplementedError` | Third-party adapters keep working until a widget that needs aggregation lands | Make required — breaking change |
+| Layout reset endpoint | Lets users escape a bad customisation | No reset — power users would have to manually edit JSON |
+| Replace `/admin/` only when `dashboard=True` | Existing apps see no behaviour change | Always replace — would surprise upgrade users |
+| Widget grid uses 12-column layout | Common, well-understood, maps to existing CSS grid | 16-column / 24-column — no benefit; flex-only — too freeform |
+| Server-rendered HTML over JSON-rendered widgets | Aligns with HTMX-first stack; widgets compose easily | JSON + client renderer — couples to a JS framework |

--- a/docs/specs/inline-cell-editing.md
+++ b/docs/specs/inline-cell-editing.md
@@ -3,11 +3,11 @@
 | Field | Value |
 |---|---|
 | Author | Claude Code |
-| Status | Draft (dispatch-authorized for implementation) |
+| Status | Approved |
 | Issue | #45 (epic 2.4 — UI/UX Polish, v0.5.0 scope: inline model editing) |
 | Milestone | v0.5.0 — Advanced UX |
 | Created | 2026-05-03 |
-| Last updated | 2026-05-03 |
+| Last updated | 2026-05-10 (Approved retroactively — milestone shipped) |
 
 ---
 

--- a/docs/specs/multi-tenancy.md
+++ b/docs/specs/multi-tenancy.md
@@ -1,0 +1,374 @@
+# SDD: Multi-Tenancy Filtering
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | #421 (epic) |
+| Milestone | v0.5.3 — Multi-Tenancy Filtering |
+| Created | 2026-05-10 |
+| Last updated | 2026-05-10 |
+
+---
+
+## Problem
+
+HyperAdmin v0.5.1 shipped the `BaseAdapter.get_queryset()` hook (a per-request `dict[str, Any]`
+filter merged into list/get/count queries) and `ObjectPermissionChecker` (per-object authorization).
+Both are foundational seams; neither is wired into a concrete tenant-isolation flow.
+
+Real deployments need:
+
+1. **List/detail isolation.** A user belonging to tenant `T1` must not see rows for tenant `T2`,
+   even if they hold the model-level `view_X` permission. Pagination counts must reflect the
+   tenant-filtered total.
+2. **Tenant resolution.** The tenant id must be resolved per-request from a stable source
+   (user record, request header, or subdomain) and exposed as `request.state.tenant_id`.
+3. **Configuration.** Per-`ModelAdmin` opt-in (`tenant_field`) and a global enable flag
+   (`tenant_enabled`) so single-tenant apps see no behaviour change.
+4. **Adapter ergonomics.** A drop-in `TenantAwareAdapterMixin` lets adapters participate in
+   tenant filtering without each one re-implementing the merge with `get_queryset()`.
+
+Without this milestone, the v0.5.1 row-level-security hook is academic — it exists, but no
+shipping component uses it. v0.5.4 (Dashboard) and v0.6.0 (real-time channels) both depend on
+"current tenant" being a request-scoped concept.
+
+## Goals
+
+- `TenantAwareAdapterMixin` injects a tenant filter into `get_queryset()` automatically,
+  reading `request.state.tenant_id` and applying `{tenant_field: tenant_id}`.
+- `TenantMiddleware` resolves the tenant id from (in order): authenticated user's tenant
+  attribute → `X-Tenant-ID` header (only honoured when the user is configured with
+  `is_multi_tenant_admin=True`) → request subdomain (when `tenant_resolve_from_subdomain=True`).
+- `AdminOptions.tenant_field: str | None = None` declares the column name on the model
+  carrying the tenant id. None ⇒ this `ModelAdmin` is tenant-agnostic.
+- `HyperAdminSettings.tenant_enabled: bool = False` is the kill switch. Disabled ⇒ middleware
+  short-circuits, mixin is a no-op, no behaviour change for existing apps.
+- Superuser bypass is opt-in per `AdminOptions.tenant_superuser_bypass: bool = True` (default
+  `True` to match Django expectations; can be disabled for stricter deployments).
+- 404 (not 403) on cross-tenant `get(pk)` to avoid disclosing existence.
+- Documentation patterns for the three deployment shapes (single-tenant, multi-tenant
+  same-DB, sharded) and the OAuth-bridge story for v0.5.2.
+
+## Non-Goals
+
+- Schema-per-tenant or DB-per-tenant — both are deployment patterns the host app owns; the
+  framework supports them via custom `BaseAdapter` subclasses but does not ship one.
+- Tenant CRUD UI / tenant onboarding wizard — host application concern.
+- Tenant-scoped RBAC (per-tenant permission grants) — defer; v0.5.1 model-level + object-level
+  is sufficient.
+- Cross-tenant administrative views ("list rows from all tenants") beyond a `superuser`
+  bypass — out of scope.
+- Tenant-aware caching / connection pooling — performance milestone (v0.7.x).
+- Tenant resolution from JWT claims — covered in v0.5.2 OAuth SDD via the `tenant_id_claim`
+  hook on `OAuthProviderConfig`.
+
+## BDD Scenarios
+
+```
+Scenario: tenant-aware adapter filters list results by request tenant
+  Given Order.tenant_field = "tenant_id"
+  And   request.state.tenant_id = 1
+  And   the table contains orders with tenant_id in {1, 2, 3}
+  When  GET /admin/order
+  Then  the response lists only orders with tenant_id = 1
+  And   pagination_info.total_count equals the tenant_id=1 row count
+
+Scenario: cross-tenant detail returns 404 to prevent existence disclosure
+  Given Order.tenant_field = "tenant_id"
+  And   request.state.tenant_id = 1
+  And   order#42 has tenant_id = 2
+  When  GET /admin/order/42
+  Then  the response is 404 Not Found
+  And   no detail data is rendered
+
+Scenario: cross-tenant update returns 404
+  Given Order.tenant_field = "tenant_id"
+  And   request.state.tenant_id = 1
+  And   order#42 has tenant_id = 2
+  When  POST /admin/order/42/edit with valid data
+  Then  the response is 404 Not Found
+  And   the row is unchanged
+
+Scenario: superuser bypass is enabled by default
+  Given a superuser request
+  And   Order.tenant_field = "tenant_id"
+  And   tenant_superuser_bypass is True
+  When  GET /admin/order
+  Then  the response lists orders for all tenants
+
+Scenario: superuser bypass can be disabled per ModelAdmin
+  Given a superuser request
+  And   Order.tenant_field = "tenant_id"
+  And   tenant_superuser_bypass is False
+  When  GET /admin/order with no resolved tenant
+  Then  the response is 400 Bad Request
+
+Scenario: middleware resolves tenant from authenticated user
+  Given user "alice" has tenant_id = 7 in the user store
+  When  alice issues an authenticated request
+  Then  request.state.tenant_id == 7
+
+Scenario: header overrides user tenant only when admin opt-in is set
+  Given user "alice" has tenant_id = 7
+  And   alice.is_multi_tenant_admin is True
+  When  alice issues a request with X-Tenant-ID: 9
+  Then  request.state.tenant_id == 9
+
+Scenario: header is ignored without opt-in
+  Given user "alice" has tenant_id = 7
+  And   alice.is_multi_tenant_admin is False
+  When  alice issues a request with X-Tenant-ID: 9
+  Then  request.state.tenant_id == 7
+
+Scenario: subdomain resolution when configured
+  Given tenant_resolve_from_subdomain is True
+  And   the host map resolves "acme.example.com" → tenant_id 12
+  When  a request arrives at https://acme.example.com/admin/
+  Then  request.state.tenant_id == 12
+
+Scenario: tenant_enabled=False short-circuits the middleware
+  Given HyperAdminSettings.tenant_enabled is False
+  When  any request arrives
+  Then  request.state.tenant_id is unset
+  And   list queries return all rows regardless of any tenant_field setting
+
+Scenario: aggregate queries respect the tenant filter
+  Given Order.tenant_field = "tenant_id"
+  And   request.state.tenant_id = 1
+  When  the dashboard count widget invokes adapter.count()
+  Then  the count reflects only tenant_id = 1 rows
+
+Scenario: missing tenant_id on a tenant-scoped model raises a clear error
+  Given Order.tenant_field = "tenant_id"
+  And   the request has no resolved tenant_id (anonymous, tenant_enabled=True)
+  When  GET /admin/order
+  Then  the response is 400 Bad Request with body "tenant required for /admin/order"
+```
+
+## Design
+
+### Architecture
+
+```
+HTTP request
+    │
+    ▼
+AuthenticationMiddleware  ──────► request.state.user
+    │
+    ▼
+TenantMiddleware          ──────► request.state.tenant_id
+    │                              (None if disabled / unresolved)
+    ▼
+View handler invokes adapter.list/get/count
+    │
+    ▼
+TenantAwareAdapterMixin.get_queryset(request)
+    │   reads options.tenant_field + request.state.tenant_id
+    ▼
+{tenant_field: tenant_id} merged into adapter's WHERE clause
+    │   (existing v0.5.1 path)
+    ▼
+SQL: WHERE tenant_id = :tid AND <other filters>
+```
+
+Module layout (new files marked `(new)`, modified files marked `(mod)`):
+
+```
+src/hyperadmin/
+├── auth/
+│   └── tenant.py           (new) — TenantMiddleware, resolution helpers
+├── adapters/
+│   ├── tenant.py           (new) — TenantAwareAdapterMixin
+│   ├── sqlmodel.py         (mod) — list/get/count already merge get_queryset(); no change
+│   └── sqlalchemy.py       (mod) — same
+├── core/
+│   ├── auth.py             (mod) — add Tenant protocol (lightweight, optional)
+│   ├── options.py          (mod) — add tenant_field, tenant_superuser_bypass
+│   └── settings.py         (mod) — add tenant_enabled, tenant_resolve_from_subdomain,
+│                                  tenant_subdomain_resolver, tenant_id_attr
+├── views/
+│   └── dynamic.py          (mod) — get/update/delete return 404 on cross-tenant miss
+└── tests/
+    ├── unit/
+    │   ├── test_tenant_middleware.py   (new)
+    │   ├── test_tenant_mixin.py        (new)
+    │   └── test_tenant_options.py      (new)
+    └── e2e/
+        └── test_multi_tenant_isolation.py (new)
+```
+
+Dependency direction stays inward: `auth/tenant.py` and `adapters/tenant.py` both depend on
+`core/`, never the other way around. No new public coupling between `auth/` and `adapters/`.
+
+### Data Model Changes
+
+No new framework-owned tables. The host application owns its `Tenant` table (or none —
+`tenant_id` may be a free-form string).
+
+The framework's `User` model does **not** gain a `tenant_id` column. Instead, the tenant
+attribute name is configurable:
+
+```python
+# HyperAdminSettings
+tenant_id_attr: str = "tenant_id"
+```
+
+`TenantMiddleware` reads `getattr(request.state.user, settings.tenant_id_attr, None)`.
+This lets host apps put the tenant association anywhere (column on User, FK to Tenant,
+property derived from membership table).
+
+### API / Protocol Changes
+
+**New mixin** in `src/hyperadmin/adapters/tenant.py`:
+
+```python
+class TenantAwareAdapterMixin:
+    """Inject {tenant_field: request.state.tenant_id} into get_queryset()."""
+
+    options: AdminOptions  # provided by the concrete adapter
+
+    def get_queryset(self, request: Request | None = None) -> dict[str, Any]:
+        base = super().get_queryset(request)  # respects subclass overrides
+        if request is None:
+            return base
+        tenant_field = self.options.tenant_field
+        if not tenant_field:
+            return base
+        tenant_id = getattr(request.state, "tenant_id", None)
+        if tenant_id is None:
+            user = getattr(request.state, "user", None)
+            if user is not None and getattr(user, "is_superuser", False) \
+               and self.options.tenant_superuser_bypass:
+                return base  # superuser sees all tenants
+            raise HTTPException(
+                status_code=400,
+                detail=f"tenant required for {request.url.path}",
+            )
+        return {**base, tenant_field: tenant_id}
+```
+
+The mixin is composed onto a concrete adapter when the host app wants tenant filtering:
+
+```python
+class TenantSQLModelAdapter(TenantAwareAdapterMixin, SQLModelAdapter):
+    pass
+```
+
+Apps that prefer a one-liner can set `Admin(default_adapter=TenantSQLModelAdapter)`.
+
+**New middleware** in `src/hyperadmin/auth/tenant.py`:
+
+```python
+class TenantMiddleware:
+    def __init__(self, app: ASGIApp, settings: HyperAdminSettings) -> None: ...
+    async def __call__(self, scope, receive, send) -> None:
+        # 1. If tenant_enabled is False → no-op
+        # 2. Resolve from user.<tenant_id_attr> by default
+        # 3. If user.is_multi_tenant_admin → honour X-Tenant-ID header
+        # 4. If settings.tenant_resolve_from_subdomain → resolve via host map
+        # Set request.state.tenant_id
+```
+
+**View-layer 404-on-cross-tenant** lives inside `DynamicModelView.detail_view/update_view/
+delete_action`. When `adapter.get(pk)` returns `None` and a tenant filter is active, the
+existing 404 path already covers it — no new branch needed. The change is behavioural:
+verify in tests that 404 (not 403) is returned.
+
+**`AdminOptions` additions** in `src/hyperadmin/core/options.py`:
+
+```python
+tenant_field: str | None = None
+tenant_superuser_bypass: bool = True
+```
+
+`__init__.py` exports gain `TenantAwareAdapterMixin` and `TenantMiddleware`.
+
+### Configuration Changes
+
+| Setting | Default | Description |
+|---|---|---|
+| `HYPERADMIN_TENANT_ENABLED` | `False` | Kill switch. Disabled ⇒ middleware no-op |
+| `HYPERADMIN_TENANT_ID_ATTR` | `"tenant_id"` | Attribute name on `request.state.user` |
+| `HYPERADMIN_TENANT_RESOLVE_FROM_SUBDOMAIN` | `False` | Enable subdomain → tenant lookup |
+| `HYPERADMIN_TENANT_SUBDOMAIN_RESOLVER` | `None` | Dotted import path to `Callable[[str], int \| None]` |
+| `HYPERADMIN_TENANT_HEADER_NAME` | `"X-Tenant-ID"` | Header name for cross-tenant admins |
+
+Per-`ModelAdmin`:
+
+```python
+class OrderAdmin(ModelAdmin):
+    options = AdminOptions(
+        tenant_field="tenant_id",
+        tenant_superuser_bypass=True,
+    )
+```
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| `tenant_enabled=True` but request has no resolved tenant and user is not a superuser | 400 Bad Request with `"tenant required for {path}"` (early signal in development) |
+| `tenant_field` set but model has no such column | SQL error surfaces during list() — fail loudly. Documented as developer error |
+| Cross-tenant `get(pk)` | Returns `None` from adapter (filter excludes it); view raises 404 |
+| Cross-tenant `update(pk, data)` | `update()` returns 0 rows; view raises 404 |
+| Cross-tenant `delete(pk)` | Same as update — 404 |
+| Aggregate / count queries | The same `get_queryset()` filter applies (already merged into count in v0.5.1) |
+| Subdomain resolver raises | Caught; tenant left unresolved; log warning |
+| Header-supplied tenant id is non-integer when DB column is integer | Coerce with `int()`; on `ValueError` → 400 |
+| User has `is_superuser=True` but no tenant_id | Bypasses filter (superuser exception). Document as expected |
+| Tenant filter + object-level checker disagree | Object-level checker runs after row is fetched (post-filter). If row passes tenant filter, then object check applies. Behaves like an AND |
+| HTMX inline-cell-edit endpoint | Same protections — view fetches row via adapter.get(pk), tenant filter applies, 404 on cross-tenant |
+| Adapter without the mixin | Behaves exactly as today — backward compatible |
+| `selectinload` relationships pulling cross-tenant rows | Documented: secondary relations are not auto-filtered. Host adds query options or model-level filters |
+| Bulk operations (future) | Inherit the same filter via `get_queryset()` — no new path needed |
+
+## Migration & Backward Compatibility
+
+- **No breaking changes.** All new fields default to `None` / `False`.
+- **No DB migration.** `tenant_id` columns belong to the host application's models; the
+  framework adds none.
+- **Public API.** `__init__.py` gains `TenantAwareAdapterMixin` and `TenantMiddleware`. No
+  removals or renames. Semver-minor bump.
+- **Adapter contract.** `get_queryset()` signature unchanged. Mixin overrides via `super()`,
+  so subclassing third-party adapters continues to work.
+
+Recommended adoption path for existing apps:
+
+1. Add `tenant_id` column to relevant models (host migration).
+2. Set `HYPERADMIN_TENANT_ENABLED=true` and `tenant_id_attr` on user model.
+3. Switch adapters to `TenantSQLModelAdapter` (or compose the mixin manually).
+4. Set `tenant_field="tenant_id"` on each scoped `ModelAdmin`.
+5. Verify `request.state.tenant_id` is populated; ship.
+
+## Open Questions
+
+- [x] Single global header name vs. per-`ModelAdmin`? → **Global.** Header name is an
+      org-wide convention; per-model would invite drift.
+- [x] Should the mixin auto-coerce `tenant_id` (e.g., string → int)? → **No.** Adapter
+      column types differ (UUID, str, int). Host app's tenant resolver returns the right
+      type.
+- [x] Default `tenant_superuser_bypass` to `True` or `False`? → **`True`.** Matches Django
+      and existing v0.5.1 superuser conventions; explicit opt-out is cheap.
+- [x] 404 vs 403 on cross-tenant access? → **404.** 403 leaks existence ("this row exists
+      but you can't see it"); 404 is opaque.
+- [ ] Should `TenantMiddleware` order be enforced relative to `AuthenticationMiddleware`?
+      → Yes — `TenantMiddleware` must run **after** auth so `request.state.user` is set.
+      Documented in `Admin.__init__` middleware stack registration. **Resolved on approval.**
+- [ ] OAuth user provisioning (v0.5.2) sets `user.tenant_id` how? → Documented in the OAuth
+      SDD. The `OAuthProviderConfig.tenant_id_claim` field maps a userinfo claim onto the
+      user's tenant attribute. New users without a claim get `tenant_id=None` and are
+      unreachable until an admin assigns them. **Resolved by reference to `oauth-sso.md`.**
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Mixin composition over inheritance | Composable with any adapter (SQLModel, SQLAlchemy, third-party) without changing the base contract | Make `BaseAdapter` always tenant-aware — breaks existing adapters and forces a config flag everywhere |
+| Tenant id attribute is a settings-driven name (`tenant_id_attr`) | Host apps embed tenancy in many shapes (column, FK, derived property); we should not prescribe one | Hard-code `user.tenant_id` — couples framework to host schema |
+| Tenant resolution prefers user → header → subdomain | User attribute is the safest default; header is an explicit cross-tenant admin opt-in; subdomain is for B2B SaaS with vanity URLs | URL-prefix routing (`/t/{tid}/...`) — breaks all existing URL helpers |
+| 404 on cross-tenant miss | Prevents existence disclosure | 403 — leaks information; rejected |
+| Settings kill switch (`tenant_enabled`) | Existing single-tenant apps must see zero behavioural change after the upgrade | No flag — every install would have to opt out, hostile to upgrade path |
+| Superuser bypass on by default | Mirrors Django; admin tools need it | Default-off — surprising for users coming from Django |
+| Filter is a flat `dict[tenant_field, tenant_id]` | Consistent with v0.5.1 `get_queryset()` shape; no `Select` mutator coupling | Callable filter — too flexible, harder to reason about; defer to v0.5.3+ if needed |
+| No new table for tenant ↔ user mapping | Host apps already have this; framework would duplicate / conflict | Ship a `Tenant` table — out of scope, opinionated |

--- a/docs/specs/oauth-sso.md
+++ b/docs/specs/oauth-sso.md
@@ -1,0 +1,482 @@
+# SDD: OAuth2/OIDC SSO — Google & GitHub
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | #420 (epic), #438 (review gate) |
+| Milestone | v0.5.2 — OAuth SSO |
+| Created | 2026-05-10 |
+| Last updated | 2026-05-10 |
+
+---
+
+## Problem
+
+HyperAdmin authenticates with username + password through `auth/views.py` and an
+`AuthBackend` Protocol. v0.5.1 added MFA on top, so the existing flow is already
+multi-stage. What is missing is **federated identity** — the ability to log in with
+Google Workspace, GitHub, or another OIDC-conformant identity provider.
+
+This blocks adoption by:
+
+- Organizations whose security policy forbids holding password material outside their IdP.
+- Engineering teams that already federate everything through GitHub.
+- B2B SaaS hosts that want their customers' employees to sign in via the customer's IdP.
+
+The existing local-auth path must keep working unchanged; OAuth must compose with MFA
+(an OAuth login still triggers the local OTP step when `mfa_enabled=True`); and OAuth
+must not undermine the v0.5.3 multi-tenancy work — tokens, claims, and provisioning rules
+must all carry the tenant correctly.
+
+## Goals
+
+- **Two providers shipped:** Google (OIDC) and GitHub (OAuth2 + custom userinfo). Both via
+  a generic `OAuthBackend` parameterized by `OAuthProviderConfig` so a third provider
+  needs only configuration, not code.
+- **Persistent tokens.** `OAuthToken` SQLModel stores per-user-per-provider access /
+  refresh tokens, scopes, and expiry. Tokens are encrypted at rest with `cryptography.Fernet`
+  using a key from `HYPERADMIN_OAUTH_TOKEN_SECRET` (32-byte url-safe base64).
+- **Refresh middleware.** A lightweight middleware refreshes tokens that expire within
+  the next 60 seconds and clears the session on hard refresh failure.
+- **Account-linking policy.** First-time OAuth login with an email matching an existing
+  local user does **not** auto-link. The user is told "Account exists; sign in with your
+  password and link from settings." Linking only happens from an authenticated session.
+- **MFA bridge.** OAuth login still respects `user.mfa_enabled`; the OAuth callback creates
+  a partial-auth session and redirects to `/admin/mfa/challenge`.
+- **Tenant bridge (v0.5.3 forward-compat).** `OAuthProviderConfig.tenant_id_claim`
+  optionally maps a userinfo claim (e.g. Google `hd`) to the user's tenant attribute on
+  provisioning. Without a mapping, new OAuth users get `tenant_id=None`.
+- **Login page UI.** "Sign in with Google" / "Sign in with GitHub" buttons render only
+  when the corresponding provider is configured.
+- **PKCE.** All OAuth2 authorization-code flows use PKCE (`S256`). Public clients become
+  optional later; PKCE in a server-side admin is cheap insurance against a leaked
+  `client_secret`.
+- **Backward compatible.** Apps with no OAuth configured see zero new UI, zero new tables
+  used, zero behaviour change.
+
+## Non-Goals
+
+- SAML2 — different protocol family, requires XML signing; deferred indefinitely.
+- Social-login providers beyond Google/GitHub (Microsoft, Okta, Auth0, Apple, ...) —
+  shipped post-v0.5.2 by configuration only, no code.
+- Provider-initiated logout / RP-initiated logout (OIDC end_session_endpoint) — defer.
+- Session revocation endpoints — defer.
+- Device-authorization grant (CLI flow) — defer.
+- Token introspection / userinfo polling for live group membership — defer.
+- SSO-driven group membership sync (claims → permissions) — defer to a later milestone;
+  v0.5.2 only provisions a base User row.
+- An admin UI to register / configure OAuth providers — host app passes config in code.
+
+## BDD Scenarios
+
+```
+Scenario: login page shows OAuth buttons only for configured providers
+  Given Admin is configured with provider "google"
+  And   provider "github" is NOT configured
+  When  the user navigates to /admin/login
+  Then  the page shows a "Sign in with Google" button
+  And   the page does NOT show a "Sign in with GitHub" button
+
+Scenario: clicking the provider button redirects to authorize URL with PKCE
+  Given Admin is configured with provider "google"
+  When  the user clicks "Sign in with Google"
+  Then  the response is 302 to https://accounts.google.com/o/oauth2/v2/auth?...
+  And   the URL includes code_challenge and code_challenge_method=S256
+  And   request.session contains the matching code_verifier and state nonce
+
+Scenario: callback exchanges code for tokens and provisions a new user
+  Given Admin is configured with provider "google"
+  And   the IdP returns userinfo {"email": "alice@acme.com", "sub": "abc123"}
+  And   no local user exists with that email
+  When  GET /oauth/callback/google?code=...&state=<valid-state>
+  Then  a new User row is created with email "alice@acme.com"
+  And   an OAuthToken row stores the encrypted access and refresh tokens
+  And   a full session is created
+  And   the response redirects to /admin/
+
+Scenario: callback links a returning user
+  Given a User exists with provider="google" sub="abc123"
+  When  GET /oauth/callback/google?code=...&state=<valid-state> with the same sub
+  Then  no new User row is created
+  And   the existing OAuthToken row is updated with new access / refresh values
+  And   a full session is created
+
+Scenario: callback with email matching a local-only user does NOT auto-link
+  Given a local User exists with email "alice@acme.com" and no OAuthToken
+  When  GET /oauth/callback/google with userinfo email="alice@acme.com"
+  Then  the response is 409 Conflict
+  And   the page renders "Account exists. Sign in with your password and link from settings."
+  And   no User or OAuthToken rows are created
+
+Scenario: callback rejects mismatched state nonce (CSRF protection)
+  Given the session has state="abc"
+  When  GET /oauth/callback/google?state=xyz&code=...
+  Then  the response is 400 Bad Request
+  And   no token exchange is attempted
+
+Scenario: callback rejects expired state (10-minute TTL)
+  Given the session-stored state was issued 11 minutes ago
+  When  the OAuth callback arrives with that state
+  Then  the response is 400 Bad Request
+
+Scenario: provider error from IdP surfaces a clear message
+  Given the IdP returns ?error=access_denied
+  When  the user is redirected back to /oauth/callback/google
+  Then  the response is 400 Bad Request
+  And   the body contains "OAuth provider denied access"
+
+Scenario: token refresh middleware refreshes near-expiry tokens
+  Given alice has an OAuthToken with expires_at in 30 seconds
+  When  alice issues an authenticated request
+  Then  the middleware exchanges the refresh_token for a new access token
+  And   the OAuthToken row is updated with the new access and expires_at
+  And   the original request proceeds normally
+
+Scenario: token refresh hard failure clears the session
+  Given alice's refresh_token has been revoked at the IdP
+  When  the middleware attempts a refresh and the IdP returns 400 invalid_grant
+  Then  the user's session is cleared
+  And   the response redirects to /admin/login with a "Session expired" flash
+
+Scenario: OAuth login still triggers MFA when user.mfa_enabled is True
+  Given user "alice" has mfa_enabled=True
+  When  GET /oauth/callback/google completes successfully
+  Then  a partial-auth session is created (no admin access)
+  And   an OTP code is sent to alice's email
+  And   the response redirects to /admin/mfa/challenge
+
+Scenario: OAuth tokens are encrypted at rest
+  Given an OAuthToken row exists for alice
+  When  the access_token field is read directly from the database
+  Then  the stored bytes are not equal to the plaintext access_token
+  And   reading via OAuthToken.access_token returns the plaintext
+
+Scenario: tenant_id_claim provisions tenant on first login
+  Given OAuthProviderConfig has tenant_id_claim="hd"
+  And   the IdP returns userinfo {"email": "alice@acme.com", "hd": "acme.com"}
+  And   the host app maps domain "acme.com" → tenant_id 7
+  When  GET /oauth/callback/google completes
+  Then  the new User row has tenant_id = 7
+
+Scenario: linking an OAuth identity from settings
+  Given alice is fully authenticated and visits /admin/oauth/link/google
+  When  alice completes the OAuth flow
+  Then  an OAuthToken row is created for alice with provider="google"
+  And   alice's User.email is unchanged
+  And   the response redirects to /admin/oauth/settings with a success flash
+
+Scenario: unlinking an OAuth identity from settings
+  Given alice has an OAuthToken row for provider="google"
+  And   alice has a usable password (i.e. is not OAuth-only)
+  When  alice POSTs /admin/oauth/unlink/google
+  Then  the OAuthToken row is deleted
+  And   alice can still log in with password
+
+Scenario: cannot unlink the only auth method
+  Given alice has an OAuthToken for provider="google"
+  And   alice's password_hash is None (provisioned via OAuth)
+  When  alice POSTs /admin/oauth/unlink/google
+  Then  the response is 400 Bad Request
+  And   the body contains "Set a password before unlinking your only sign-in method"
+```
+
+## Design
+
+### Architecture
+
+```
+                ┌──────────────────────────┐
+                │     auth/oauth/          │   (new package)
+                │  ─ backend.py            │   OAuthBackend (AuthBackend impl)
+                │  ─ providers.py          │   OAuthProviderConfig + builders
+                │  ─ tokens.py             │   FernetTokenCipher
+                │  ─ refresh.py            │   OAuthRefreshMiddleware
+                │  ─ exceptions.py         │   OAuthProviderError, AccountLinkRequiredError
+                │  ─ views.py              │   /oauth/authorize, /oauth/callback, link, unlink
+                └────────────┬─────────────┘
+                             │ uses (Protocol)
+                             ▼
+                ┌────────────────────────┐
+                │   core/auth.py         │  AuthBackend (existing)
+                │                        │  + OAuthBackend conforms
+                └────────────────────────┘
+                             ▲
+                             │ implements
+                             │
+        ┌────────────────────┴───────────────────────┐
+        │   auth/views.py (mod) — login_view shows   │
+        │   provider buttons; reuses existing MFA    │
+        │   redirect flow on partial-auth sessions   │
+        └────────────────────────────────────────────┘
+                             ▲
+                             │ persistence
+                             │
+        ┌────────────────────┴────────────────────┐
+        │   auth/models.py (mod)                  │
+        │   + OAuthToken (encrypted access/       │
+        │      refresh tokens, expiry, scopes)    │
+        │   + User.password_hash → Optional       │
+        │   + User.oauth_only computed property   │
+        └─────────────────────────────────────────┘
+```
+
+Module layout:
+
+```
+src/hyperadmin/auth/oauth/
+├── __init__.py        — public exports
+├── backend.py         — OAuthBackend (implements AuthBackend)
+├── providers.py       — OAuthProviderConfig, google_provider(), github_provider()
+├── tokens.py          — FernetTokenCipher, helpers
+├── refresh.py         — OAuthRefreshMiddleware
+├── exceptions.py      — OAuthProviderError, AccountLinkRequiredError, MFARequiredError
+└── views.py           — authorize, callback, link, unlink, settings handlers
+
+src/hyperadmin/auth/
+├── models.py          — (mod) add OAuthToken; relax User.password_hash to Optional
+├── views.py           — (mod) login page renders provider buttons
+└── __init__.py        — (mod) re-export OAuthBackend, OAuthProviderConfig
+
+src/hyperadmin/templates/auth/
+├── login.html         — (mod) provider button rows
+├── oauth_link_required.html  — (new) account-link interstitial
+└── oauth_settings.html        — (new) per-user link/unlink view
+```
+
+Dependency direction:
+
+- `auth/oauth/` → `auth/` and `core/` (one direction, no cycles).
+- `auth/oauth/views.py` consumes the existing `core/auth.AuthBackend` Protocol and produces
+  full-auth or partial-auth sessions through the same helpers `auth/views.py` already uses.
+
+Library choice — `httpx-oauth` (`>=0.13`):
+
+- Battle-tested in `fastapi-users`.
+- Async-native (`httpx`).
+- Built-in Google and GitHub provider classes; OIDC discovery for Google.
+- PKCE supported.
+- 23 KB of dependencies — small footprint.
+
+### Data Model Changes
+
+```python
+# src/hyperadmin/auth/models.py
+
+class OAuthToken(SQLModel, table=True):
+    __tablename__ = "hyperadmin_oauth_tokens"
+
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="hyperadmin_users.id", index=True)
+    provider: str = Field(max_length=32, index=True)
+    sub: str = Field(max_length=255, index=True)  # IdP-side stable user id
+    access_token_encrypted: bytes
+    refresh_token_encrypted: bytes | None = None
+    expires_at: datetime | None = None
+    scopes: list[str] = Field(default_factory=list, sa_column=Column(JSON))
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    __table_args__ = (
+        UniqueConstraint("provider", "sub", name="uq_oauth_provider_sub"),
+        UniqueConstraint("user_id", "provider", name="uq_oauth_user_provider"),
+    )
+
+    @property
+    def access_token(self) -> str:
+        return _cipher().decrypt(self.access_token_encrypted).decode()
+
+    @access_token.setter
+    def access_token(self, value: str) -> None:
+        self.access_token_encrypted = _cipher().encrypt(value.encode())
+
+    # refresh_token property mirrors access_token, handling None
+```
+
+`User` model changes (additive, backward compatible):
+
+```python
+class User(SQLModel, table=True):
+    ...
+    password_hash: str | None = Field(default=None)  # was required; now optional for OAuth-only
+
+    @property
+    def oauth_only(self) -> bool:
+        return self.password_hash is None
+```
+
+Existing rows already have `password_hash` set; the column type loosening is a no-op at the
+SQL level (NULLability change is the only schema effect, and host apps own that migration).
+
+### API / Protocol Changes
+
+**`OAuthProviderConfig`** (frozen dataclass, no Pydantic — config is wired in code):
+
+```python
+@dataclass(frozen=True, slots=True)
+class OAuthProviderConfig:
+    name: str                       # "google" | "github" | custom
+    client_id: str
+    client_secret: str
+    scopes: tuple[str, ...]
+    authorize_url: str
+    token_url: str
+    userinfo_url: str
+    sub_claim: str = "sub"          # GitHub uses "id"; Google uses "sub"
+    email_claim: str = "email"
+    tenant_id_claim: str | None = None
+    button_label: str | None = None
+    button_icon: str | None = None  # path under /static/
+```
+
+Helper builders:
+
+```python
+def google_provider(client_id: str, client_secret: str, *, hosted_domain: str | None = None,
+                    tenant_id_claim: str | None = None) -> OAuthProviderConfig: ...
+def github_provider(client_id: str, client_secret: str, *,
+                    scopes: tuple[str, ...] = ("read:user", "user:email")) -> OAuthProviderConfig: ...
+```
+
+**`OAuthBackend`** implements `AuthBackend`:
+
+```python
+class OAuthBackend:
+    def __init__(self, providers: dict[str, OAuthProviderConfig], session_factory): ...
+    async def login(self, request, user) -> None: ...   # existing AuthBackend contract
+    async def logout(self, request) -> None: ...
+    async def authorize(self, request, provider: str) -> RedirectResponse: ...
+    async def callback(self, request, provider: str) -> Response: ...
+```
+
+**Endpoints** (registered when `Admin(oauth_backend=OAuthBackend(...))`):
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET  | `/admin/oauth/authorize/{provider}` | Build authorize URL with PKCE + state, redirect |
+| GET  | `/admin/oauth/callback/{provider}`  | Validate state, exchange code, provision/log in |
+| GET  | `/admin/oauth/settings`             | Render link/unlink view (auth required) |
+| GET  | `/admin/oauth/link/{provider}`      | Initiate link flow from settings (auth required) |
+| POST | `/admin/oauth/unlink/{provider}`    | Delete OAuthToken row (auth required) |
+
+**`Admin(...)`** gains:
+
+```python
+def __init__(
+    self,
+    ...,
+    oauth_backend: OAuthBackend | None = None,
+) -> None: ...
+```
+
+When provided, `__init__` mounts `OAuthRefreshMiddleware` and registers the routes above.
+
+**Public exports** added to `hyperadmin.__init__`:
+
+```python
+from hyperadmin.auth.oauth import (
+    OAuthBackend,
+    OAuthProviderConfig,
+    OAuthProviderError,
+    AccountLinkRequiredError,
+    google_provider,
+    github_provider,
+)
+```
+
+### Configuration Changes
+
+| Variable | Default | Description |
+|---|---|---|
+| `HYPERADMIN_OAUTH_TOKEN_SECRET` | (none — required if OAuth used) | 32-byte url-safe base64 Fernet key |
+| `HYPERADMIN_OAUTH_STATE_TTL_SECONDS` | `600` | Authorize-state expiry |
+| `HYPERADMIN_OAUTH_REFRESH_LEEWAY_SECONDS` | `60` | Refresh tokens this many seconds before expiry |
+| `HYPERADMIN_OAUTH_LOGIN_REDIRECT` | `"/admin/"` | Post-login destination |
+
+Per-app code wiring:
+
+```python
+admin = Admin(
+    app,
+    oauth_backend=OAuthBackend(providers={
+        "google": google_provider(env["GOOGLE_CLIENT_ID"], env["GOOGLE_CLIENT_SECRET"],
+                                  hosted_domain="acme.com", tenant_id_claim="hd"),
+        "github": github_provider(env["GH_CLIENT_ID"], env["GH_CLIENT_SECRET"]),
+    }),
+)
+```
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| `HYPERADMIN_OAUTH_TOKEN_SECRET` missing while OAuth configured | Hard fail at `Admin.__init__` — refuse to start |
+| Fernet key rotation | Two-key support: list-of-keys env var, decrypt with any, encrypt with first. Documented; v0.5.2+ feature |
+| State nonce reused | Single-use — deleted from session on first callback hit |
+| State nonce missing | 400 Bad Request — likely cookie cleared mid-flow |
+| Provider returns no email (GitHub privacy) | Fall back to provider's `/user/emails` endpoint with `read:user`+`user:email` scopes; if still none, 400 with "Email required" |
+| Provider userinfo schema drifts | `OAuthProviderConfig` exposes `sub_claim` / `email_claim` so the host can patch without code change |
+| Same email, two different `sub` values across providers | Treated as account-link conflict — settings flow links explicitly |
+| Email collision with local user (no OAuth row) | 409 with link-required interstitial; **never** auto-link |
+| Email collision with another OAuth-provisioned user (different IdP `sub`) | 409 — user must log in with the other identity and link from settings |
+| Token refresh failure (network) | Retry once with 1s backoff inside middleware; on second failure, leave token as-is, allow request to proceed (admin endpoints will 401 if access token is rejected) |
+| Token refresh failure (`invalid_grant`) | Hard — clear session, redirect to login with flash |
+| User-agent strips cookies between authorize and callback | State validation fails → 400; user clicks login again, new flow |
+| MFA-enabled user completes OAuth | Partial-auth session, redirect to `/admin/mfa/challenge`. Existing OTP service handles the rest |
+| Tenant claim present but no domain mapping | New user gets `tenant_id=None` (admin must assign). Logged at INFO |
+| Tenant claim absent on returning user | Don't overwrite existing `tenant_id` — preserve admin assignment |
+| OAuth-only user disables MFA | Allowed; OAuth login still requires the IdP's authentication |
+| OAuth unlink would orphan the user | Reject with 400 ("Set a password before unlinking your only sign-in method") |
+| Concurrent callback (two tabs) | Latest one wins; tokens upserted on `(provider, sub)` unique constraint |
+| Provider request to `userinfo` returns 401 | Treat as expired access token; trigger refresh; on refresh failure, 502 to user |
+| Webhook / API token use of OAuth tokens | Out of scope — OAuth tokens are session-coupled. Documented |
+
+## Migration & Backward Compatibility
+
+- **No breaking changes.**
+- **DB migration owned by host app** (single table add: `hyperadmin_oauth_tokens`; one
+  column nullability change on `hyperadmin_users.password_hash`). Documented in changelog.
+- **`User.password_hash` → Optional** is read-compatible — existing values keep working.
+- **Public API** is additive. `__init__.py` exports added; nothing renamed/removed.
+- **Existing `AuthBackend` implementations** continue to work — `OAuthBackend` is a peer,
+  not a replacement.
+- **MFA + OAuth interaction** preserves the v0.5.1 partial-auth session shape.
+
+## Open Questions
+
+- [x] Library: `httpx-oauth` vs hand-rolled? → **`httpx-oauth`.** PKCE + token refresh +
+      provider classes in 23 KB. Pinning `>=0.13,<1.0`.
+- [x] Token storage: encrypt at rest or rely on DB-level encryption? → **Encrypt at rest.**
+      Defense in depth; cheap; one Fernet roundtrip per request is negligible.
+- [x] Auto-link by email or interstitial? → **Interstitial.** Auto-link is a known SSO
+      vulnerability when IdP email isn't verified or attacker controls the email's MX.
+- [x] OAuth-only users: allow no password? → **Yes**, gated on a unlink check that
+      requires either a password or another linked OAuth identity.
+- [x] Where do PKCE verifier and state nonce live? → **Session.** No new table.
+      State carries TTL via session timestamp.
+- [x] Token refresh: middleware vs background task? → **Middleware.** Background tasks
+      add complexity (Redis, scheduler) and don't help if the user is offline anyway.
+- [ ] Group/role provisioning from OAuth claims? → **Deferred.** v0.5.2 only provisions
+      the User row. Group sync needs an SDD of its own (ties into v0.5.x permissions).
+      Resolved on approval as out-of-scope.
+- [ ] Rate-limiting on the callback endpoint? → **Yes**, per-IP rate limit on
+      `/oauth/callback/{provider}`. Reuses the OTP rate limiter pattern. Final knob:
+      `HYPERADMIN_OAUTH_CALLBACK_RATE_LIMIT=(20, 60)` (20 attempts / minute / IP).
+      Resolved on approval.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| `httpx-oauth` library | Mature, async, supports PKCE + Google + GitHub out of the box; small footprint | `authlib` (heavier, more features we don't need); hand-rolled (PKCE + token refresh easy to misimplement) |
+| PKCE on by default | Cheap; protects against `client_secret` exposure in misconfigured deployments | Skip PKCE for confidential clients — rejected, no downside to enabling |
+| Encrypt tokens at rest with Fernet | Defense in depth; single dep (`cryptography`) already transitive | Plain text + DB encryption — relies on host config; AES-GCM custom impl — reinventing |
+| Account-link interstitial on email collision | Auto-link is a known SSO takeover vector | Auto-link by verified email — fragile; some IdPs lie about verification |
+| Refresh in middleware | Predictable; no background infra | Background task — adds Redis dep + scheduling; cron — too coarse |
+| Tenant claim mapping is optional | Single-tenant apps must not be forced into a claim mapping | Mandatory tenant claim — couples OAuth to multi-tenancy |
+| `OAuthProviderConfig` is a `dataclass`, not Pydantic | Wired in code, not env; immutable; no validation cost per request | Pydantic model — adds runtime cost without benefit |
+| Two endpoints per provider (`authorize`, `callback`) | Maps directly to OAuth2 spec | Single endpoint — harder to reason about / log |
+| Settings flow for link/unlink | Mirrors MFA settings UX from v0.5.1 | Inline on profile page — too crowded; magic link in email — out of scope |
+| `User.password_hash` becomes Optional | Required to support OAuth-only users | Sentinel password ("oauth_only") — hostile to debugging |
+| Exceptions: `OAuthProviderError`, `AccountLinkRequiredError`, `MFARequiredError` | Structured failure modes the views can render to specific templates | Generic `HTTPException` with codes — couples flow to status codes |
+| Provider button rendering only for configured providers | Avoid 404 buttons | Always render — confusing UX |

--- a/docs/specs/realtime-occ.md
+++ b/docs/specs/realtime-occ.md
@@ -1,0 +1,412 @@
+# SDD: Optimistic Concurrency Control (OCC)
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | #332 (epic), #314–#321 (stories) |
+| Milestone | v0.6.0 — Real-Time Layer (Track B, independent of WebSocket track) |
+| Created | 2026-05-10 |
+| Last updated | 2026-05-10 |
+
+---
+
+## Problem
+
+When two admins open the same record and save in sequence, the second save silently
+overwrites the first. v0.5.0 shipped inline cell editing — an interaction pattern that
+specifically encourages quick, cell-at-a-time edits — making the lost-update problem
+more visible. The v0.5.1 SDD explicitly deferred OCC to a follow-up epic.
+
+What's missing today:
+
+1. **Conflict detection.** No version field is read or compared on update.
+2. **Adapter contract.** `BaseAdapter.update(pk, data)` ignores prior state.
+3. **View-layer signalling.** No HTTP 409 response, no conflict-resolution UI.
+4. **OCC for inline cell editing.** The new endpoint shipped in v0.5.0 has no version field.
+
+OCC is the smallest of the four v0.6.0 epics, has no dependency on WebSocket / PubSub
+infrastructure, and provides immediate value to inline editing. Shipping it first inside
+v0.6.0 lets the WebSocket track proceed in parallel with no merge contention.
+
+## Goals
+
+- **Auto-detect a version field** on each model: prefer an explicit `version: int` column;
+  fall back to `updated_at: datetime` when settings allow it.
+- **Adapter enforcement.** `BaseAdapter.update(pk, data, expected_version)` raises a
+  typed `StaleRecordError` when the row's current version differs from `expected_version`.
+- **View-layer wiring.** Update form renders a hidden `__version` field; on submit, view
+  passes it through; on `StaleRecordError`, view returns HTTP 409 and renders a conflict
+  dialog comparing the user's edits to the current values.
+- **Inline cell editing integration.** Inline endpoints accept `__version` from the cell
+  fragment; on conflict, the cell re-renders with a small "Refresh, your value is stale"
+  affordance instead of swapping the value.
+- **Opt-in per `ModelAdmin`.** `AdminOptions.enforce_occ: bool = False` (default off) so
+  existing apps see no behaviour change; flip on once their models have a version column.
+- **Settings switch for `updated_at` fallback.** `concurrency_use_updated_at: bool = False`.
+  Documented as approximate (sub-millisecond races possible).
+- **Friendly conflict resolution UI.** A diff dialog shows the user's submitted values vs.
+  the current row, with "Override anyway" and "Discard my edits" actions.
+- **Backward compatible.** `enforce_occ=False` ⇒ identical to current behaviour.
+
+## Non-Goals
+
+- Pessimistic locking (DB-level row locks held across HTTP requests). Always lossy on the
+  open web; out of scope.
+- Multi-row / batch update OCC. Bulk operations are not yet a first-class feature.
+- Distributed lock managers (Redis lock). YAGNI for MVP; OCC is a server-side compare.
+- Field-level conflict resolution ("merge their change in field X with my change in field
+  Y"). Defer — would require structural diff and cell-level merging UI.
+- Three-way merge with the original snapshot. The dialog is two-way (submitted vs.
+  current); the user chooses one.
+- Real-time notification of in-progress edits ("alice is editing this row"). That is the
+  Presence epic (v0.6.0 Track D), not OCC.
+- Versioned audit log of all changes. Audit log is its own SDD (deferred from v0.5.1).
+
+## BDD Scenarios
+
+```
+Scenario: version field is auto-detected on a model with `version: int`
+  Given a SQLModel Order has fields including version: int
+  When  the framework introspects the model
+  Then  the detected version_field is "version"
+
+Scenario: updated_at fallback when version column is absent
+  Given a SQLModel Order has updated_at: datetime but no version column
+  And   concurrency_use_updated_at = True
+  When  the framework introspects the model
+  Then  the detected version_field is "updated_at"
+
+Scenario: no version field detected when neither is present
+  Given a SQLModel Tag has no version and no updated_at column
+  When  the framework introspects the model with enforce_occ=True
+  Then  a clear ConfigurationError is raised at startup
+
+Scenario: update succeeds when expected_version matches current
+  Given order#42 has version=3
+  When  adapter.update(42, {"name": "Alice"}, expected_version=3) is called
+  Then  the row is updated
+  And   the new version is 4
+
+Scenario: update raises StaleRecordError when expected_version is stale
+  Given order#42 has version=3
+  When  adapter.update(42, {"name": "Alice"}, expected_version=2) is called
+  Then  StaleRecordError is raised with current=3, expected=2
+
+Scenario: update form renders hidden __version field
+  Given OrderAdmin.options.enforce_occ = True
+  And   order#42 has version=3
+  When  GET /admin/order/42/edit is rendered
+  Then  the form contains an <input type="hidden" name="__version" value="3">
+
+Scenario: update view returns 409 on stale submit
+  Given OrderAdmin.options.enforce_occ = True
+  And   order#42 has version=3
+  When  POST /admin/order/42/edit is submitted with __version=2 and updated fields
+  Then  the response status is 409
+  And   the response renders the conflict dialog
+  And   the dialog shows the user's submitted values vs the current row
+
+Scenario: conflict dialog "discard my edits" navigates to a fresh edit form
+  Given the user is on the conflict dialog after a stale submit
+  When  the user clicks "Discard my edits"
+  Then  the response is 302 to /admin/order/42/edit
+  And   the form is rendered with current values
+
+Scenario: conflict dialog "override anyway" re-submits with current version
+  Given the user is on the conflict dialog with the current version=4
+  When  the user clicks "Override anyway"
+  Then  the form is re-submitted with __version=4
+  And   the update succeeds (assuming no further concurrent change)
+  And   the new version is 5
+
+Scenario: inline cell save returns 409 on stale version
+  Given OrderAdmin.options.enforce_occ = True
+  And   list_editable = ["name"]
+  And   order#42 has version=3
+  When  POST /admin/order/42/inline/name with __version=2 and value="Alicia"
+  Then  the response status is 409
+  And   the cell re-renders showing the current value with a "Stale, refresh" indicator
+  And   the row is unchanged
+
+Scenario: enforce_occ=False preserves legacy behaviour
+  Given OrderAdmin.options.enforce_occ = False (default)
+  When  two concurrent updates both POST without __version
+  Then  both updates succeed (last write wins, as today)
+  And   no StaleRecordError is raised
+
+Scenario: superuser does NOT bypass OCC
+  Given a superuser request
+  And   OrderAdmin.options.enforce_occ = True
+  When  POST /admin/order/42/edit with stale __version
+  Then  the response is 409
+  And   the row is unchanged
+
+Scenario: missing __version field on a configured model returns 400
+  Given OrderAdmin.options.enforce_occ = True
+  When  POST /admin/order/42/edit with no __version field
+  Then  the response is 400 Bad Request
+  And   the row is unchanged
+
+Scenario: updated_at fallback rejects sub-millisecond stale writes
+  Given concurrency_use_updated_at = True
+  And   order#42 has updated_at = "2026-05-10T12:00:00.123Z"
+  When  POST /admin/order/42/edit submits __version with a different timestamp
+  Then  the response is 409
+
+Scenario: prefetched form does not become stale until submit
+  Given alice opens the edit form for order#42 (version=3)
+  And   bob saves order#42 a moment later (now version=4)
+  When  alice opens a different page and returns to the still-loaded form
+  Then  alice's form still shows __version=3
+  And   submitting it returns 409 with the conflict dialog
+```
+
+## Design
+
+### Architecture
+
+```
+                       ┌─────────────────────────────┐
+                       │  core/concurrency.py        │   (new)
+                       │  ─ detect_version_field()   │
+                       │  ─ StaleRecordError         │
+                       └─────────────┬───────────────┘
+                                     │ used by
+              ┌──────────────────────┼──────────────────────┐
+              ▼                      ▼                      ▼
+     core/adapters.py        adapters/sqlmodel.py    adapters/sqlalchemy.py
+     (BaseAdapter contract)  (impl with WHERE pk    (impl with WHERE pk
+       update(pk, data,        AND version=:v)       AND version=:v)
+       expected_version=None)
+              ▲                      ▲                      ▲
+              │ called by                                   │
+              ▼                                             │
+     views/dynamic.py                                       │
+     ─ update_view raises 409 on StaleRecordError, renders  │
+       conflict_dialog.html                                  │
+     ─ inline_save_view returns inline_cell_stale.html      │
+              ▲                                             │
+              │ render                                      │
+              ▼                                             │
+     templates/components/                                  │
+     ─ conflict_dialog.html         (new)                   │
+     ─ inline_cell_stale.html        (new)                   │
+     ─ form.html                     (mod) hidden __version │
+     ─ inline_cell.html              (mod) data-version attr│
+```
+
+Module layout:
+
+```
+src/hyperadmin/core/
+└── concurrency.py            (new) — version detection + StaleRecordError
+
+src/hyperadmin/adapters/
+├── sqlmodel.py               (mod) — update(pk, data, expected_version)
+└── sqlalchemy.py             (mod) — same
+
+src/hyperadmin/core/
+├── adapters.py               (mod) — BaseAdapter contract update
+├── options.py                (mod) — enforce_occ
+└── settings.py               (mod) — concurrency_use_updated_at
+
+src/hyperadmin/views/
+└── dynamic.py                (mod) — handle __version on update + inline_save
+
+src/hyperadmin/templates/
+├── form.html                 (mod) — hidden __version
+└── components/
+    ├── conflict_dialog.html  (new) — full-form conflict UI
+    ├── inline_cell.html      (mod) — data-version attr on cell
+    └── inline_cell_stale.html (new) — stale indicator + refresh affordance
+
+tests/unit/test_concurrency.py
+tests/unit/test_occ_adapters.py
+tests/e2e/test_occ_conflict.py
+```
+
+`core/concurrency.py` lives in `core/` (no ORM-specific dependencies) — it only knows
+about model field metadata and exception types.
+
+### Data Model Changes
+
+The framework adds **no columns** to its own tables. OCC works against host-application
+columns:
+
+- Recommended: `version: int = Field(default=1)` on any model that opts into OCC.
+- Fallback: `updated_at: datetime` when `concurrency_use_updated_at=True`. Documented as
+  approximate (timestamp resolution / clock skew can produce false negatives at sub-
+  millisecond scale; rare in practice).
+
+Detection precedence (in `detect_version_field()`):
+
+1. If the model declares `__version_field__: ClassVar[str] = "..."`, use it.
+2. Else if a `version: int` field exists, use it.
+3. Else if `concurrency_use_updated_at` is `True` and `updated_at: datetime` exists, use it.
+4. Else if `enforce_occ=True`, raise `ConfigurationError` at `Admin.__init__`.
+5. Else, OCC is silently disabled for this model (legacy behaviour).
+
+### API / Protocol Changes
+
+**`StaleRecordError`** in `src/hyperadmin/core/concurrency.py`:
+
+```python
+class StaleRecordError(Exception):
+    def __init__(self, *, model: type, pk: Any, expected: Any, current: Any) -> None: ...
+```
+
+**`BaseAdapter.update`** signature change:
+
+```python
+async def update(
+    self,
+    pk: Any,
+    data: dict[str, Any],
+    *,
+    expected_version: Any | None = None,
+) -> Any:
+    """Update a row.
+    If ``expected_version`` is provided, raise :class:`StaleRecordError` when the
+    current version differs.
+    """
+```
+
+`expected_version=None` preserves today's behaviour for adapters that pre-date OCC.
+
+**SQLModel adapter implementation** (illustrative):
+
+```python
+async def update(self, pk, data, *, expected_version=None):
+    vf = self._version_field
+    async with self.session_factory() as session:
+        if expected_version is not None and vf is not None:
+            stmt = update(self.model).where(self.model.id == pk,
+                                            getattr(self.model, vf) == expected_version)
+            stmt = stmt.values(**data, **{vf: _bump(vf, expected_version)})
+            result = await session.execute(stmt)
+            if result.rowcount == 0:
+                current = await session.get(self.model, pk)
+                raise StaleRecordError(model=self.model, pk=pk,
+                                       expected=expected_version,
+                                       current=getattr(current, vf, None))
+            await session.commit()
+            # Re-fetch to return the canonical updated row
+            return await session.get(self.model, pk)
+        else:
+            return await super().update(pk, data)
+```
+
+`_bump(vf, current)` increments integer versions and refreshes `updated_at` to
+`datetime.now(UTC)`.
+
+**View-layer changes** in `views/dynamic.py`:
+
+```python
+async def update_view(self, request, item_id):
+    form = await self._build_form(request, item_id)
+    expected_version = form.data.pop("__version", None)
+    try:
+        await self.adapter.update(item_id, form.data, expected_version=expected_version)
+    except StaleRecordError as exc:
+        current = await self.adapter.get(item_id)
+        return self._render_conflict_dialog(request, submitted=form.data, current=current)
+    return RedirectResponse(...)
+```
+
+A parallel branch in `inline_save_view` returns `inline_cell_stale.html`.
+
+**`AdminOptions`** addition:
+
+```python
+enforce_occ: bool = False
+```
+
+**Public exports** added to `hyperadmin.__init__`:
+
+```python
+from hyperadmin.core.concurrency import StaleRecordError
+```
+
+### Configuration Changes
+
+| Variable | Default | Description |
+|---|---|---|
+| `HYPERADMIN_CONCURRENCY_USE_UPDATED_AT` | `False` | Allow `updated_at` as a fallback version field |
+| `HYPERADMIN_OCC_RENDER_DIALOG` | `True` | If `False`, return raw 409 with JSON body (for API clients) |
+
+Per-`ModelAdmin`:
+
+```python
+class OrderAdmin(ModelAdmin):
+    options = AdminOptions(enforce_occ=True)
+```
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| `enforce_occ=True` but no version field detectable | `ConfigurationError` at startup. Fail fast |
+| `enforce_occ=True` and the form posts no `__version` | 400 Bad Request — hostile / malformed client |
+| `enforce_occ=False` and `__version` is present | Ignored. Forward-compat, no error |
+| Multiple concurrent updates from the same user (two tabs) | Whichever submits second receives 409 |
+| Override-anyway round-trip after the row changed *again* | Second 409. UI loops correctly |
+| `updated_at` field with no timezone | Coerce to UTC at compare time. Documented |
+| `updated_at` with database-side `NOW()` triggers | Works — adapter re-fetches after update |
+| Custom version field name | Set `__version_field__: ClassVar[str] = "rev"` on the model |
+| Bulk delete includes a stale row | Bulk operations bypass OCC in MVP. Documented; revisit when bulk update lands |
+| Inline cell save with stale __version | 409 + `inline_cell_stale.html` (small "Refresh" indicator). Cell does not swap |
+| Detail view (read-only) | OCC has no effect; reads are always best-effort |
+| File upload field with OCC | Works — the file write happens after the version compare passes |
+| Form re-render on validation error | `__version` re-emitted from the now-current value (refresh-aware) — actually no, we keep the original `__version` so the user can still resolve their conflict on resubmit. Documented |
+| Object-level permission denial after OCC pass | Permission check runs first (existing v0.5.1 path); OCC compare runs only if permission granted |
+| Tenant filter mismatch | The pre-update `adapter.get(pk)` already 404s for cross-tenant; OCC never executes |
+| API client wants a raw 409 | `HYPERADMIN_OCC_RENDER_DIALOG=False` returns `{"error": "stale", "current_version": ...}` |
+| Two updates with identical version values (e.g. trigger increments concurrently) | DB constraint or atomic `UPDATE WHERE version=:v` prevents — only one increments. The other gets 0 rows and 409 |
+
+## Migration & Backward Compatibility
+
+- **No breaking changes.** `enforce_occ=False` (default) preserves current behaviour.
+- **`BaseAdapter.update` signature** gains a keyword-only `expected_version=None`.
+  Third-party adapters that don't accept it: callers will pass it as a kwarg, raising
+  `TypeError`. Mitigated by adding the kwarg with default `None` to the protocol; runtime
+  callers only pass it when `enforce_occ=True`. Documented.
+- **DB migration owned by host app.** When opting into OCC, add `version: int default 1`
+  to the relevant model. Documented in changelog.
+- **Public API.** `__init__.py` gains `StaleRecordError`. Nothing renamed.
+- **Inline cell editing.** The inline `__version` data attribute is additive on the cell
+  fragment; absent cells render as today.
+
+## Open Questions
+
+- [x] Where does version detection live — adapter or core? → **`core/concurrency.py`.**
+      Pure metadata inspection; no ORM dependency. Adapters consume the helper.
+- [x] What's the fallback when no version field exists and `enforce_occ=True`? →
+      **`ConfigurationError` at startup.** Better than silently degrading to last-write-
+      wins.
+- [x] Auto-bump strategy for integer versions? → **`current + 1`** in the same UPDATE
+      statement (atomic, no race with the SELECT).
+- [x] Show conflict dialog vs auto-merge? → **Show dialog.** Auto-merge is a research
+      problem and silently swallows intent.
+- [x] What does the inline cell stale indicator look like? → A small "stale" badge on the
+      cell + a "Refresh" link. Submission re-runs the inline GET to fetch the current value.
+- [ ] Should OCC be ON by default in v0.7? → Likely yes once host apps have had a release
+      to add version columns. Tracked separately; **not a blocker** for v0.6.0.
+- [ ] OCC interaction with bulk operations? → Bulk update isn't a feature yet. When it
+      lands, OCC will need a per-row check. **Out of scope** for this SDD.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Optimistic concurrency, not pessimistic | Web-scale interactive UI; pessimistic locks held across HTTP are toxic | Pessimistic — rejected, doesn't survive abandoned tabs |
+| Atomic `UPDATE WHERE pk=? AND version=?` | Single round-trip; race-free | SELECT + UPDATE — needs serializable isolation |
+| Auto-detect version field with override | Most apps will use `version: int`; flexibility for legacy schemas | Force every app to declare — friction |
+| `updated_at` fallback off by default | Approximate (clock-skew, sub-ms races); explicit opt-in | On by default — surprising false positives |
+| Opt-in per `ModelAdmin` | Existing apps must see no change after upgrade | On by default — breaks every existing install |
+| Conflict dialog renders submitted vs current | Lets user pick winner without losing their edits | Auto-discard / auto-override — silent data loss either way |
+| `StaleRecordError` exposed publicly | Lets host apps catch and translate as they need | Internal — would force host apps to catch generic Exception |
+| Inline cell stale indicator (not full dialog) | A full-page dialog over a single-cell edit is jarring | Full dialog for inline too — UX whiplash |
+| Render mode toggle (HTML dialog vs JSON 409) | Same routes serve both UI and API clients | Two route prefixes — duplication |
+| OCC uses `expected_version` keyword-only | Future-proof against positional ambiguity | Positional — easier to misuse |
+| Track B independent of WebSocket track | OCC has zero infra dependency on PubSub; ship it first inside v0.6.0 | Bundle into a single epic — slows OCC delivery |

--- a/docs/specs/responsive-design.md
+++ b/docs/specs/responsive-design.md
@@ -3,11 +3,11 @@
 | Field | Value |
 |---|---|
 | Author | Claude Code |
-| Status | Draft |
+| Status | Approved |
 | Issue | TBD (epic issue to be created via gitpm push) |
 | Milestone | v0.4.0 — Responsive Design |
 | Created | 2026-05-03 |
-| Last updated | 2026-05-03 |
+| Last updated | 2026-05-10 (Approved retroactively — milestone shipped) |
 
 ---
 


### PR DESCRIPTION
## Summary

Drafts the four missing SDDs that block in-progress milestones, and flips the two retroactive SDDs (responsive design, inline cell editing) from Draft to Approved now that those milestones have shipped.

### New SDDs

- **`docs/specs/multi-tenancy.md`** (v0.5.3) — \`TenantAwareAdapterMixin\` composes onto any adapter and merges \`{tenant_field: request.state.tenant_id}\` into \`get_queryset()\`. \`TenantMiddleware\` resolves tenant in priority user → header (admin opt-in only) → subdomain (when configured). 404 (not 403) on cross-tenant access to avoid existence disclosure. Default-off via \`tenant_enabled\` kill switch.
- **`docs/specs/oauth-sso.md`** (v0.5.2) — \`httpx-oauth\`-based \`OAuthBackend\` for Google + GitHub, parameterized by \`OAuthProviderConfig\`. Tokens encrypted at rest with Fernet (\`HYPERADMIN_OAUTH_TOKEN_SECRET\`). PKCE on by default. Account-link interstitial on email collision (no auto-link — known SSO takeover vector). MFA bridge: OAuth login still triggers OTP when \`user.mfa_enabled=True\`. Tenant claim mapping (\`tenant_id_claim\`) for forward-compat with v0.5.3.
- **`docs/specs/dashboard-builder.md`** (v0.5.4) — \`DashboardWidget\` Protocol with one async \`render()\` method. Built-ins: \`CountWidget\`, \`RecentItemsWidget\`, \`QuickActionsWidget\`. Per-user \`DashboardLayout\` row, drag-drop via \`@alpinejs/sort\` (no new JS). \`BaseAdapter.count()\` and \`aggregate()\` honour \`get_queryset()\` so multi-tenancy filtering applies for free. In-process TTL cache keyed by \`(user_id, tenant_id, widget_id)\`.
- **`docs/specs/realtime-occ.md`** (v0.6.0 Track B — independent of the WebSocket track) — Auto-detects \`version: int\` (or \`updated_at\` fallback). Atomic \`UPDATE WHERE pk=? AND version=?\`. \`StaleRecordError\` raised on 0-row updates. Conflict dialog shows submitted vs. current with override / discard actions. Inline cell stale indicator on the cell fragment. Opt-in per \`AdminOptions.enforce_occ\`.

### Status flips

- \`responsive-design.md\` → Approved (v0.4.0 shipped)
- \`inline-cell-editing.md\` → Approved (v0.5.0 shipped)

### How this fits the rest of v0.6.0

Track A (connection foundation, PubSub, CRUD events) already has \`realtime-connection-foundation.md\` on develop and the connection MVP just landed in #551. This OCC SDD covers Track B explicitly (no overlap). Tracks C (hx-ws notifications) and D (presence) still need their own SDDs and can follow.

## Test plan

These are spec docs — no runtime change. Reviewer checklist per \`.claude/rules/sdd-conventions.md\`:

- [ ] Problem statement is clear and scoped
- [ ] Goals are measurable, non-goals prevent over-engineering
- [ ] BDD scenarios cover happy + ≥1 failure path per goal
- [ ] Data model + API + configuration changes documented
- [ ] Edge cases enumerated
- [ ] Open questions resolved or explicitly deferred with justification
- [ ] CONSTITUTION.md compliance (no circular imports, no \`utils.py\`, business logic out of view handlers)

## Notes

- Each SDD's review story already exists in \`.meta/\`: #438 (OAuth), #455 (Dashboard). Multi-tenancy and OCC reviews can be created alongside this PR if the team prefers an explicit human gate before implementation dispatch.
- After approval, dispatch order I recommend:
  1. v0.5.3 multi-tenancy (smallest, no upstream blockers)
  2. v0.5.2 OAuth SSO + v0.5.4 Dashboard in parallel (different file footprints)
  3. v0.6.0 OCC alongside the existing connection-foundation track