### PR TITLE
docs(meta): upstream readiness phase 1 — tracking epic + v0.5.5 plan

### DIFF
--- a/.meta/epics/epic-upstream-readiness/epic.md
+++ b/.meta/epics/epic-upstream-readiness/epic.md
@@ -1,0 +1,95 @@
+---
+type: epic
+id: ups-readiness-01
+title: "epic(meta): Upstream Readiness — H2/H3/H4/H5/H6/H12/H13/H14/H15/H20"
+status: todo
+priority: high
+owner: null
+labels:
+  - tracking
+  - planned
+  - upstream-readiness
+milestone_ref: null
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Overview
+
+Umbrella tracking epic for the ten generic admin capabilities (H2–H20) HyperAdmin
+must ship before it can serve as the framework backbone for any consumer admin
+application. Each capability is delivered through its own milestone via the
+project's standard pipeline (`.claude/rules/bdd-conventions.md`,
+`sdd-conventions.md`, `planning-playbook.md`). This epic is metadata-only: it
+holds no implementation work itself.
+
+The H-list is intentionally framework-neutral. No consumer-specific naming,
+schema, or business logic enters this repository. See
+`docs/specs/upstream-readiness-plan.md` (this epic body) for the qualification
+matrix.
+
+## Capability Index
+
+| H#  | Capability                          | Status          | Milestone                              |
+|-----|-------------------------------------|-----------------|----------------------------------------|
+| H2  | Inline / nested forms               | shipped v0.5.0  | (polish patch — inline row errors)     |
+| H3  | Bulk actions with param forms       | planned         | v0.5.5 — Bulk Actions & Autocomplete   |
+| H4  | Detail-page panels / tabs           | planned         | v0.5.6 — Detail Panels & Filter Library|
+| H5  | Object-level permissions            | shipped v0.5.1  | —                                      |
+| H6  | HTMX FK/M2M autocomplete            | partial         | v0.5.5 — Bulk Actions & Autocomplete   |
+| H12 | Filter library                      | planned         | v0.5.6 — Detail Panels & Filter Library|
+| H13 | File / image upload (advanced)      | MVP shipped     | v0.3.2 — Advanced File Uploads         |
+| H14 | OLAP / pivot reporting              | planned         | v0.5.4 — Reporting & Charts            |
+| H15 | Chart components                    | planned         | v0.5.4 — Reporting & Charts            |
+| H20 | Tabular permission-matrix UI        | planned         | v0.5.7 — Permissions Matrix            |
+
+## Sequencing
+
+1. **v0.5.0 follow-up** — H2 inline-row error highlighting (bugfix patch).
+2. **v0.5.5** — H3 bulk actions and H6 autocomplete (unblocks consumer build).
+3. **v0.5.6** — H4 detail panels and H12 filter library (depends on H6 wiring).
+4. **v0.5.4** — H14 OLAP reporting and H15 charts (depends on H12 filter forms).
+5. **v0.3.2** — H13 advanced uploads (independent track, in_progress).
+6. **v0.5.7** — H20 permission matrix (depends on H5 surface area).
+
+## SDDs Required
+
+| Milestone | New SDDs |
+|-----------|----------|
+| v0.3.2    | `docs/specs/file-uploads-advanced.md` |
+| v0.5.5    | `docs/specs/bulk-actions.md`, `docs/specs/htmx-autocomplete.md` |
+| v0.5.6    | `docs/specs/detail-panels.md`, `docs/specs/filter-library.md` |
+| v0.5.4    | `docs/specs/olap-reporting.md`, `docs/specs/chart-components.md` |
+| v0.5.7    | `docs/specs/permission-matrix-ui.md` |
+
+Existing SDDs reused: `file-uploads-mvp.md`, `object-permissions-mfa.md`.
+
+## Acceptance (qualification suite)
+
+The ten readiness checks run against `examples/full-demo/` (new in v0.5.7) using
+framework-generic domain models (`Order`, `Invoice`, `Product`, `Supplier`).
+When every check passes on `develop`, HyperAdmin is upstream-ready:
+
+- [ ] H2 polish — nested formset save with one failing child highlights that row
+- [ ] H3 — bulk action across 5 rows, 1 fails, per-row outcome page rendered
+- [ ] H4 — detail page exposes Invoice/History/Transitions panels (panel registry + PDF demo)
+- [ ] H5 — list view filterable by current user via `IsOwnerFilter`
+- [ ] H6 — FK autocomplete narrows variants by selected supplier, "+" creates inline
+- [ ] H12 — sidebar applies date-range + multi-FK + boolean over HTMX, saved as named view
+- [ ] H13 — JPEG upload renders thumbnail in list
+- [ ] H14 — OLAP report sales-by-SKU × month with quarter bucketing, CSV+XLSX export
+- [ ] H15 — same dataset charted via SVG/Chart.js widget
+- [ ] H20 — permission matrix flips view-but-not-edit for a role, detail page reflects it
+
+## Out of Scope
+
+- Anything tied to a specific downstream app — domain models, integration adapters, app-specific business rules.
+- Framework features outside the H-list (state-machine field, audit trail, polymorphic models, money fields, document numbering) — these stay at the consumer layer.
+
+## Parent
+
+- Roadmap: project-wide tracking
+
+## Children (stories)
+
+See `stories/` for per-H# tracker entries.

--- a/.meta/epics/epic-v050-h2-inline-row-errors/epic.md
+++ b/.meta/epics/epic-v050-h2-inline-row-errors/epic.md
@@ -1,0 +1,68 @@
+---
+type: epic
+id: ep-v050-h2-01
+title: "fix(inlines): per-row error highlighting in nested formsets"
+status: todo
+priority: medium
+owner: null
+labels:
+  - size:S
+  - planned
+  - frontend
+  - upstream-readiness
+  - H2
+milestone_ref:
+  id: 1U5Neu25VVR2
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Overview
+
+Closing gap on upstream readiness **H2** (inline / nested forms — shipped in
+v0.5.0). The current `inline_row.html` template renders per-field `aria-invalid`
+and a `<ul class="ha-field-errors">` list, but a failing row is not visually
+distinguished at the row level — operators scanning a long formset can miss the
+failure. The H2 qualification check requires the failing row to be highlighted
+in place.
+
+Bugfix-sized; no SDD required per `sdd-conventions.md`. BDD scenarios in the
+single story.
+
+## Tracks
+
+### Track A: Template + style
+- `inline_row.html` gains a row-level `aria-invalid` and a `ha-inline-row-error` class when any field on the row has errors.
+- `data-testid="inline-{prefix}-row-{index}-error"` exposed when the row is in error state, to let E2E assert the highlight without inspecting CSS.
+
+## Scenarios
+
+```
+Scenario: nested formset save with one failing child highlights that row
+  Given a parent + 3 inline children, child index 1 missing a required field
+  When  the parent form is submitted
+  Then  the response re-renders the formset
+  And   the inline row at index 1 has data-testid="inline-children-row-1-error"
+  And   the row has aria-invalid="true" at the row level
+  And   the other two rows have no error testid
+
+Scenario: all-valid submission renders no row-level error marker
+  Given a parent + 3 inline children, all valid
+  When  the form is submitted and the page re-renders for any reason
+  Then  no inline row carries the row-level error testid
+```
+
+## Acceptance Criteria
+
+- [ ] Row-level `aria-invalid="true"` on `<tr>` when any field on the row has errors
+- [ ] `data-testid="inline-{prefix}-row-{index}-error"` exposed when the row is in error
+- [ ] `ha-inline-row-error` class for styling (no change to E2E selector convention)
+- [ ] CSS rule giving the row a visible accent (border-left or background)
+- [ ] Two E2E scenarios added to existing nested-formset test file
+- [ ] Visual snapshot refreshed
+- [ ] `poe lint` and `poe test:e2e -k inline` pass
+
+## Parent
+
+- Milestone: v0.5.0 (follow-up patch)
+- Tracking: `epic-upstream-readiness` (H2)

--- a/.meta/epics/epic-v050-h2-inline-row-errors/stories/fixinlines-row-level-error-highlighting.md
+++ b/.meta/epics/epic-v050-h2-inline-row-errors/stories/fixinlines-row-level-error-highlighting.md
@@ -1,0 +1,63 @@
+---
+type: story
+id: st-v050-h2-01
+title: "fix(inlines): row-level error highlighting in nested formsets"
+status: todo
+priority: medium
+assignee: null
+labels:
+  - size:S
+  - planned
+  - frontend
+  - tests
+  - upstream-readiness
+  - H2
+estimate: null
+epic_ref:
+  id: ep-v050-h2-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+Apply row-level error markers to `inline_row.html` so operators can spot a
+failing child immediately when scanning a long inline formset. Adds a
+`data-testid` for the row error state and a CSS class for the visual accent.
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/templates/components/inline_row.html` — `aria-invalid` and `data-testid` at `<tr>` level, `ha-inline-row-error` class
+- **Modified:** `src/hyperadmin/static/css/...` (the relevant existing inline stylesheet) — `.ha-inline-row-error` rule
+- **Modified:** `tests/e2e/test_inlines.py` (or the closest existing inline E2E) — two new scenarios
+- **Modified:** visual snapshot baseline if affected
+
+## Scenarios
+
+```
+Scenario: nested formset save with one failing child highlights that row
+  Given a parent + 3 inline children, child index 1 missing a required field
+  When  the parent form is submitted
+  Then  the inline row at index 1 has data-testid="inline-<prefix>-row-1-error"
+  And   the row's aria-invalid is "true"
+  And   the other rows have no row-level error testid
+
+Scenario: all-valid submission renders no row-level error marker
+  Given a parent + 3 inline children, all valid
+  When  the form is submitted and re-renders for any reason
+  Then  no inline row carries the row-level error testid
+```
+
+## Acceptance Criteria
+
+- [ ] `<tr>` gains `aria-invalid="true"` when any field on the row has errors
+- [ ] `<tr>` gains `data-testid="inline-{prefix}-row-{index}-error"` in error state
+- [ ] `ha-inline-row-error` class applied for visual accent
+- [ ] Existing per-field error testids unchanged (backward compatible)
+- [ ] Two E2E scenarios in place with G/W/T comments
+- [ ] Visual snapshot refreshed
+- [ ] `poe lint` and `poe test:e2e -k inline` pass
+
+## Parent
+
+- Epic: `epic-v050-h2-inline-row-errors`

--- a/.meta/epics/epic-v055-bulk-actions/epic.md
+++ b/.meta/epics/epic-v055-bulk-actions/epic.md
@@ -1,0 +1,79 @@
+---
+type: epic
+id: ep-v055-bulk-01
+title: "epic(actions): bulk actions with Pydantic parameter forms"
+status: todo
+priority: high
+owner: null
+labels:
+  - size:L
+  - planned
+  - backend
+  - frontend
+  - upstream-readiness
+  - H3
+milestone_ref:
+  id: v055-bulk-ac-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Overview
+
+Implements upstream readiness capability **H3**: bulk-mode `@action` decorator,
+list-view checkbox column with action selector, optional Pydantic param form
+collected before execution, per-row outcome page, and `requires_selection=True`
+enforcement. Permission re-check runs per row inside the bulk handler.
+
+**SDD:** [`docs/specs/bulk-actions.md`](../../../docs/specs/bulk-actions.md)
+(required — touches `core/`, `views/`, templates).
+
+## Tracks
+
+### Track A: Decorator + metadata
+- Extend `ActionDef` with `bulk: bool`, `form: type[BaseModel] | None`.
+- Extend `@action` decorator with `bulk=`, `form=` kwargs and decoration-time validation.
+- Handler signature validation (`(self, request, item_id, *, params=None)`).
+
+### Track B: Endpoints + per-row execution
+- `DynamicModelView.run_bulk_action` — POST `/{model}/actions/{name}/bulk`.
+- `DynamicModelView.confirm_bulk_action` — POST `/{model}/actions/{name}/bulk/confirm`.
+- `BulkRowResult` NamedTuple, per-row error capture, object-permission re-check.
+- `requires_selection` enforcement (server-side 400 if `ids` empty).
+
+### Track C: Templates + list-view UX
+- Checkbox column in `list.html` (rendered only when bulk actions exist).
+- Action `<select>` + Run button in list toolbar.
+- `components/bulk_form.html` — Pydantic form rendered with hidden `ids[]`.
+- `components/bulk_result.html` — per-row status grid + "Retry failures" link.
+- `data-testid` selectors for E2E (`bulk-checkbox`, `bulk-action-select`,
+  `bulk-run-btn`, `bulk-result-row`, `bulk-retry-link`).
+
+## Scenarios
+
+(See SDD for the full set; six scenarios listed under `## BDD Scenarios`.)
+
+## Acceptance Criteria
+
+- [ ] `@action(bulk=True)` accepted; legacy `@action(...)` still works
+- [ ] `@action(form=X)` without `bulk=True` raises `TypeError` at decoration time
+- [ ] Handler signature validated at decoration time
+- [ ] Bulk endpoint enforces `requires_selection` (400 on empty ids)
+- [ ] Param form rendered and prefilled with selected ids
+- [ ] Per-row result page lists ok / failed / forbidden per id
+- [ ] Object-level permissions are re-checked per row
+- [ ] "Retry failures" link re-submits only failed ids
+- [ ] HTMX request returns swap-friendly fragment; non-HTMX returns full page
+- [ ] Checkbox column rendered only when bulk actions exist
+- [ ] Unit tests for `ActionDef`/`@action` validation
+- [ ] E2E tests for all six scenarios
+- [ ] `poe lint` and `poe test` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-bulk-actions` (SDD approved)
+
+## Parent
+
+- Milestone: `v055-bulk-actions-autocomplete`
+- Tracking: `epic-upstream-readiness` (H3)

--- a/.meta/epics/epic-v055-bulk-actions/stories/featcore-extend-actiondef-with-bulk-and-form.md
+++ b/.meta/epics/epic-v055-bulk-actions/stories/featcore-extend-actiondef-with-bulk-and-form.md
@@ -1,0 +1,71 @@
+---
+type: story
+id: st-v055-bulk-01
+title: "feat(core): extend ActionDef and @action with bulk/form parameters"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - backend
+  - upstream-readiness
+  - H3
+estimate: null
+epic_ref:
+  id: ep-v055-bulk-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+Add `bulk: bool` and `form: type[BaseModel] | None` to `ActionDef` and the
+`@action` decorator. Validate at decoration time that `form is not None`
+implies `bulk is True`, and that the handler signature accepts a `params=None`
+keyword when `bulk=True`.
+
+**Spec:** [`docs/specs/bulk-actions.md`](../../../../docs/specs/bulk-actions.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/core/actions.py` — extend dataclass and decorator
+- **Modified:** `tests/unit/test_actions.py` (new file if missing) — decoration-time validation tests
+
+## Scenarios
+
+```
+Scenario: @action(form=X) without bulk=True raises TypeError
+  When  @action(label="x", form=ReassignParams) is applied to a handler
+  Then  a TypeError is raised with message "form= requires bulk=True"
+
+Scenario: @action(bulk=True) accepts a handler with params kwarg
+  Given async def archive(self, request, item_id, *, params=None): ...
+  When  @action(label="Archive", bulk=True) is applied
+  Then  the decorator returns the function unchanged
+  And   handler._action_def.bulk is True
+
+Scenario: legacy single-record @action(label="X") still works
+  Given async def deactivate(self, request, item_id): ...
+  When  @action(label="Deactivate") is applied
+  Then  handler._action_def.bulk is False
+  And   handler._action_def.form is None
+```
+
+## Acceptance Criteria
+
+- [ ] `ActionDef` gains `bulk: bool = False`, `form: type[BaseModel] | None = None`
+- [ ] `@action` accepts `bulk=`, `form=` keyword args
+- [ ] Decoration-time `TypeError` when `form` set without `bulk`
+- [ ] Decoration-time `TypeError` when `bulk=True` handler signature lacks `params` kwarg
+- [ ] Legacy decoration paths unchanged
+- [ ] Unit tests cover all three scenarios above
+- [ ] `poe lint` passes
+
+## Blocked by
+
+- `reviewspec-approve-sdd-bulk-actions`
+
+## Parent
+
+- Epic: `epic-v055-bulk-actions`

--- a/.meta/epics/epic-v055-bulk-actions/stories/feattemplates-add-checkbox-column-and-bulk-toolbar.md
+++ b/.meta/epics/epic-v055-bulk-actions/stories/feattemplates-add-checkbox-column-and-bulk-toolbar.md
@@ -1,0 +1,87 @@
+---
+type: story
+id: st-v055-bulk-03
+title: "feat(templates): add checkbox column, action selector, bulk form, result grid"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - frontend
+  - upstream-readiness
+  - H3
+estimate: null
+epic_ref:
+  id: ep-v055-bulk-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+Add the list-view UX for bulk actions: a checkbox column (rendered only when
+the registered actions include at least one `bulk=True`), an action `<select>`
++ Run button in the toolbar, the Pydantic-derived parameter form template, and
+the per-row result grid with a "Retry failures" link.
+
+All interactive elements use `data-testid` per CLAUDE.md.
+
+**Spec:** [`docs/specs/bulk-actions.md`](../../../../docs/specs/bulk-actions.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/templates/list.html` — checkbox column, toolbar
+- **New:** `src/hyperadmin/templates/components/bulk_form.html`
+- **New:** `src/hyperadmin/templates/components/bulk_result.html`
+- **Modified:** `src/hyperadmin/views/dynamic.py` — pass `bulk_actions` to list context
+
+## data-testid Reference
+
+| Element | testid |
+|---|---|
+| Row checkbox | `bulk-checkbox` |
+| Action `<select>` | `bulk-action-select` |
+| Run button | `bulk-run-btn` |
+| Param form | `bulk-form` |
+| Result row | `bulk-result-row` |
+| Retry-failures link | `bulk-retry-link` |
+
+## Scenarios
+
+```
+Scenario: list view without bulk actions hides the checkbox column
+  Given a ModelAdmin with no @action(bulk=True)
+  When  the user opens /admin/products/
+  Then  the rendered table has no element with data-testid="bulk-checkbox"
+
+Scenario: list view with at least one bulk action renders the toolbar
+  Given a ModelAdmin with @action(label="Archive", bulk=True)
+  When  the user opens /admin/products/
+  Then  the toolbar shows a bulk-action-select containing option "Archive"
+  And   each row has data-testid="bulk-checkbox"
+
+Scenario: result page renders a row per outcome
+  Given run_bulk_action returns [BulkRowResult(1,"ok",None), BulkRowResult(2,"failed","x")]
+  When  the result template renders
+  Then  the page has two bulk-result-row entries
+  And   the "Retry failures" link targets the bulk endpoint with ids=[2]
+```
+
+## Acceptance Criteria
+
+- [ ] Checkbox column hidden when no bulk actions registered
+- [ ] Action selector populated from `bulk_actions` context
+- [ ] Param form template renders Pydantic fields; preserves selected ids in hidden inputs
+- [ ] Result grid renders one row per `BulkRowResult` with status badge
+- [ ] "Retry failures" link is omitted when no failures exist
+- [ ] E2E selectors use the `data-testid` table above (no `ha-*` class selectors)
+- [ ] `poe lint` passes; visual snapshots updated if applicable
+
+## Blocked by
+
+- `featviews-add-run-bulk-action-endpoint`
+
+## Parent
+
+- Epic: `epic-v055-bulk-actions`

--- a/.meta/epics/epic-v055-bulk-actions/stories/featviews-add-run-bulk-action-endpoint.md
+++ b/.meta/epics/epic-v055-bulk-actions/stories/featviews-add-run-bulk-action-endpoint.md
@@ -1,0 +1,79 @@
+---
+type: story
+id: st-v055-bulk-02
+title: "feat(views): add run_bulk_action endpoint with per-row outcome"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - upstream-readiness
+  - H3
+estimate: null
+epic_ref:
+  id: ep-v055-bulk-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+Wire the bulk endpoint on `DynamicModelView`. Parses `ids[]` from the POST body,
+enforces `requires_selection`, dispatches to the param-form renderer when a
+form is configured, otherwise runs the handler per row and renders the result
+page. Each row is wrapped in object-permission re-check + exception capture.
+
+**Spec:** [`docs/specs/bulk-actions.md`](../../../../docs/specs/bulk-actions.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/views/dynamic.py` — add `run_bulk_action`, `confirm_bulk_action`, `_render_bulk_result`, register routes
+- **New:** `src/hyperadmin/core/bulk_results.py` — `BulkRowResult` NamedTuple
+- **Modified:** `tests/unit/test_dynamic_views.py` — bulk endpoint coverage
+
+## Scenarios
+
+```
+Scenario: empty ids with requires_selection returns 400
+  When  POST /admin/orders/actions/archive/bulk with ids=[]
+  Then  response status is 400 and body contains "Selection required"
+
+Scenario: bulk handler runs per-row, captures HTTPException(403) as forbidden
+  Given handler raises HTTPException(403) for id=2
+  When  POST .../bulk with ids=[1,2,3]
+  Then  result rows are ok / forbidden / ok in order
+
+Scenario: bulk handler runs per-row, captures generic exception as failed
+  Given handler raises RuntimeError("boom") for id=2
+  When  POST .../bulk with ids=[1,2,3]
+  Then  result rows are ok / failed / ok in order
+  And   the "failed" row carries detail "boom"
+
+Scenario: object-permission denial surfaces per row
+  Given an ObjectPermissionChecker that denies "archive" on id=2
+  When  POST .../bulk with ids=[1,2,3]
+  Then  result rows are ok / forbidden / ok
+  And   the handler is invoked only for ids 1 and 3
+```
+
+## Acceptance Criteria
+
+- [ ] `BulkRowResult` NamedTuple defined in `core/bulk_results.py`
+- [ ] `run_bulk_action` and `confirm_bulk_action` registered on `DynamicModelView`
+- [ ] Routes mounted at `/{model}/actions/{name}/bulk` and `/.../bulk/confirm`
+- [ ] `requires_selection` enforced with 400 response
+- [ ] Object-level permission re-check per row
+- [ ] HTTPException → "forbidden"; other exceptions → "failed" with `str(exc)`
+- [ ] HTMX request returns fragment; non-HTMX returns full page
+- [ ] Unit tests for all four scenarios above
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `featcore-extend-actiondef-with-bulk-and-form`
+
+## Parent
+
+- Epic: `epic-v055-bulk-actions`

--- a/.meta/epics/epic-v055-bulk-actions/stories/reviewspec-approve-sdd-bulk-actions.md
+++ b/.meta/epics/epic-v055-bulk-actions/stories/reviewspec-approve-sdd-bulk-actions.md
@@ -1,0 +1,49 @@
+---
+type: story
+id: st-v055-bulk-00
+title: "review(spec): approve SDD for bulk actions"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - needs-human
+  - upstream-readiness
+  - H3
+estimate: null
+epic_ref:
+  id: ep-v055-bulk-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+**Human gate** — review and approve `docs/specs/bulk-actions.md` before
+implementation sub-tasks may start.
+
+## Checklist
+
+- [ ] Problem statement scoped to H3 only (no creep into queues / async)
+- [ ] Goals measurable against BDD scenarios
+- [ ] Non-goals defer async execution, cross-model bulk, streaming progress
+- [ ] BDD scenarios cover happy path + ≥1 failure path + permission failure
+- [ ] `ActionDef` change is backward compatible (new fields default to False/None)
+- [ ] Endpoint naming `/actions/{name}/bulk` vs `/{id}/action/{name}` decided
+- [ ] Object-permission re-check policy confirmed
+- [ ] Open Questions resolved (auto-require-selection default, select-all-matching, rollback)
+
+## Open Questions to resolve
+
+1. Should `bulk=True` imply `requires_selection=True` by default?
+2. Accept `select_all_matching_filter=true` in v0.5.5 or defer?
+3. Expose a "rollback" affordance on the result page, or rely on audit log?
+
+## Blocked by
+
+(none — SDD draft is committed)
+
+## Parent
+
+- Epic: `epic-v055-bulk-actions`

--- a/.meta/epics/epic-v055-bulk-actions/stories/teste2e-bulk-action-scenarios.md
+++ b/.meta/epics/epic-v055-bulk-actions/stories/teste2e-bulk-action-scenarios.md
@@ -1,0 +1,59 @@
+---
+type: story
+id: st-v055-bulk-04
+title: "test(e2e): bulk action scenarios via Playwright"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - tests
+  - upstream-readiness
+  - H3
+estimate: null
+epic_ref:
+  id: ep-v055-bulk-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+Translate the six BDD scenarios in `docs/specs/bulk-actions.md` to Playwright
+tests under `tests/e2e/`. One test per scenario, named after the scenario
+title. Inline `# Given / # When / # Then` comments are mandatory.
+
+Use `get_by_role`, `get_by_label`, `get_by_text`, `get_by_test_id` — never
+`.ha-*` CSS selectors.
+
+## Files to Change
+
+- **New:** `tests/e2e/test_bulk_actions.py`
+- **Modified:** `tests/e2e/conftest.py` (if a new admin fixture is required)
+
+## Scenarios → Tests
+
+| Scenario | Test function |
+|---|---|
+| bulk action with no selection re-renders list with warning | `test_bulk_action_with_no_selection_shows_warning` |
+| bulk action with param form prompts before running | `test_bulk_action_with_param_form_prompts_before_running` |
+| bulk action with valid params runs over selected rows | `test_bulk_action_with_valid_params_runs_over_selected_rows` |
+| per-row failure is surfaced without aborting the bulk run | `test_per_row_failure_is_surfaced` |
+| requires_selection blocks zero-row submission server-side | `test_requires_selection_blocks_zero_row_post` |
+| object-level permission is enforced per row | `test_object_permission_enforced_per_row` |
+
+## Acceptance Criteria
+
+- [ ] Six Playwright tests, one per scenario, with mandatory G/W/T comments
+- [ ] Each test uses accessibility-first locators or `data-testid` only
+- [ ] `poe test:e2e -k bulk_actions` passes locally and in CI
+- [ ] Visual snapshots refreshed if list/result templates change
+
+## Blocked by
+
+- `feattemplates-add-checkbox-column-and-bulk-toolbar`
+
+## Parent
+
+- Epic: `epic-v055-bulk-actions`

--- a/.meta/epics/epic-v055-htmx-autocomplete/epic.md
+++ b/.meta/epics/epic-v055-htmx-autocomplete/epic.md
@@ -1,0 +1,78 @@
+---
+type: epic
+id: ep-v055-ac-01
+title: "epic(views): HTMX FK/M2M autocomplete with dependent filtering and inline create"
+status: todo
+priority: high
+owner: null
+labels:
+  - size:L
+  - planned
+  - backend
+  - frontend
+  - upstream-readiness
+  - H6
+milestone_ref:
+  id: v055-bulk-ac-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Overview
+
+Implements upstream readiness capability **H6**: declarative dependent FK/M2M
+filtering, a "+" popup that creates the related row without losing parent-form
+state, and per-relation `display_template` for option rendering. Backward
+compatible — existing relation widgets keep working unchanged.
+
+**SDD:** [`docs/specs/htmx-autocomplete.md`](../../../docs/specs/htmx-autocomplete.md)
+(required — touches `core/`, `views/`, `templates/widgets/`).
+
+## Tracks
+
+### Track A: Options + field metadata
+- `AdminOptions.relation_filters: dict[str, RelationDependency] | None`.
+- `AdminOptions.relation_display: dict[str, str] | None`.
+- `RelationDependency` Pydantic model (`depends_on`, `placeholder`).
+- Validation: `depends_on` must reference an existing form field on the same model.
+
+### Track B: Popup endpoint + widget
+- `DynamicModelView.create_popup_view` — POST `/{model}/create-popup`.
+- On success: `HX-Trigger: hyperadminPopupCreated` with `{id, label, target}`.
+- `AutocompleteWidget` rendered for FK/M2M when `use_autocomplete_widget=True`
+  (default True in v0.5.5).
+
+### Track C: Templates + JS glue
+- `templates/widgets/autocomplete.html` — search input, hidden select, popup button.
+- `templates/widgets/popup_form.html` — modal shell, returns empty body + HX-Trigger.
+- Single `<div id="ha-popup-root">` in `base.html` for modal swap target.
+- Tiny inline JS listener that consumes `hyperadminPopupCreated`, inserts the
+  new option into the target select, and closes the modal. No new bundled JS file.
+
+## Scenarios
+
+(See SDD for the full set; seven scenarios listed under `## BDD Scenarios`.)
+
+## Acceptance Criteria
+
+- [ ] `AdminOptions.relation_filters` / `relation_display` configurable
+- [ ] `RelationDependency.depends_on` validated against form fields
+- [ ] FK fields render as `AutocompleteWidget` by default
+- [ ] Dependent FK forwards parent value via `hx-include`
+- [ ] Dropdown empty + placeholder shown when parent is unset
+- [ ] "+" button renders only when the related model is registered with the same Admin
+- [ ] Popup success returns `HX-Trigger: hyperadminPopupCreated` with payload
+- [ ] `display_template` format strings render custom option labels
+- [ ] `choices_view` returns 404 for unknown relation field (regression test)
+- [ ] Unit tests for options validation, widget rendering, popup view
+- [ ] E2E tests for all seven scenarios
+- [ ] `poe lint` and `poe test` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-htmx-autocomplete` (SDD approved)
+
+## Parent
+
+- Milestone: `v055-bulk-actions-autocomplete`
+- Tracking: `epic-upstream-readiness` (H6)

--- a/.meta/epics/epic-v055-htmx-autocomplete/stories/featcore-extend-adminoptions-with-relation-config.md
+++ b/.meta/epics/epic-v055-htmx-autocomplete/stories/featcore-extend-adminoptions-with-relation-config.md
@@ -1,0 +1,62 @@
+---
+type: story
+id: st-v055-ac-01
+title: "feat(core): extend AdminOptions with relation_filters and relation_display"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - backend
+  - upstream-readiness
+  - H6
+estimate: null
+epic_ref:
+  id: ep-v055-ac-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+Add the two declarative knobs that drive dependent filtering and custom option
+labels. Validate `depends_on` against the model's form fields at construction.
+
+**Spec:** [`docs/specs/htmx-autocomplete.md`](../../../../docs/specs/htmx-autocomplete.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/core/options.py` — add `relation_filters`, `relation_display`, `use_autocomplete_widget` (default True), `RelationDependency` model
+- **Modified:** `tests/unit/test_options.py` (new file if absent) — validation tests
+
+## Scenarios
+
+```
+Scenario: relation_filters with unknown depends_on raises at construction
+  Given AdminOptions(relation_filters={"variant_id": {"depends_on": "missing"}})
+  When  the options are bound to a model with no "missing" field
+  Then  ValueError is raised: "depends_on='missing' not in form fields"
+
+Scenario: relation_display format string with valid placeholder is accepted
+  Given AdminOptions(relation_display={"supplier_id": "{name} — {city}"})
+  When  the options are validated against Supplier
+  Then  no error is raised
+```
+
+## Acceptance Criteria
+
+- [ ] `RelationDependency` Pydantic model in `core/options.py`
+- [ ] `AdminOptions.relation_filters`, `relation_display`, `use_autocomplete_widget` added
+- [ ] Construction-time validation of `depends_on` against form fields
+- [ ] `use_autocomplete_widget` defaults to True
+- [ ] Unit tests for validation
+- [ ] `poe lint` passes
+
+## Blocked by
+
+- `reviewspec-approve-sdd-htmx-autocomplete`
+
+## Parent
+
+- Epic: `epic-v055-htmx-autocomplete`

--- a/.meta/epics/epic-v055-htmx-autocomplete/stories/feattemplates-autocomplete-widget-and-popup-modal.md
+++ b/.meta/epics/epic-v055-htmx-autocomplete/stories/feattemplates-autocomplete-widget-and-popup-modal.md
@@ -1,0 +1,89 @@
+---
+type: story
+id: st-v055-ac-03
+title: "feat(templates): AutocompleteWidget, popup modal, ha-popup-root slot"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - frontend
+  - upstream-readiness
+  - H6
+estimate: null
+epic_ref:
+  id: ep-v055-ac-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+Replace the default `<select>` rendering for FK/M2M fields with an
+`AutocompleteWidget` driven by HTMX: debounced search input, hidden
+populated `<select>`, optional "+" popup button, and `hx-include` of the
+`depends_on` field when one is configured. Add the single
+`<div id="ha-popup-root">` slot to `base.html` and the minimal JS listener
+that consumes `hyperadminPopupCreated`.
+
+**Spec:** [`docs/specs/htmx-autocomplete.md`](../../../../docs/specs/htmx-autocomplete.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/templates/widgets/autocomplete.html`
+- **Modified:** `src/hyperadmin/templates/widgets/choices_options.html` — render `display_template` when configured
+- **Modified:** `src/hyperadmin/templates/base.html` — add `<div id="ha-popup-root">`
+- **Modified:** `src/hyperadmin/views/forms.py` — wire `AutocompleteWidget` when `use_autocomplete_widget=True`
+
+## data-testid Reference
+
+| Element | testid |
+|---|---|
+| Search input | `autocomplete-{field}` |
+| Hidden select | `autocomplete-select-{field}` |
+| "+" popup button | `autocomplete-add-{field}` |
+| Popup modal root | `popup-root` |
+
+## Scenarios
+
+```
+Scenario: FK field renders as autocomplete by default
+  When  the user opens /admin/products/create
+  Then  the supplier_id field is rendered with data-testid="autocomplete-supplier_id"
+
+Scenario: dependent FK widget includes parent field in hx-include
+  Given relation_filters has variant_id depends_on supplier_id
+  When  the widget for variant_id is rendered
+  Then  its hx-include attribute is "[name='supplier_id']"
+
+Scenario: "+" button omitted when related model unregistered
+  Given Supplier is NOT registered with the Admin
+  When  the supplier_id widget renders
+  Then  no element with data-testid="autocomplete-add-supplier_id" is present
+
+Scenario: display_template renders custom option label
+  Given relation_display has supplier_id = "{name} — {city}"
+  And   the dataset has one Supplier(name="Acme", city="Paris")
+  When  choices_view returns a fragment
+  Then  the rendered option label is "Acme — Paris"
+```
+
+## Acceptance Criteria
+
+- [ ] `AutocompleteWidget` rendered for FK/M2M when `use_autocomplete_widget=True`
+- [ ] `hx-include` is set when `depends_on` is configured
+- [ ] "+" button only rendered when related model is in `Admin.registry`
+- [ ] `display_template` format-string applied in `choices_options.html`
+- [ ] `<div id="ha-popup-root">` present once in `base.html`
+- [ ] Minimal inline JS listener inserts new option + closes modal
+- [ ] All four scenarios covered by unit or rendering tests
+- [ ] `poe lint` passes
+
+## Blocked by
+
+- `featviews-add-create-popup-view`
+
+## Parent
+
+- Epic: `epic-v055-htmx-autocomplete`

--- a/.meta/epics/epic-v055-htmx-autocomplete/stories/featviews-add-create-popup-view.md
+++ b/.meta/epics/epic-v055-htmx-autocomplete/stories/featviews-add-create-popup-view.md
@@ -1,0 +1,67 @@
+---
+type: story
+id: st-v055-ac-02
+title: "feat(views): add create_popup_view returning HX-Trigger payload"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - upstream-readiness
+  - H6
+estimate: null
+epic_ref:
+  id: ep-v055-ac-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+Add `create_popup_view` to `DynamicModelView`. On a successful POST, return an
+empty 200 with `HX-Trigger: hyperadminPopupCreated` carrying
+`{"target": "<field>", "id": <pk>, "label": "<display>"}`. On validation
+failure, re-render the popup form fragment with field errors.
+
+**Spec:** [`docs/specs/htmx-autocomplete.md`](../../../../docs/specs/htmx-autocomplete.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/views/dynamic.py` — `create_popup_view`, route registration
+- **New:** `src/hyperadmin/templates/widgets/popup_form.html`
+- **Modified:** `tests/unit/test_dynamic_views.py` — popup-view tests
+
+## Scenarios
+
+```
+Scenario: popup create with valid data returns HX-Trigger payload
+  Given Supplier is registered and the user is authenticated as admin
+  When  POST /admin/suppliers/create-popup with valid form data + target=supplier_id
+  Then  response status is 200 and body is empty
+  And   HX-Trigger header contains "hyperadminPopupCreated" with id=<new pk> and target="supplier_id"
+
+Scenario: popup create with permission denied returns 403
+  Given the user lacks "add" permission on Supplier
+  When  POST /admin/suppliers/create-popup with valid form data
+  Then  response status is 403 with the standard error template fragment
+```
+
+## Acceptance Criteria
+
+- [ ] `create_popup_view` registered at `POST /{model}/create-popup`
+- [ ] Permission check via existing `_check_permission("add")`
+- [ ] Success: 200 + empty body + `HX-Trigger` JSON payload
+- [ ] Validation failure: 200 + re-rendered fragment with errors
+- [ ] Permission failure: 403 + standard error fragment
+- [ ] Unit tests cover both scenarios above
+- [ ] `poe lint` passes
+
+## Blocked by
+
+- `featcore-extend-adminoptions-with-relation-config`
+
+## Parent
+
+- Epic: `epic-v055-htmx-autocomplete`

--- a/.meta/epics/epic-v055-htmx-autocomplete/stories/reviewspec-approve-sdd-htmx-autocomplete.md
+++ b/.meta/epics/epic-v055-htmx-autocomplete/stories/reviewspec-approve-sdd-htmx-autocomplete.md
@@ -1,0 +1,49 @@
+---
+type: story
+id: st-v055-ac-00
+title: "review(spec): approve SDD for HTMX autocomplete"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - needs-human
+  - upstream-readiness
+  - H6
+estimate: null
+epic_ref:
+  id: ep-v055-ac-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+**Human gate** — review and approve `docs/specs/htmx-autocomplete.md` before
+implementation sub-tasks may start.
+
+## Checklist
+
+- [ ] Problem statement scoped to H6 only (no virtualised dropdown, no M2M chips)
+- [ ] Goals measurable against BDD scenarios
+- [ ] Non-goals defer pagination, cross-admin popups, custom widget plugin API
+- [ ] BDD scenarios cover happy + dependent + popup + display_template paths
+- [ ] `AdminOptions` change is backward compatible (new fields default to None)
+- [ ] Popup uses `HX-Trigger` event (not navigation) — confirmed correct
+- [ ] `use_autocomplete_widget=True` default is safe (legacy admins opt out)
+- [ ] Open Questions resolved (callable display, popup root location, multi-parent)
+
+## Open Questions to resolve
+
+1. Accept `Callable[[Any], str]` in addition to format strings for `relation_display`?
+2. Single `<div id="ha-popup-root">` or per-widget popup containers?
+3. Defer multi-parent `depends_on: list[str]` or design it in now?
+
+## Blocked by
+
+(none — SDD draft is committed)
+
+## Parent
+
+- Epic: `epic-v055-htmx-autocomplete`

--- a/.meta/epics/epic-v055-htmx-autocomplete/stories/teste2e-autocomplete-scenarios.md
+++ b/.meta/epics/epic-v055-htmx-autocomplete/stories/teste2e-autocomplete-scenarios.md
@@ -1,0 +1,61 @@
+---
+type: story
+id: st-v055-ac-04
+title: "test(e2e): HTMX autocomplete scenarios via Playwright"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - tests
+  - upstream-readiness
+  - H6
+estimate: null
+epic_ref:
+  id: ep-v055-ac-01
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+## Summary
+
+Translate the seven BDD scenarios in `docs/specs/htmx-autocomplete.md` to
+Playwright tests under `tests/e2e/`. One test per scenario, named after the
+scenario title. Inline `# Given / # When / # Then` comments are mandatory.
+
+Use accessibility-first locators and the new `data-testid` selectors:
+`autocomplete-{field}`, `autocomplete-select-{field}`,
+`autocomplete-add-{field}`, `popup-root`.
+
+## Files to Change
+
+- **New:** `tests/e2e/test_htmx_autocomplete.py`
+- **Modified:** `tests/e2e/conftest.py` (if a Supplier/Product fixture is needed)
+
+## Scenarios → Tests
+
+| Scenario | Test function |
+|---|---|
+| FK field renders an autocomplete widget by default | `test_fk_field_renders_autocomplete_widget_by_default` |
+| dependent FK forwards the parent value via hx-include | `test_dependent_fk_forwards_parent_via_hx_include` |
+| dependent FK with no parent value lists nothing | `test_dependent_fk_with_no_parent_lists_nothing` |
+| "+" popup creates the related row and selects it | `test_popup_creates_related_row_and_selects_it` |
+| "+" popup is hidden when the related model is not registered | `test_popup_hidden_when_related_model_unregistered` |
+| display_template renders custom option rows | `test_display_template_renders_custom_option_rows` |
+| choices_view rejects unknown relation field | `test_choices_view_rejects_unknown_relation_field` |
+
+## Acceptance Criteria
+
+- [ ] Seven Playwright tests, one per scenario, mandatory G/W/T comments
+- [ ] Only accessibility-first or `data-testid` locators (no `.ha-*`)
+- [ ] `poe test:e2e -k autocomplete` passes locally and in CI
+- [ ] Visual snapshots refreshed if templates change
+
+## Blocked by
+
+- `feattemplates-autocomplete-widget-and-popup-modal`
+
+## Parent
+
+- Epic: `epic-v055-htmx-autocomplete`

--- a/.meta/roadmap/milestones/v055-bulk-actions-autocomplete.md
+++ b/.meta/roadmap/milestones/v055-bulk-actions-autocomplete.md
@@ -1,0 +1,16 @@
+---
+type: milestone
+id: v055-bulk-ac-01
+title: v0.5.5 — Bulk Actions & Autocomplete
+status: planned
+created_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-10T00:00:00Z
+---
+
+H3 + H6 from upstream readiness. Bulk actions with Pydantic parameter forms,
+per-row outcome reporting, and `requires_selection=True` wiring; HTMX FK/M2M
+autocomplete with dependent filtering, create-on-the-fly popup, and configurable
+display template per relation. Foundational for any consumer admin build.
+
+Spec: `docs/specs/bulk-actions.md`, `docs/specs/htmx-autocomplete.md`.
+Tracking: `.meta/epics/epic-upstream-readiness/` (H3, H6).

--- a/docs/specs/bulk-actions.md
+++ b/docs/specs/bulk-actions.md
@@ -1,0 +1,230 @@
+# SDD: Bulk Actions with Parameter Forms
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD |
+| Milestone | v0.5.5 — Bulk Actions & Autocomplete |
+| Created | 2026-05-10 |
+| Last updated | 2026-05-10 |
+
+---
+
+## Problem
+
+HyperAdmin's `@action` decorator (`src/hyperadmin/core/actions.py`) and
+`run_action` view (`src/hyperadmin/views/dynamic.py`) currently support only
+single-record actions invoked from a detail page. `ActionDef.requires_selection`
+exists as reserved metadata but is not wired anywhere. Consumer admins
+routinely need to:
+
+1. Apply an action to many selected rows in a list view (the H3 upstream check).
+2. Collect parameters before running the action (reason note, deadline,
+   destination warehouse) via a server-rendered form.
+3. See a per-row outcome page when some rows succeed and others fail, so the
+   operator can retry only the failures.
+
+Without these, every consumer reinvents bulk operations as ad-hoc list-view
+buttons that bypass the admin's permission and audit machinery.
+
+## Goals
+
+- A `@action` decorator that opts into bulk mode (`bulk=True`) and an optional
+  parameter form (`form=PydanticModel`).
+- A list-view checkbox column + action selector + "Run" button that POSTs to a
+  new bulk endpoint.
+- A confirmation/param-collection page rendered when `form` is set, before the
+  action runs.
+- A per-row result page summarising success/failure for each selected row, with
+  a follow-up "retry failures" affordance.
+- `requires_selection=True` is enforced — clicking Run with no rows selected
+  re-renders the list with an inline warning.
+- Permission re-check per row inside the bulk handler (selection does not
+  bypass `_check_object_permission`).
+
+## Non-Goals
+
+- Async / background-job execution. v0.5.5 runs the bulk action in-request; a
+  later milestone can introduce a job-runner adapter.
+- Cross-model bulk actions. An action is bound to one `ModelAdmin`.
+- Streaming progress updates over WebSocket. The result page is rendered once,
+  after all rows are processed.
+- Configurable concurrency / batch size. Rows are processed sequentially.
+
+## BDD Scenarios
+
+```
+Scenario: bulk action with no selection re-renders list with warning
+  Given a ModelAdmin with @action(label="Archive", bulk=True, requires_selection=True)
+  When  the user clicks "Run" on the list view with no rows checked
+  Then  the list re-renders with a flash "Select at least one row"
+  And   the handler is not invoked
+
+Scenario: bulk action with param form prompts before running
+  Given a ModelAdmin with @action(label="Reassign", bulk=True, form=ReassignParams)
+  When  the user selects 3 rows and clicks Run on action "reassign"
+  Then  the response renders a Pydantic-derived form at /admin/orders/actions/reassign/bulk
+  And   the form preserves the selected ids in hidden inputs
+
+Scenario: bulk action with valid params runs over selected rows
+  Given the same ReassignParams form with field operator: int
+  When  the user posts the form with operator=42 and ids=[1,2,3]
+  Then  the handler runs three times — one per id — with form data validated
+  And   the per-row outcome page lists 3 rows with status "ok"
+
+Scenario: per-row failure is surfaced without aborting the bulk run
+  Given the handler raises HTTPException(403) for id=2 only
+  When  the user posts the bulk form with ids=[1,2,3]
+  Then  the result page shows ok / failed / ok for ids 1, 2, 3 respectively
+  And   the failed row carries the error message "permission denied"
+  And   the user sees a "Retry failures" link that re-submits with ids=[2]
+
+Scenario: requires_selection blocks zero-row submission server-side
+  Given the user crafts a POST to /admin/orders/actions/archive/bulk with ids=[]
+  When  the request reaches the bulk endpoint
+  Then  the response is 400 with detail "Selection required"
+  And   the handler is not invoked
+
+Scenario: object-level permission is enforced per row
+  Given an ObjectPermissionChecker that denies "archive" on id=2
+  When  the user posts a bulk archive with ids=[1,2,3]
+  Then  the result page shows ok / forbidden / ok
+  And   adapter.delete was called for ids 1 and 3 only
+```
+
+## Design
+
+### Architecture
+
+Three modules touched:
+
+```
+core/actions.py          — extend ActionDef + decorator with bulk/form params
+views/dynamic.py         — new bulk endpoint + per-row outcome renderer
+templates/components/    — checkbox column, action selector, bulk_form, bulk_result
+```
+
+No new top-level module. The bulk endpoint is a sibling of the existing
+single-record `run_action` handler.
+
+Request flow:
+
+```
+GET  /{model}/                                       → list with checkboxes + action <select>
+POST /{model}/actions/{name}/bulk          (no form) → run handler over ids, render result
+POST /{model}/actions/{name}/bulk           (form=X) → render param form prefilled with ids
+POST /{model}/actions/{name}/bulk/confirm   (form=X) → validate Pydantic form, run, render result
+```
+
+The "confirm" suffix only exists for form-bearing actions. Form-less actions
+go straight from list submit to result.
+
+### Data Model Changes
+
+No DB tables added. `ActionDef` gains two fields (frozen dataclass replaced with
+`@dataclass(frozen=True, slots=True, kw_only=True)`):
+
+```python
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ActionDef:
+    name: str
+    label: str
+    handler: Callable[..., Any]
+    requires_selection: bool = False
+    bulk: bool = False
+    form: type[BaseModel] | None = None
+```
+
+### API / Protocol Changes
+
+**Decorator:**
+
+```python
+@action(
+    label: str,
+    *,
+    requires_selection: bool = False,
+    bulk: bool = False,
+    form: type[BaseModel] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]
+```
+
+Validation at decoration time:
+- `form is not None` implies `bulk is True` (raise `TypeError` otherwise).
+- `bulk is True` requires the handler signature `(self, request, item_id, *, params=None)`
+  where `params` is the validated Pydantic instance (or `None` for form-less actions).
+  Validated by inspection of `inspect.signature` at decorator time.
+
+**Endpoints (added to `DynamicModelView`):**
+
+```python
+async def run_bulk_action(
+    self,
+    request: Request,
+    action_name: str,
+) -> Response: ...
+
+async def confirm_bulk_action(
+    self,
+    request: Request,
+    action_name: str,
+) -> Response: ...
+```
+
+`run_bulk_action` parses `ids` from the form payload (multi-valued
+`ids=1&ids=2&...`), checks `requires_selection`, dispatches to the param-form
+renderer or directly to per-row execution.
+
+**Per-row result:**
+
+```python
+class BulkRowResult(NamedTuple):
+    id: Any
+    status: Literal["ok", "failed", "forbidden"]
+    detail: str | None
+```
+
+Rendered via `templates/components/bulk_result.html` listing each row with its
+status and a "Retry failures" link.
+
+### Configuration Changes
+
+`AdminOptions` gains no new fields. List-view checkbox column is rendered when
+any registered action has `bulk=True`. If no bulk actions exist, the column is
+omitted (zero-cost for admins that don't use it).
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Action not found / not bulk | 404 with message "Bulk action 'x' not found" |
+| `ids` missing or empty + `requires_selection=True` | 400 "Selection required" |
+| `ids` contains non-existent row | per-row "failed" with detail "row not found" |
+| Pydantic form validation error | re-render form with field errors and selected ids preserved |
+| Handler raises `HTTPException(403)` | per-row "forbidden" with `detail` from exception |
+| Handler raises any other `Exception` | per-row "failed" with `str(exc)`, logged at WARNING |
+| Object-permission denied | per-row "forbidden" (same as 403) |
+| HTMX request (`hx-request` header) | bulk endpoint returns an HTMX fragment to swap into result region |
+| Action handler returns `Response` | ignored in bulk mode — return value reserved for single-record path |
+
+## Migration & Backward Compatibility
+
+Backward compatible. Existing single-record `@action` decorators (no `bulk`,
+no `form`) keep working unchanged. The `run_action` endpoint stays. New defaults
+are false / `None`. No database migration required.
+
+## Open Questions
+
+- [ ] Should `bulk=True` actions automatically gain `requires_selection=True`? Default proposal: yes, with explicit `requires_selection=False` opt-out for actions that operate on all matching rows (e.g. "Archive all overdue").
+- [ ] Should the bulk endpoint accept `select_all_matching_filter=true` as an alternative to explicit ids, so a million-row archive doesn't ship a million ids in the request? Deferred to a follow-up unless the v0.5.5 demo needs it.
+- [ ] Should the result page expose a "rollback" affordance when all rows failed? Default: no — the admin's audit log is the rollback surface.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Pydantic for param forms | Already the project's validation surface; reuses existing form rendering machinery | WTForms, hand-rolled dataclass |
+| Sequential per-row execution | Simplest; preserves request-scoped transaction semantics in adapters | asyncio.gather with semaphore; bg-job dispatch |
+| Per-row outcome page (not abort-on-first-failure) | Operator can retry just the failures; matches H3 acceptance check | All-or-nothing transaction; first-failure abort |
+| Bulk endpoint at `/actions/{name}/bulk` (not `/{id}/action/{name}` extended) | Keeps single-record route unchanged; clearer in logs | Overload `run_action` with `ids` query param |

--- a/docs/specs/htmx-autocomplete.md
+++ b/docs/specs/htmx-autocomplete.md
@@ -1,0 +1,228 @@
+# SDD: HTMX FK/M2M Autocomplete with Dependent Filtering and Inline Create
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD |
+| Milestone | v0.5.5 — Bulk Actions & Autocomplete |
+| Created | 2026-05-10 |
+| Last updated | 2026-05-10 |
+
+---
+
+## Problem
+
+The existing relation widget surface (`views/dynamic.py:choices_view`,
+`core/fields.py:classify_field`, `views/forms.py`) renders FK and M2M fields
+as static `<select>` elements populated via a single HTMX endpoint
+(`GET /{model}/choices/{field_name}`). It is *partial* because:
+
+1. **No dependent filtering UX.** `choices_view` already forwards arbitrary
+   extra query params to `adapter.get_choices()`, but no widget pattern wires
+   one select's value to another's `hx-include`. Consumers reinvent this with
+   ad-hoc JavaScript every time.
+2. **No inline create.** When an admin needs to pick a Supplier that doesn't
+   exist yet, the user must abandon the form, create the Supplier elsewhere,
+   then start over. Standard admin UX has a "+" affordance that opens a modal
+   to create the related record without losing form state.
+3. **No per-relation display template.** `choices_options.html` hard-codes
+   how an option label is rendered. Consumers want richer option rows
+   (`{name} — {city}, {country}`, possibly with thumbnails).
+
+## Goals
+
+- A standard FK/M2M autocomplete widget driven by HTMX with debounced search,
+  no custom JavaScript required by consumers.
+- A declarative way to express "field B's choices depend on field A's value"
+  so the widget forwards the parent value via `hx-include`.
+- A "+" button next to FK widgets that opens a popup form, creates the related
+  record, returns the new pk, and inserts it into the parent form.
+- A per-relation `display_template` so admin authors can customise option
+  rendering without overriding the choices view.
+- Backward compatibility: existing relation widgets keep working with no code
+  changes; new behaviour is opt-in via `AdminOptions`.
+
+## Non-Goals
+
+- Pagination / infinite scroll inside the dropdown. `choices_view` already
+  supports `limit`/`offset`; v0.5.5 keeps the current "show first 50, type to
+  filter" UX. A virtualised dropdown is a v0.5.6+ task.
+- Cross-admin popup creation. The "+" popup can only target a model that is
+  also registered with the same `Admin()`.
+- Server-rendered M2M tag inputs (chips). Deferred — multi-select is rendered
+  as a multi-checkbox list in v0.5.5.
+- Authoring custom widgets from scratch. We expose `display_template` and
+  dependency wiring, not a full widget plugin API.
+
+## BDD Scenarios
+
+```
+Scenario: FK field renders an autocomplete widget by default
+  Given a ModelAdmin for Product with FK to Supplier
+  When  the user opens /admin/products/create
+  Then  the Supplier field renders as <input type="search"> with hx-get="/admin/products/choices/supplier_id"
+  And   typing "ac" issues a debounced GET /admin/products/choices/supplier_id?q=ac
+
+Scenario: dependent FK forwards the parent value via hx-include
+  Given AdminOptions(relation_filters={"variant_id": {"depends_on": "supplier_id"}})
+  When  the user selects supplier_id=42 and focuses the variant_id field
+  Then  the variant_id widget's hx-get includes "?supplier_id=42"
+  And   the dropdown lists only variants whose supplier_id == 42
+
+Scenario: dependent FK with no parent value lists nothing
+  Given the same dependent wiring
+  When  the user focuses variant_id before choosing a supplier
+  Then  the dropdown renders an empty <option> list
+  And   the field shows placeholder "Pick a supplier first"
+
+Scenario: "+" popup creates the related row and selects it
+  Given the Supplier model is registered in the same Admin
+  When  the user clicks "+" next to the supplier_id field on /admin/products/create
+  Then  a modal loads /admin/suppliers/create-popup
+  And   on save the modal closes
+  And   the parent supplier_id field has the new supplier's id and label
+
+Scenario: "+" popup is hidden when the related model is not registered
+  Given Supplier is not registered with this Admin
+  When  the user opens /admin/products/create
+  Then  the Supplier field has no "+" button
+
+Scenario: display_template renders custom option rows
+  Given AdminOptions(relation_display={"supplier_id": "{name} — {city}"})
+  When  the user types "ac" in the supplier_id widget
+  Then  each <option> label is rendered as "{name} — {city}" for the matching row
+
+Scenario: choices_view rejects unknown relation field
+  When  GET /admin/products/choices/not_a_field is called
+  Then  the response is 404 with detail "Unknown relation field: 'not_a_field'"
+```
+
+## Design
+
+### Architecture
+
+Touched modules:
+
+```
+core/options.py        — AdminOptions gains relation_filters, relation_display
+core/fields.py         — classify_field carries dependent / display metadata
+views/dynamic.py       — choices_view stays; new create_popup_view added
+views/forms.py         — AutocompleteWidget renders search input + hx-get + hx-include
+templates/widgets/     — autocomplete.html, choices_options.html (refined), popup_form.html
+```
+
+No new top-level module. The popup endpoint is an alias of the existing create
+view with an HTMX-aware response that returns an `HX-Trigger` event carrying
+the new row's `(id, label)` payload.
+
+### Data Model Changes
+
+No data model changes. `AdminOptions` gains two new optional fields:
+
+```python
+relation_filters: dict[str, RelationDependency] | None = None
+relation_display: dict[str, str] | None = None
+```
+
+with:
+
+```python
+class RelationDependency(BaseModel):
+    depends_on: str            # name of the parent field in the same form
+    placeholder: str | None = None  # text shown when the parent is unset
+```
+
+### API / Protocol Changes
+
+**New view:**
+
+```python
+async def create_popup_view(self, request: Request) -> Response: ...
+```
+
+Mounted at `POST /{model}/create-popup`. On successful create, returns:
+
+```
+HTTP 200
+HX-Trigger: {"hyperadminPopupCreated": {"target": "<field_name>", "id": <new_pk>, "label": "<display>"}}
+Content-Type: text/html
+<empty body, modal closes via hx-on>
+```
+
+The label uses the related model's admin `relation_display` template if set,
+or falls back to `str(instance)`.
+
+**`choices_view`** is unchanged — it already accepts arbitrary extra query
+params for cascading filters.
+
+**Widget output template** (`widgets/autocomplete.html`) renders:
+
+```html
+<div class="ha-autocomplete" data-field="{{ field.name }}">
+  <input
+    type="search"
+    name="{{ field.name }}_search"
+    hx-get="{{ choices_url }}"
+    hx-trigger="keyup changed delay:200ms"
+    hx-target="next .ha-options"
+    {% if field.depends_on %}
+      hx-include="[name='{{ field.depends_on }}']"
+      data-depends-on="{{ field.depends_on }}"
+    {% endif %}
+    data-testid="autocomplete-{{ field.name }}"
+  >
+  <select name="{{ field.name }}" data-testid="autocomplete-select-{{ field.name }}">
+    {% include "widgets/choices_options.html" %}
+  </select>
+  {% if popup_url %}
+    <button type="button" hx-get="{{ popup_url }}" hx-target="#ha-popup-root" data-testid="autocomplete-add-{{ field.name }}">+</button>
+  {% endif %}
+</div>
+```
+
+When `depends_on` is set, the widget also emits a tiny `hx-trigger="change from:[name='{{ depends_on }}']"` so changing the parent re-fetches options.
+
+### Configuration Changes
+
+`AdminOptions` adds `relation_filters` and `relation_display`. No env vars.
+No `Admin()` constructor arg changes. Both fields default to `None`; the widget
+falls back to its current behaviour when unset.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| `depends_on` references a field that doesn't exist on the form | Raised at `AdminOptions` validation: `ValueError("depends_on='x' not in form fields")` |
+| `relation_display` template references a missing attribute | Render falls back to `str(instance)`; warning logged once per template per process |
+| Popup target model not registered | "+" button omitted client-side; server-side 404 if a crafted POST hits `create-popup` |
+| `choices_view` parent param is unset and a `depends_on` is configured | Returns the empty-options fragment with the configured `placeholder` |
+| User types fast | Debounce 200ms on the input prevents thrash; `choices_view` is safe to call concurrently |
+| HTMX request without `hx-request` header (curl, manual test) | Endpoint still returns HTML fragment; no special handling required |
+| Permission denied on popup create | Returns 403 with the standard error template; modal stays open with error |
+
+## Migration & Backward Compatibility
+
+Backward compatible. Existing widgets render unchanged when `relation_filters`
+and `relation_display` are unset. `choices_view`'s contract is unchanged.
+
+`AutocompleteWidget` replaces the default `<select>` for FK/M2M fields when
+`AdminOptions.use_autocomplete_widget` is True. v0.5.5 defaults this to True
+because the new widget is strictly a superset of the old select. Admins that
+want the legacy select can set `use_autocomplete_widget=False`.
+
+## Open Questions
+
+- [ ] Should `relation_display` accept a callable in addition to a format string? Proposal: yes — `str | Callable[[Any], str]`. Format strings cover 80% of cases; callables let consumers reach into computed properties.
+- [ ] Where does the popup modal live in the DOM? Proposal: a single `<div id="ha-popup-root">` added once to `base.html`. HTMX swaps the modal contents in/out; close via `hx-on::after-request="this.innerHTML=''"`.
+- [ ] Should dependent filtering support more than one parent (`depends_on: ["a", "b"]`)? Proposal: defer; if needed, a follow-up extends `depends_on` to accept a list without breaking the single-string form.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Reuse existing `choices_view` for cascading filters | It already forwards arbitrary query params to the adapter; no new endpoint surface | New `/depends-choices/` endpoint per dependency |
+| Single popup-root div in `base.html` | One slot, predictable target; matches HTMX idioms | Per-widget popup containers; Alpine.js modal store |
+| Format-string `relation_display` (not full Jinja) | Format strings are safe by default and trivially serialisable; full Jinja would invite XSS via untrusted attribute access | `Template(...)` per relation; callable-only |
+| Default `use_autocomplete_widget=True` | New widget is a strict superset; consumers benefit immediately | Default off — would mean v0.5.5 ships dormant |
+| Popup uses `HX-Trigger` event, not `HX-Location` | Event carries the structured payload (id + label); page must not navigate away from the parent form | `HX-Location` (loses parent form state); inline `Set-Cookie` (fragile) |


### PR DESCRIPTION
## Summary

Executes the unblocked phase of the upstream readiness plan
(`/Users/yevheniidehtiar/.claude/plans/staged-toasting-acorn.md`). Plan-only —
no application code changes.

- Adds **`epic-upstream-readiness`** as the umbrella tracking epic for the ten H#
  capabilities (H2/H3/H4/H5/H6/H12/H13/H14/H15/H20) HyperAdmin must ship before
  it can serve as the framework backbone for any consumer admin.
- Creates the **v0.5.5 milestone** (Bulk Actions & Autocomplete — H3 + H6,
  unblocks the bulk of any consumer build per the plan's sequencing rationale).
- Drafts the two SDDs the milestone requires (`docs/specs/bulk-actions.md`,
  `docs/specs/htmx-autocomplete.md`) — both in `Status: Draft`, awaiting human
  approval via the spec-review story gates.
- Cuts the two v0.5.5 implementation epics with bottom-up sub-tasks
  (decorator/options → views → templates → e2e) per `planning-playbook.md`.
- Cuts the v0.5.0 follow-up patch epic for the H2 inline-row error
  highlighting gap (bugfix-sized, no SDD per `sdd-conventions.md`).

## What is *not* in this PR (deferred to phase 2)

- v0.5.6 SDDs (`detail-panels.md`, `filter-library.md`) — blocked on the H4
  detail-panel scope open question in the plan (line 88–90).
- v0.5.4 rename (Dashboard Builder → Reporting & Charts) + SDDs
  (`olap-reporting.md`, `chart-components.md`).
- v0.5.7 SDD (`permission-matrix-ui.md`).

These are technically unblocked but kept out of phase 1 to preserve a tight,
reviewable scope around the foundational H3/H6 work the plan flagged as
unblocking the rest.

## Methodology compliance

- **SDD-first**: every new epic's first sub-task is `review(spec): approve SDD`
  (human gate per `sdd-conventions.md`); all implementation stories are
  `blocked_by` that gate.
- **BDD**: every SDD and every implementation/e2e story carries `## Scenarios`
  in Given/When/Then form. E2E stories map 1:1 to scenarios with mandatory
  `# Given / # When / # Then` comments.
- **Bottom-up**: each epic's stories follow `core → views → templates → e2e`,
  never reversed.
- **Framework-neutral**: no consumer-specific names, schemas, or domain logic
  introduced anywhere in this PR (per the project's "no downstream consumer
  names in repo" rule).

## Test plan

- [x] Verify `.meta/` tree validates (`./scripts/gitpm.sh validate` once gitpm CLI is available locally)
- [x] Confirm `docs/specs/bulk-actions.md` and `docs/specs/htmx-autocomplete.md` render in the docs preview
- [ ] Human review of the two SDDs against `docs/specs/TEMPLATE.md` and the SDD review checklist
- [ ] Confirm sequencing matches the plan: v0.5.5 (H3+H6) → v0.5.6 (H4+H12) → v0.5.4 (H14+H15) → v0.5.7 (H20)
- [ ] Decide H4 scope question before phase 2 starts (panel registry + tabbed layout + one PDF-streaming demo only?)