### PR TITLE
docs(meta): upstream readiness phase 2 — v0.5.6 / v0.5.4 / v0.5.7 plan

### DIFF
--- a/.meta/epics/epic-v054-chart-components/epic.md
+++ b/.meta/epics/epic-v054-chart-components/epic.md
@@ -1,0 +1,78 @@
+---
+type: epic
+id: ep-v054-charts-01
+title: "epic(widgets): chart components bound to ReportView"
+status: todo
+priority: high
+owner: null
+labels:
+  - size:L
+  - planned
+  - frontend
+  - backend
+  - upstream-readiness
+  - H15
+milestone_ref:
+  id: 8DidH5NiN6cP
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Overview
+
+Implements upstream readiness capability **H15**: SVG primitives
+(`BarChart`, `LineChart`, `StackedBarChart`, `PieChart`) and an HTMX-loaded
+chart fragment route per `ReportView`. Server-rendered SVG by default with
+an optional Chart.js mode for richer interactivity. Accessible by default —
+each chart ships an inline `<details><table>` data fallback.
+
+**SDD:** [`docs/specs/chart-components.md`](../../../docs/specs/chart-components.md)
+(required — new module, cross-module integration with reports + filters).
+
+## Tracks
+
+### Track A: SVG primitives
+- `widgets/charts.py` + `templates/widgets/charts/*.svg.html` for the four shapes.
+- Accessible markup (`role="img"`, `<title>`, `<desc>`, data-table fallback).
+- CSS variable palette (`--ha-chart-1` … `--ha-chart-7`).
+
+### Track B: Chart.js mode + vendored bundle
+- `static/vendor/chart-js/chart.umd.js` (vendored, not from CDN).
+- `templates/widgets/charts/chartjs.html` — canvas + JSON dataset slot.
+- Graceful fallback to SVG if the vendor file is missing.
+
+### Track C: Wrapper + route + dataset reuse
+- `Chart` Python wrapper (`kind`, `report`, `mode`, `title`, `height`).
+- New chart-fragment route `GET /admin/reports/{slug}/chart`.
+- Filter querystring passed through to the bound `ReportView`.
+
+### Track D: E2E + accessibility
+- Six SDD scenarios covered by Playwright.
+- Axe-style accessibility assertions on the SVG output.
+
+## Scenarios
+
+See SDD `## BDD Scenarios` (six scenarios: SVG render, Chart.js mode,
+stacked bar, lazy-load, a11y data table, filter context pass-through).
+
+## Acceptance Criteria
+
+- [ ] Four SVG primitives implemented + visual snapshots
+- [ ] Chart.js mode opt-in via `mode="chartjs"` or `Admin(chart_mode="chartjs")`
+- [ ] Chart.js bundle vendored under `static/vendor/`
+- [ ] `Chart` wrapper exported from `hyperadmin.widgets`
+- [ ] `/admin/reports/{slug}/chart` fragment endpoint registered
+- [ ] Filter querystring forwarded transparently
+- [ ] Accessible data-table fallback on by default
+- [ ] Six SDD scenarios pass (unit + E2E)
+- [ ] `poe lint` and `poe test` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-chart-components`
+- Epic `epic-v054-olap-reporting` (binds to `ReportView`)
+
+## Parent
+
+- Milestone: `v054-dashboard-builder` (Reporting & Charts)
+- Tracking: `epic-upstream-readiness` (H15)

--- a/.meta/epics/epic-v054-chart-components/stories/featviews-chart-fragment-route-and-e2e.md
+++ b/.meta/epics/epic-v054-chart-components/stories/featviews-chart-fragment-route-and-e2e.md
@@ -1,0 +1,63 @@
+---
+type: story
+id: st-v054-charts-03
+title: "feat(views+e2e): chart fragment route + Playwright suite"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - tests
+  - upstream-readiness
+  - H15
+estimate: null
+epic_ref:
+  id: ep-v054-charts-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Register a chart fragment route per `ReportView`
+(`GET /admin/reports/{slug}/chart`). Forward filter querystring to the
+underlying report so chart and grid stay in sync. Cover the six SDD
+scenarios in Playwright (SVG, Chart.js, stacked bar, lazy-load, a11y
+fallback, filter context).
+
+**Spec:** [`docs/specs/chart-components.md`](../../../../docs/specs/chart-components.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/reports/view.py` — `chart_view` handler
+- **Modified:** `src/hyperadmin/core/app.py` — register the chart route alongside the report grid
+- **New:** `tests/e2e/test_chart_components.py`
+
+## Scenarios → Tests
+
+| Scenario | Test function |
+|---|---|
+| SVG bar chart renders from a ReportView dataset | `test_svg_bar_chart_renders_from_report` |
+| Chart.js mode renders a canvas with a data payload | `test_chartjs_mode_renders_canvas_with_payload` |
+| stacked bar chart renders one stack per column dimension | `test_stacked_bar_renders_one_stack_per_column` |
+| chart fragment lazy-loads via HTMX in a host template | `test_chart_fragment_lazy_loads_via_htmx` |
+| SVG chart includes accessible data table fallback | `test_svg_chart_includes_accessible_data_table` |
+| chart respects the report's filter context | `test_chart_respects_report_filter_context` |
+
+## Acceptance Criteria
+
+- [ ] Chart route registered alongside each report's grid route
+- [ ] Filter querystring forwarded unchanged
+- [ ] Six scenarios pass at unit / E2E level
+- [ ] Visual snapshots committed
+- [ ] `poe lint` and `poe test` pass
+
+## Blocked by
+
+- `featwidgets-chartjs-mode-and-vendor`
+
+## Parent
+
+- Epic: `epic-v054-chart-components`

--- a/.meta/epics/epic-v054-chart-components/stories/featwidgets-chartjs-mode-and-vendor.md
+++ b/.meta/epics/epic-v054-chart-components/stories/featwidgets-chartjs-mode-and-vendor.md
@@ -1,0 +1,70 @@
+---
+type: story
+id: st-v054-charts-02
+title: "feat(widgets): Chart.js mode + vendored UMD bundle"
+status: todo
+priority: medium
+assignee: null
+labels:
+  - size:M
+  - planned
+  - frontend
+  - upstream-readiness
+  - H15
+estimate: null
+epic_ref:
+  id: ep-v054-charts-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Add the `mode="chartjs"` rendering path: `<canvas>` + a JSON payload that the
+client-side glue reads to construct the Chart.js instance. Vendor the
+Chart.js UMD bundle under `static/vendor/chart-js/`. Falls back to SVG when
+the vendor file is missing (logs at WARNING).
+
+**Spec:** [`docs/specs/chart-components.md`](../../../../docs/specs/chart-components.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/static/vendor/chart-js/chart.umd.js` (vendored)
+- **New:** `src/hyperadmin/static/vendor/chart-js/LICENSE`
+- **New:** `src/hyperadmin/templates/widgets/charts/chartjs.html`
+- **Modified:** `src/hyperadmin/widgets/charts.py` — mode dispatch
+- **Modified:** `src/hyperadmin/core/options.py` — `Admin(chart_mode=...)` default
+- **New:** `tests/unit/test_charts_chartjs.py`
+
+## Scenarios
+
+```
+Scenario: chartjs mode renders canvas with data payload
+  Given a BarChart with mode="chartjs" and dataset [(A,10),(B,20)]
+  When  the fragment renders
+  Then  the body contains "<canvas data-testid=\"chart-{slug}\">"
+  And   a <script type="application/json" data-chart-data="{slug}"> with the dataset
+
+Scenario: missing vendor file falls back to SVG
+  Given the vendored chart.umd.js file is absent
+  When  the chartjs fragment renders
+  Then  the output is the SVG variant
+  And   a WARNING is logged with message "Chart.js bundle missing — falling back to SVG"
+```
+
+## Acceptance Criteria
+
+- [ ] Chart.js UMD bundle vendored with its LICENSE
+- [ ] `mode="chartjs"` renders canvas + JSON payload + script include
+- [ ] `Admin(chart_mode=...)` default propagates when widget doesn't specify
+- [ ] Fallback path when vendor file missing
+- [ ] Two scenarios above covered by unit tests
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `featwidgets-svg-chart-primitives`
+
+## Parent
+
+- Epic: `epic-v054-chart-components`

--- a/.meta/epics/epic-v054-chart-components/stories/featwidgets-svg-chart-primitives.md
+++ b/.meta/epics/epic-v054-chart-components/stories/featwidgets-svg-chart-primitives.md
@@ -1,0 +1,78 @@
+---
+type: story
+id: st-v054-charts-01
+title: "feat(widgets): SVG chart primitives (bar, line, stacked-bar, pie)"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - frontend
+  - upstream-readiness
+  - H15
+estimate: null
+epic_ref:
+  id: ep-v054-charts-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Implement the four server-rendered SVG chart primitives in
+`widgets/charts.py` + matching Jinja templates. Each chart produces
+accessible SVG (`role="img"`, `<title>`, `<desc>`) and a paired
+`<details><table>` data-table fallback. Uses the CSS variable palette
+`--ha-chart-1` … `--ha-chart-7` so consumers can theme without forking
+templates.
+
+**Spec:** [`docs/specs/chart-components.md`](../../../../docs/specs/chart-components.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/widgets/charts.py` — `BarChart`, `LineChart`, `StackedBarChart`, `PieChart`, `Chart` wrapper
+- **New:** `src/hyperadmin/templates/widgets/charts/bar.svg.html`
+- **New:** `src/hyperadmin/templates/widgets/charts/line.svg.html`
+- **New:** `src/hyperadmin/templates/widgets/charts/stacked_bar.svg.html`
+- **New:** `src/hyperadmin/templates/widgets/charts/pie.svg.html`
+- **New:** `src/hyperadmin/templates/widgets/chart_fallback.html`
+- **Modified:** existing CSS — chart palette variables
+- **New:** `tests/unit/test_charts_svg.py`
+
+## Scenarios
+
+```
+Scenario: BarChart renders one bar per category
+  Given a dataset [(A, 10), (B, 20), (C, 30)]
+  When  BarChart.render(dataset) is called
+  Then  the output contains exactly three <rect class="bar"> elements
+
+Scenario: long category label is truncated with ellipsis
+  Given a category label "supercalifragilisticexpialidocious" (>18 chars)
+  When  the chart renders with default width
+  Then  the rendered tspan text ends with "…"
+
+Scenario: data-table fallback enumerates the source rows
+  When  the chart renders
+  Then  the output contains a <details data-testid="chart-data-table-{title-slug}"> with one <tr> per data point
+```
+
+## Acceptance Criteria
+
+- [ ] Four chart classes implemented; each has its template
+- [ ] SVG has `role="img"`, `<title>`, `<desc>` populated from `Chart.title`
+- [ ] `<details><table>` fallback in DOM order after the SVG
+- [ ] CSS palette `--ha-chart-1..7` used (no hard-coded colours)
+- [ ] Long-label truncation at the configured width
+- [ ] Three scenarios above covered as unit / rendering tests
+- [ ] Visual snapshots committed for each chart kind
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-chart-components`
+
+## Parent
+
+- Epic: `epic-v054-chart-components`

--- a/.meta/epics/epic-v054-chart-components/stories/reviewspec-approve-sdd-chart-components.md
+++ b/.meta/epics/epic-v054-chart-components/stories/reviewspec-approve-sdd-chart-components.md
@@ -1,0 +1,43 @@
+---
+type: story
+id: st-v054-charts-00
+title: "review(spec): approve SDD for chart components"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - needs-human
+  - upstream-readiness
+  - H15
+estimate: null
+epic_ref:
+  id: ep-v054-charts-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+**Human gate** — review and approve `docs/specs/chart-components.md` before
+implementation sub-tasks may start.
+
+## Checklist
+
+- [ ] Four SVG primitives cover H15 acceptance
+- [ ] Default mode `svg`, opt-in `chartjs` — correct
+- [ ] Vendored Chart.js (no CDN) — confirmed acceptable
+- [ ] Accessibility: data-table fallback on by default
+- [ ] Charts placed under `widgets/` (not `reports/`) — boundary acceptable
+- [ ] Open Questions resolved (CDN vs vendor, CSS variables, fallback default)
+
+## Open Questions to resolve
+
+1. Vendor Chart.js or load from CDN?
+2. CSS variable palette names — `--ha-chart-N`?
+3. Data-table fallback default on or opt-in?
+
+## Parent
+
+- Epic: `epic-v054-chart-components`

--- a/.meta/epics/epic-v054-olap-reporting/epic.md
+++ b/.meta/epics/epic-v054-olap-reporting/epic.md
@@ -1,0 +1,82 @@
+---
+type: epic
+id: ep-v054-olap-01
+title: "epic(reports): OLAP / pivot reporting with CSV+XLSX export"
+status: todo
+priority: high
+owner: null
+labels:
+  - size:L
+  - planned
+  - backend
+  - upstream-readiness
+  - H14
+milestone_ref:
+  id: 8DidH5NiN6cP
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Overview
+
+Implements upstream readiness capability **H14**: new
+`src/hyperadmin/reports/` package with declarative aggregates, crosstab
+dimensions, time-series bucketing, filter integration (via H12), CSV / XLSX
+export, permission gating (via H5), and a cached materialisation seam for
+fact-table-backed reports.
+
+**SDD:** [`docs/specs/olap-reporting.md`](../../../docs/specs/olap-reporting.md)
+(required — new top-level module, multi-module integration).
+
+## Tracks
+
+### Track A: Aggregates + crosstab core
+- `reports/aggregates.py` — `Sum`, `Count`, `Min`, `Max`, `StringAggComma`, `Many2One`.
+- `reports/view.py` — `ReportView` base + registration.
+- `reports/crosstab.py` — pivot builder.
+- `reports/bucketing.py` — `TimeBucket` + `auto`-period resolver.
+
+### Track B: Source dispatch + filter wiring
+- `reports/cache.py` — `FactTableSource` seam.
+- Filter integration with `filters/` from v0.5.6.
+- Source-selection dispatcher: live query vs fact-table.
+
+### Track C: Export endpoints + routes
+- CSV streamer with proper content-disposition.
+- XLSX streamer using `openpyxl.write_only` (memory-safe).
+- Permission codename `view_report_{slug}` enforcement.
+- Three routes per registered `ReportView`.
+
+### Track D: Templates + unit/E2E
+- `templates/reports/list.html`, `detail.html`.
+- Export buttons + filter sidebar reuse.
+- E2E for the eight SDD scenarios.
+
+## Scenarios
+
+See SDD `## BDD Scenarios` (eight scenarios: registration, single-group sum,
+crosstab, auto-bucketing, CSV export, XLSX export, permission gating, fact-
+table cache).
+
+## Acceptance Criteria
+
+- [ ] `reports/` package with documented public API
+- [ ] Six aggregates implemented + unit tested
+- [ ] Pivot builder produces correct grids across dialects
+- [ ] Time-bucketing including `auto` resolver
+- [ ] Filter integration via `filters/` (v0.5.6)
+- [ ] CSV + XLSX export streamed (no in-memory blowup)
+- [ ] `FactTableSource` swaps the live query transparently
+- [ ] Permission codename gates report access
+- [ ] Eight SDD scenarios pass
+- [ ] `poe lint` and `poe test` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-olap-reporting`
+- Epic `epic-v056-filter-library` (depends on `FilterDef` protocol)
+
+## Parent
+
+- Milestone: `v054-dashboard-builder` (Reporting & Charts)
+- Tracking: `epic-upstream-readiness` (H14)

--- a/.meta/epics/epic-v054-olap-reporting/stories/featreports-aggregates-and-crosstab-core.md
+++ b/.meta/epics/epic-v054-olap-reporting/stories/featreports-aggregates-and-crosstab-core.md
@@ -1,0 +1,73 @@
+---
+type: story
+id: st-v054-olap-01
+title: "feat(reports): aggregates, crosstab, time-bucketing core"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:L
+  - planned
+  - backend
+  - upstream-readiness
+  - H14
+estimate: null
+epic_ref:
+  id: ep-v054-olap-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Stand up the `reports/` package with `ReportView`, the six aggregates, the
+crosstab pivot builder, and `TimeBucket` (including the `auto` resolver).
+Implementation is data-layer first — no routes / templates / exports yet.
+
+**Spec:** [`docs/specs/olap-reporting.md`](../../../../docs/specs/olap-reporting.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/reports/__init__.py`
+- **New:** `src/hyperadmin/reports/aggregates.py`
+- **New:** `src/hyperadmin/reports/view.py`
+- **New:** `src/hyperadmin/reports/crosstab.py`
+- **New:** `src/hyperadmin/reports/bucketing.py`
+- **New:** `tests/unit/test_reports_core.py`
+
+## Scenarios
+
+```
+Scenario: Sum aggregate compiles to SUM(field)
+  Given Sum(field="amount")
+  When  .sql(dialect="postgresql") is called
+  Then  the result is "SUM(\"amount\")"
+
+Scenario: pivot builder pivots (sku, month) → row × col grid
+  Given a flat result [(sku=A, month=2026-01, total=10), (sku=A, month=2026-02, total=20), (sku=B, month=2026-01, total=5)]
+  When  pivot(rows=["sku"], cols=["month"], value="total") runs
+  Then  the grid maps {("A","2026-01"): 10, ("A","2026-02"): 20, ("B","2026-01"): 5}
+
+Scenario: auto bucketing picks quarter for 365-day range
+  Given TimeBucket("created_at", period="auto") and range 2025-01-01 .. 2025-12-31
+  When  resolve_period(range) is called
+  Then  the result is "quarter"
+```
+
+## Acceptance Criteria
+
+- [ ] Six aggregates implemented; each has a per-dialect SQL stub
+- [ ] `ReportView.run()` executes the grouped query and returns a flat result set
+- [ ] Pivot builder handles missing cells (None / zero per aggregate convention)
+- [ ] `TimeBucket("...", period="auto")` resolver matches SDD thresholds
+- [ ] Public exports from `hyperadmin.reports`
+- [ ] Unit tests cover all three scenarios + per-aggregate SQL
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-olap-reporting`
+
+## Parent
+
+- Epic: `epic-v054-olap-reporting`

--- a/.meta/epics/epic-v054-olap-reporting/stories/featreports-source-dispatch-and-filters.md
+++ b/.meta/epics/epic-v054-olap-reporting/stories/featreports-source-dispatch-and-filters.md
@@ -1,0 +1,72 @@
+---
+type: story
+id: st-v054-olap-02
+title: "feat(reports): source dispatcher, fact-table cache seam, filter integration"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - upstream-readiness
+  - H14
+estimate: null
+epic_ref:
+  id: ep-v054-olap-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Add `FactTableSource` and the source dispatcher: when a `ReportView` declares
+a cache, the dispatcher reads from the fact table instead of the live query
+with no calling-code change. Wire the report's `filters` list through the
+v0.5.6 filter pipeline so a `ReportView` can mount the same sidebar as a
+list view.
+
+**Spec:** [`docs/specs/olap-reporting.md`](../../../../docs/specs/olap-reporting.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/reports/cache.py`
+- **Modified:** `src/hyperadmin/reports/view.py` — source dispatcher in `.run()`
+- **Modified:** `tests/unit/test_reports_core.py` — cache + filter coverage
+
+## Scenarios
+
+```
+Scenario: cache source replaces live query
+  Given ReportView.cache = FactTableSource(model=OrderRevenueFact)
+  When  .run() executes
+  Then  the executed query targets OrderRevenueFact
+  And   the result equals the live-query reference
+
+Scenario: cache validation rejects missing columns
+  Given a fact table missing the "sku" column referenced in rows
+  When  register_report() runs
+  Then  ValueError is raised: "FactTableSource missing column 'sku'"
+
+Scenario: filters are applied before the aggregate
+  Given a DateRangeFilter and a Sum aggregate
+  When  .run() executes with {"created_at__gte": "2026-02-01"}
+  Then  the SQL WHERE clause includes "created_at >= '2026-02-01'"
+  And   the result excludes pre-February rows
+```
+
+## Acceptance Criteria
+
+- [ ] `FactTableSource` implemented; live-query default preserved
+- [ ] Column-shape validation at `register_report` time
+- [ ] Filter parse → apply → run pipeline in `ReportView.run()`
+- [ ] Unit tests for all three scenarios
+- [ ] `poe lint` passes
+
+## Blocked by
+
+- `featreports-aggregates-and-crosstab-core`
+
+## Parent
+
+- Epic: `epic-v054-olap-reporting`

--- a/.meta/epics/epic-v054-olap-reporting/stories/featviews-report-routes-and-export.md
+++ b/.meta/epics/epic-v054-olap-reporting/stories/featviews-report-routes-and-export.md
@@ -1,0 +1,75 @@
+---
+type: story
+id: st-v054-olap-03
+title: "feat(views): report routes + CSV/XLSX streaming exports"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - upstream-readiness
+  - H14
+estimate: null
+epic_ref:
+  id: ep-v054-olap-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Wire `ReportView` into the admin router. Each registered report gets three
+routes: HTML grid, CSV export, XLSX export. XLSX uses `openpyxl.write_only`
+so a million-cell export does not blow memory. Permission codename
+`view_report_{slug}` enforced on each.
+
+**Spec:** [`docs/specs/olap-reporting.md`](../../../../docs/specs/olap-reporting.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/reports/export.py` — `stream_csv`, `stream_xlsx`
+- **Modified:** `src/hyperadmin/views/dynamic.py` (or new `views/reports.py` if cleaner) — route registration
+- **Modified:** `src/hyperadmin/core/app.py` — `Admin.register_report(...)` and discovery
+- **Modified:** `tests/unit/test_reports_core.py` — route + export tests
+
+## Scenarios
+
+```
+Scenario: HTML grid renders pivot
+  When  GET /admin/reports/orders-revenue/
+  Then  response is 200 and body has a <table data-testid="report-grid">
+
+Scenario: CSV stream sets attachment disposition
+  When  GET /admin/reports/orders-revenue/export.csv
+  Then  Content-Type is "text/csv"
+  And   Content-Disposition is "attachment; filename=orders-revenue.csv"
+
+Scenario: XLSX stream is openable by openpyxl
+  When  GET /admin/reports/orders-revenue/export.xlsx
+  Then  Content-Type is the XLSX media type
+  And   loading the body with openpyxl.load_workbook yields a single sheet matching the grid
+
+Scenario: permission codename gates report access
+  Given the user lacks "view_report_orders_revenue"
+  When  GET /admin/reports/orders-revenue/
+  Then  response is 403
+```
+
+## Acceptance Criteria
+
+- [ ] `Admin.register_report(...)` registers three routes per report
+- [ ] CSV streamer with correct headers and BOM-free UTF-8
+- [ ] XLSX streamer uses `write_only` workbook
+- [ ] Permission check on all three routes
+- [ ] Unit tests for all four scenarios
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `featreports-source-dispatch-and-filters`
+
+## Parent
+
+- Epic: `epic-v054-olap-reporting`

--- a/.meta/epics/epic-v054-olap-reporting/stories/reviewspec-approve-sdd-olap-reporting.md
+++ b/.meta/epics/epic-v054-olap-reporting/stories/reviewspec-approve-sdd-olap-reporting.md
@@ -1,0 +1,44 @@
+---
+type: story
+id: st-v054-olap-00
+title: "review(spec): approve SDD for OLAP reporting"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - needs-human
+  - upstream-readiness
+  - H14
+estimate: null
+epic_ref:
+  id: ep-v054-olap-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+**Human gate** — review and approve `docs/specs/olap-reporting.md` before
+implementation sub-tasks may start.
+
+## Checklist
+
+- [ ] H14 scope satisfied (aggregates, crosstab, bucketing, CSV+XLSX, cache seam)
+- [ ] Non-goals defer drill-down, self-service builder, scheduled refresh
+- [ ] Route layout `/admin/reports/{slug}/...` confirmed
+- [ ] Permission codename scheme `view_report_{slug}` confirmed
+- [ ] CSV + XLSX both required (not CSV-only)
+- [ ] Auto-bucketing thresholds reasonable
+- [ ] Open Questions resolved (route nesting, Many2One render, XLSX cover sheet)
+
+## Open Questions to resolve
+
+1. Top-level `/admin/reports/` vs nested under model?
+2. `Many2One` aggregate — render display or pk?
+3. XLSX "Filters used" cover sheet — include?
+
+## Parent
+
+- Epic: `epic-v054-olap-reporting`

--- a/.meta/epics/epic-v054-olap-reporting/stories/teste2e-report-scenarios.md
+++ b/.meta/epics/epic-v054-olap-reporting/stories/teste2e-report-scenarios.md
@@ -1,0 +1,58 @@
+---
+type: story
+id: st-v054-olap-04
+title: "test(e2e): report scenarios via Playwright"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - tests
+  - upstream-readiness
+  - H14
+estimate: null
+epic_ref:
+  id: ep-v054-olap-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Cover the eight SDD scenarios end-to-end. Use the `examples/full-demo/`
+generic `Order/Product/Supplier` seed data so the qualification check is
+reproducible without consumer-specific schema.
+
+## Files to Change
+
+- **New:** `tests/e2e/test_olap_reporting.py`
+- **Modified:** `tests/e2e/conftest.py` — seed for `OrderRevenueReport` if missing
+
+## Scenarios → Tests
+
+| Scenario | Test function |
+|---|---|
+| report registers and lists in the admin nav | `test_report_registers_in_admin_nav` |
+| sum aggregate over one row group renders a grid | `test_sum_aggregate_renders_grid` |
+| time-bucketed crosstab renders rows × month columns | `test_time_bucketed_crosstab_renders` |
+| auto bucketing picks quarter for a year-range request | `test_auto_bucketing_picks_quarter` |
+| CSV export streams the same dataset | `test_csv_export_streams_dataset` |
+| XLSX export streams the same dataset | `test_xlsx_export_streams_dataset` |
+| permission codename gates report access | `test_permission_gates_report_access` |
+| cached fact-table source replaces the live query | `test_cached_source_replaces_live_query` |
+
+## Acceptance Criteria
+
+- [ ] Eight Playwright tests, one per scenario, mandatory G/W/T comments
+- [ ] Accessibility-first locators or `data-testid` only (`report-grid`,
+  `report-export-csv`, `report-export-xlsx`)
+- [ ] `poe test:e2e -k olap_reporting` passes locally and in CI
+
+## Blocked by
+
+- `featviews-report-routes-and-export`
+
+## Parent
+
+- Epic: `epic-v054-olap-reporting`

--- a/.meta/epics/epic-v056-detail-panels/epic.md
+++ b/.meta/epics/epic-v056-detail-panels/epic.md
@@ -1,0 +1,76 @@
+---
+type: epic
+id: ep-v056-dp-01
+title: "epic(detail): tabbed detail panels with HTMX lazy-load and PDF streaming"
+status: todo
+priority: high
+owner: null
+labels:
+  - size:L
+  - planned
+  - backend
+  - frontend
+  - upstream-readiness
+  - H4
+milestone_ref:
+  id: v056-dpfl-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Overview
+
+Implements upstream readiness capability **H4**: `panels` registry on
+`AdminOptions`, `@panel` decorator, tabbed detail layout with HTMX lazy-load,
+and a bundled `PDFStreamPanel` demo. History/Transitions panel content is an
+extension point for downstream apps — out of scope here per the H4 SDD.
+
+**SDD:** [`docs/specs/detail-panels.md`](../../../docs/specs/detail-panels.md)
+(required — touches `core/`, `views/`, templates).
+
+## Tracks
+
+### Track A: Registry + decorator (core)
+- `src/hyperadmin/core/panels.py` — `PanelDef`, `@panel` decorator, `collect_panels`.
+- `AdminOptions.panels: list[PanelDef] | None`.
+- Slug-collision validation at registration.
+- Default permission codename derivation (`view_{model}_panel_{slug}`).
+
+### Track B: View routes + streaming (views)
+- `DynamicModelView.render_panel_view` — `GET /{model}/{id}/panels/{slug}`.
+- `DynamicModelView.stream_panel_view` — `GET /{model}/{id}/panels/{slug}/stream`.
+- StreamingResponse detection → iframe wrapper fragment.
+- Per-panel permission re-check.
+- Bundled `hyperadmin.panels.pdf_stream_panel` factory.
+
+### Track C: Templates + E2E (frontend)
+- `templates/detail.html` — tab strip slot under `{% if panels %}`.
+- `templates/components/panel_tab_strip.html`.
+- `data-testid` exports: `panel-tab-{slug}`, `panel-body-{slug}`, `panel-iframe-{slug}`.
+- E2E suite covering all six scenarios in the SDD.
+
+## Scenarios
+
+See SDD `## BDD Scenarios` (six scenarios: tab render, lazy-load, streaming,
+forbidden, slug collision, permission gate).
+
+## Acceptance Criteria
+
+- [ ] `PanelDef` + `@panel` defined and unit tested
+- [ ] `AdminOptions.panels` validated for slug uniqueness at registration
+- [ ] Two new routes registered per panel-bearing model
+- [ ] Streaming handlers yield `<iframe>` wrapper; HTML handlers swap inline
+- [ ] Permission codename gates every panel request (default + override)
+- [ ] `PDFStreamPanel` factory in `hyperadmin.panels` package
+- [ ] `detail.html` backward compatible when `panels` is None
+- [ ] Six E2E scenarios pass
+- [ ] `poe lint` and `poe test` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-detail-panels`
+
+## Parent
+
+- Milestone: `v056-detail-panels-filter-library`
+- Tracking: `epic-upstream-readiness` (H4)

--- a/.meta/epics/epic-v056-detail-panels/stories/featcore-add-panel-registry.md
+++ b/.meta/epics/epic-v056-detail-panels/stories/featcore-add-panel-registry.md
@@ -1,0 +1,72 @@
+---
+type: story
+id: st-v056-dp-01
+title: "feat(core): add PanelDef, @panel decorator, panels registry"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - upstream-readiness
+  - H4
+estimate: null
+epic_ref:
+  id: ep-v056-dp-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Introduce the panel contract in `src/hyperadmin/core/panels.py` (`PanelDef`,
+`@panel`, `collect_panels`) and wire `AdminOptions.panels: list[PanelDef] |
+None`. Validate slug uniqueness at registration; derive a default permission
+codename `view_{model}_panel_{slug}` per entry.
+
+**Spec:** [`docs/specs/detail-panels.md`](../../../../docs/specs/detail-panels.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/core/panels.py`
+- **Modified:** `src/hyperadmin/core/options.py` — add `panels`
+- **Modified:** `src/hyperadmin/core/__init__.py` — export `PanelDef`, `panel`
+- **New:** `tests/unit/test_panels.py`
+
+## Scenarios
+
+```
+Scenario: duplicate panel slug raises at registration
+  Given AdminOptions(panels=[PanelDef(slug="x", ...), PanelDef(slug="x", ...)])
+  When  the model is registered
+  Then  ValueError("duplicate panel slug 'x'") is raised
+
+Scenario: default permission codename is derived from model and slug
+  Given PanelDef(slug="invoice", label="Invoice", handler=...) on the Order admin
+  When  the panel is registered
+  Then  the resolved permission is "view_order_panel_invoice"
+
+Scenario: explicit permission overrides the default
+  Given PanelDef(slug="invoice", ..., permission="invoice.view")
+  Then  the resolved permission is "invoice.view"
+```
+
+## Acceptance Criteria
+
+- [ ] `PanelDef` dataclass: `slug`, `label`, `handler`, `icon`, `permission`
+- [ ] `@panel` decorator validates handler signature (`(self, request, obj, *, ...)` per resolution of open question)
+- [ ] `collect_panels(cls)` returns `list[PanelDef]`
+- [ ] Slug uniqueness enforced at registration
+- [ ] Default permission codename `view_{model}_panel_{slug}` derived
+- [ ] Public exports from `hyperadmin.core` and `hyperadmin`
+- [ ] Unit tests cover all three scenarios
+- [ ] `poe lint` passes
+
+## Blocked by
+
+- `reviewspec-approve-sdd-detail-panels`
+
+## Parent
+
+- Epic: `epic-v056-detail-panels`

--- a/.meta/epics/epic-v056-detail-panels/stories/feattemplates-tab-strip-and-e2e.md
+++ b/.meta/epics/epic-v056-detail-panels/stories/feattemplates-tab-strip-and-e2e.md
@@ -1,0 +1,72 @@
+---
+type: story
+id: st-v056-dp-03
+title: "feat(templates+e2e): tab strip and panel E2E coverage"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - frontend
+  - tests
+  - upstream-readiness
+  - H4
+estimate: null
+epic_ref:
+  id: ep-v056-dp-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Render the tab strip in `detail.html` under `{% if panels %}` and add a
+component partial. Each tab carries `hx-get` for lazy load. Cover all six
+SDD scenarios in Playwright.
+
+**Spec:** [`docs/specs/detail-panels.md`](../../../../docs/specs/detail-panels.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/templates/detail.html` — tab strip slot
+- **New:** `src/hyperadmin/templates/components/panel_tab_strip.html`
+- **New:** `tests/e2e/test_detail_panels.py`
+- **New:** `tests/_fixtures/sample.pdf` — small PDF used by PDFStreamPanel demo
+
+## data-testid Reference
+
+| Element | testid |
+|---|---|
+| Tab strip container | `panel-tabs` |
+| Single tab link | `panel-tab-{slug}` |
+| Active panel body | `panel-body-{slug}` |
+| Streaming-mode iframe | `panel-iframe-{slug}` |
+
+## Scenarios → Tests
+
+| Scenario | Test function |
+|---|---|
+| detail page renders configured panel tabs | `test_detail_page_renders_configured_panel_tabs` |
+| panel body lazy-loads when its tab becomes visible | `test_panel_body_lazy_loads_on_tab_click` |
+| streaming panel returns Content-Disposition inline | `test_streaming_panel_serves_inline_pdf` |
+| panel handler raising HTTPException(403) surfaces forbidden | `test_panel_handler_403_surfaces_forbidden_body` |
+| panel slug collision raises at registration | `test_panel_slug_collision_raises_at_registration` (unit) |
+| permission codename gates panel access | `test_permission_codename_gates_panel_access` |
+
+## Acceptance Criteria
+
+- [ ] Tab strip rendered only when `panels` configured
+- [ ] Each tab has the `data-testid` per the table above
+- [ ] PDF fixture in `tests/_fixtures/sample.pdf`
+- [ ] All six scenarios covered (slug-collision as unit test, others E2E)
+- [ ] Visual snapshot baseline updated
+- [ ] `poe test:e2e -k detail_panels` passes
+
+## Blocked by
+
+- `featviews-panel-render-and-stream`
+
+## Parent
+
+- Epic: `epic-v056-detail-panels`

--- a/.meta/epics/epic-v056-detail-panels/stories/featviews-panel-render-and-stream.md
+++ b/.meta/epics/epic-v056-detail-panels/stories/featviews-panel-render-and-stream.md
@@ -1,0 +1,83 @@
+---
+type: story
+id: st-v056-dp-02
+title: "feat(views): render_panel_view + stream_panel_view + PDFStreamPanel factory"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - upstream-readiness
+  - H4
+estimate: null
+epic_ref:
+  id: ep-v056-dp-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Register the two panel routes per panel-bearing model. `render_panel_view`
+inspects the handler's return type: `HTMLResponse` is swapped inline,
+`StreamingResponse` is wrapped in an `<iframe>` whose `src` points to
+`stream_panel_view`. Both routes re-check permission. Ship the bundled
+`PDFStreamPanel` factory in `hyperadmin.panels`.
+
+**Spec:** [`docs/specs/detail-panels.md`](../../../../docs/specs/detail-panels.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/views/dynamic.py` — add both panel views, register routes
+- **New:** `src/hyperadmin/panels/__init__.py` — re-exports
+- **New:** `src/hyperadmin/panels/pdf.py` — `pdf_stream_panel` factory
+- **Modified:** `tests/unit/test_dynamic_views.py` — panel-view tests
+
+## Scenarios
+
+```
+Scenario: render_panel_view returns 404 for unknown slug
+  When  GET /admin/orders/1/panels/missing
+  Then  response is 404 with detail "Unknown panel"
+
+Scenario: HTMLResponse handler returns fragment inline
+  Given a panel handler returning HTMLResponse(content="<p>ok</p>")
+  When  GET /admin/orders/1/panels/x
+  Then  response body is "<p>ok</p>" and content-type is text/html
+
+Scenario: StreamingResponse handler returns iframe wrapper
+  Given a panel handler returning a StreamingResponse
+  When  GET /admin/orders/1/panels/x
+  Then  response body contains "<iframe" with src ending in "/panels/x/stream"
+
+Scenario: stream_panel_view streams the bytes with inline disposition
+  Given the same handler
+  When  GET /admin/orders/1/panels/x/stream
+  Then  response Content-Disposition is "inline"
+  And   body bytes equal the handler's stream
+
+Scenario: permission codename gates panel access
+  Given user lacks "view_order_panel_invoice"
+  When  GET /admin/orders/1/panels/invoice
+  Then  response is 403
+```
+
+## Acceptance Criteria
+
+- [ ] `render_panel_view` and `stream_panel_view` registered
+- [ ] StreamingResponse detection wraps in iframe with correct `src`
+- [ ] HTMLResponse swapped inline
+- [ ] Per-panel permission enforced; default codename applied when override absent
+- [ ] `pdf_stream_panel` factory in `hyperadmin.panels` returns a `PanelDef`
+- [ ] 5 scenarios pass at unit-test level
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `featcore-add-panel-registry`
+
+## Parent
+
+- Epic: `epic-v056-detail-panels`

--- a/.meta/epics/epic-v056-detail-panels/stories/reviewspec-approve-sdd-detail-panels.md
+++ b/.meta/epics/epic-v056-detail-panels/stories/reviewspec-approve-sdd-detail-panels.md
@@ -1,0 +1,43 @@
+---
+type: story
+id: st-v056-dp-00
+title: "review(spec): approve SDD for detail panels"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - needs-human
+  - upstream-readiness
+  - H4
+estimate: null
+epic_ref:
+  id: ep-v056-dp-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+**Human gate** — review and approve `docs/specs/detail-panels.md` before
+implementation sub-tasks may start.
+
+## Checklist
+
+- [ ] H4 scope (registry + tabbed layout + PDF demo) — confirmed correct
+- [ ] History/Transitions panel content excluded — confirmed correct
+- [ ] BDD scenarios cover happy + streaming + forbidden + collision paths
+- [ ] Backward compatible (no `panels` → renders unchanged `detail.html`)
+- [ ] Default permission codename scheme acceptable
+- [ ] Open Questions resolved (handler signature, package naming, `enabled` predicate)
+
+## Open Questions to resolve
+
+1. Pass `obj` to panel handlers or only `request, item_id`?
+2. `hyperadmin.panels` package vs `hyperadmin.panels.streams`?
+3. Add `PanelDef.enabled: Callable[[Any], bool] | None` for instance-scoped visibility?
+
+## Parent
+
+- Epic: `epic-v056-detail-panels`

--- a/.meta/epics/epic-v056-filter-library/epic.md
+++ b/.meta/epics/epic-v056-filter-library/epic.md
@@ -1,0 +1,80 @@
+---
+type: epic
+id: ep-v056-fl-01
+title: "epic(filters): filter library with saved views"
+status: todo
+priority: high
+owner: null
+labels:
+  - size:L
+  - planned
+  - backend
+  - frontend
+  - upstream-readiness
+  - H12
+milestone_ref:
+  id: v056-dpfl-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Overview
+
+Implements upstream readiness capability **H12**: new
+`src/hyperadmin/filters/` package with six built-in filters
+(`DateRangeFilter`, `MultiFKFilter`, `MultiChoiceFilter`, `BooleanFilter`,
+`IsOwnerFilter`, `CurrentPeriodDefault`); querystring-state HTMX list view
+with `<tbody>` swap and `HX-Push-Url`; per-user saved views persisted in a
+new `hyperadmin_saved_view` table. Backward compatible with the legacy
+`list_filter: list[str]` syntax.
+
+**SDD:** [`docs/specs/filter-library.md`](../../../docs/specs/filter-library.md)
+(required — new top-level module + new DB table).
+
+## Tracks
+
+### Track A: Filter package (core)
+- `filters/base.py` — `FilterDef` protocol, render/parse/apply hooks.
+- `filters/date.py`, `filters/relation.py`, `filters/choice.py`, `filters/boolean.py` — six concrete filters.
+- `core/filters_compat.py` — adapter that wraps legacy string entries.
+- `AdminOptions.list_filter` widened to `list[FilterDef | str]`.
+
+### Track B: List view + saved views (views + storage)
+- `views/dynamic.py:list_view` passes filter sidebar context; applies filters in order.
+- HTMX-aware `<tbody>` swap with `HX-Push-Url`.
+- `SavedView` SQLModel + Alembic migration (`hyperadmin_saved_view`).
+- Saved-view endpoints (GET/POST/DELETE), scoped to `request.user.id`.
+
+### Track C: Templates + E2E (frontend)
+- `templates/components/filter_sidebar.html` and `saved_views.html`.
+- `templates/list.html` — sidebar slot.
+- `data-testid`: `filter-{slug}`, `filter-{slug}-gte`, `filter-{slug}-lte`, `saved-view-{id}`, `save-view-btn`.
+- E2E covering all eight scenarios in the SDD.
+
+## Scenarios
+
+See SDD `## BDD Scenarios` (eight scenarios: legacy compat, DateRange render,
+HTMX swap, IsOwner, CurrentPeriodDefault, saved-view create/load, cross-user
+isolation).
+
+## Acceptance Criteria
+
+- [ ] `filters/` package with six built-in filters
+- [ ] `FilterDef` protocol with render/parse/apply hooks
+- [ ] Legacy `list[str]` config still works (no breaking change)
+- [ ] HTMX `<tbody>` swap with `HX-Push-Url`
+- [ ] `hyperadmin_saved_view` table created via Alembic
+- [ ] Saved-view endpoints scoped to current user (no cross-user leakage)
+- [ ] `IsOwnerFilter` reuses `ObjectPermissionChecker`
+- [ ] `CurrentPeriodDefault` redirects to canonical URL on first load
+- [ ] Eight E2E scenarios pass
+- [ ] `poe lint` and `poe test` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-filter-library`
+
+## Parent
+
+- Milestone: `v056-detail-panels-filter-library`
+- Tracking: `epic-upstream-readiness` (H12)

--- a/.meta/epics/epic-v056-filter-library/stories/featfilters-add-package-with-six-filters.md
+++ b/.meta/epics/epic-v056-filter-library/stories/featfilters-add-package-with-six-filters.md
@@ -1,0 +1,77 @@
+---
+type: story
+id: st-v056-fl-01
+title: "feat(filters): new package with six built-in filters and FilterDef protocol"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - upstream-readiness
+  - H12
+estimate: null
+epic_ref:
+  id: ep-v056-fl-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Add the `src/hyperadmin/filters/` package with `FilterDef` protocol and six
+concrete filters. Widen `AdminOptions.list_filter` to `list[FilterDef | str]`
+and add a compat shim that wraps legacy strings into a generic exact-match
+`FilterDef`.
+
+**Spec:** [`docs/specs/filter-library.md`](../../../../docs/specs/filter-library.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/filters/__init__.py`
+- **New:** `src/hyperadmin/filters/base.py` — `FilterDef`, `FilterRenderContext`
+- **New:** `src/hyperadmin/filters/date.py` — `DateRangeFilter`, `CurrentPeriodDefault`
+- **New:** `src/hyperadmin/filters/relation.py` — `MultiFKFilter`
+- **New:** `src/hyperadmin/filters/choice.py` — `MultiChoiceFilter`
+- **New:** `src/hyperadmin/filters/boolean.py` — `BooleanFilter`, `IsOwnerFilter`
+- **New:** `src/hyperadmin/core/filters_compat.py` — legacy `str → FilterDef` adapter
+- **Modified:** `src/hyperadmin/core/options.py` — widen `list_filter` type
+- **New:** `tests/unit/test_filters.py`
+
+## Scenarios
+
+```
+Scenario: legacy list_filter=["status"] is wrapped into a FilterDef
+  Given AdminOptions(list_filter=["status"])
+  When  the list view collects filters
+  Then  filters[0] is an instance of FilterDef
+  And   filters[0].field == "status"
+
+Scenario: DateRangeFilter.parse extracts gte/lte from querystring
+  Given DateRangeFilter(field="created_at")
+  When  parse({"created_at__gte": "2026-01-01", "created_at__lte": "2026-01-31"}) is called
+  Then  the result is {"gte": date(2026,1,1), "lte": date(2026,1,31)}
+
+Scenario: IsOwnerFilter with anonymous user applies nothing
+  Given IsOwnerFilter(owner_field="created_by") and request.user is None
+  When  apply(query, parsed={"is_owner": True}) is called
+  Then  the query is returned unchanged
+```
+
+## Acceptance Criteria
+
+- [ ] Six filter classes implemented per SDD signatures
+- [ ] `FilterDef` protocol with `render`, `parse`, `apply` hooks
+- [ ] Legacy `str` entries wrapped via `core/filters_compat.py`
+- [ ] `AdminOptions.list_filter` widened (backward compatible)
+- [ ] Unit tests cover all three scenarios + per-filter parse/apply behaviour
+- [ ] `poe lint` passes
+
+## Blocked by
+
+- `reviewspec-approve-sdd-filter-library`
+
+## Parent
+
+- Epic: `epic-v056-filter-library`

--- a/.meta/epics/epic-v056-filter-library/stories/feattemplates-sidebar-and-e2e.md
+++ b/.meta/epics/epic-v056-filter-library/stories/feattemplates-sidebar-and-e2e.md
@@ -1,0 +1,76 @@
+---
+type: story
+id: st-v056-fl-03
+title: "feat(templates+e2e): filter sidebar, saved views panel, E2E suite"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - frontend
+  - tests
+  - upstream-readiness
+  - H12
+estimate: null
+epic_ref:
+  id: ep-v056-fl-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Render the filter sidebar and saved-views panel in `list.html`. Provide the
+`data-testid` set the SDD requires; cover all eight SDD scenarios in
+Playwright.
+
+**Spec:** [`docs/specs/filter-library.md`](../../../../docs/specs/filter-library.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/templates/components/filter_sidebar.html`
+- **New:** `src/hyperadmin/templates/components/saved_views.html`
+- **Modified:** `src/hyperadmin/templates/list.html` — sidebar slot
+- **New:** `tests/e2e/test_filter_library.py`
+
+## data-testid Reference
+
+| Element | testid |
+|---|---|
+| Sidebar root | `filter-sidebar` |
+| Individual filter widget | `filter-{slug}` |
+| Date range gte / lte inputs | `filter-{slug}-gte`, `filter-{slug}-lte` |
+| Multi-FK / multi-choice option | `filter-{slug}-option-{value}` |
+| Apply button | `filter-apply-btn` |
+| Save current view button | `save-view-btn` |
+| Saved-view link | `saved-view-{id}` |
+| Saved-view delete | `saved-view-delete-{id}` |
+
+## Scenarios → Tests
+
+| Scenario | Test function |
+|---|---|
+| legacy string list_filter still classifies fields | `test_legacy_string_list_filter_classifies` |
+| explicit DateRangeFilter renders two date inputs | `test_daterange_filter_renders_two_inputs` |
+| applying a filter swaps only the table body | `test_applying_filter_swaps_tbody_with_push_url` |
+| IsOwnerFilter restricts to objects the user owns | `test_isowner_filter_restricts_to_owned_rows` |
+| CurrentPeriodDefault preselects the current month on first load | `test_current_period_default_redirects_on_first_load` |
+| saving the current filter set creates a SavedView row | `test_save_current_view_creates_row` |
+| loading a saved view applies its querystring | `test_loading_saved_view_applies_querystring` |
+| another user does not see alice's saved views | `test_saved_views_are_scoped_per_user` |
+
+## Acceptance Criteria
+
+- [ ] Sidebar + saved-views partials match the `data-testid` table
+- [ ] All eight scenarios covered with G/W/T comments
+- [ ] `poe test:e2e -k filter_library` passes locally and in CI
+- [ ] Visual snapshot baseline updated
+
+## Blocked by
+
+- `featviews-list-htmx-swap-and-saved-views`
+
+## Parent
+
+- Epic: `epic-v056-filter-library`

--- a/.meta/epics/epic-v056-filter-library/stories/featviews-list-htmx-swap-and-saved-views.md
+++ b/.meta/epics/epic-v056-filter-library/stories/featviews-list-htmx-swap-and-saved-views.md
@@ -1,0 +1,86 @@
+---
+type: story
+id: st-v056-fl-02
+title: "feat(views): HTMX tbody swap, saved-view endpoints, SavedView table"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:L
+  - planned
+  - backend
+  - upstream-readiness
+  - H12
+estimate: null
+epic_ref:
+  id: ep-v056-fl-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Wire filters into `list_view`. When the request is HTMX, return only the
+`<tbody>` fragment and emit `HX-Push-Url` so the URL stays in sync with the
+filter state. Add the `SavedView` SQLModel + Alembic migration, plus three
+saved-view endpoints scoped to the current user.
+
+**Spec:** [`docs/specs/filter-library.md`](../../../../docs/specs/filter-library.md)
+
+## Files to Change
+
+- **Modified:** `src/hyperadmin/views/dynamic.py` — `list_view` filter pipeline + HTMX swap + saved-view endpoints
+- **New:** `src/hyperadmin/filters/saved_views.py` — `SavedView` SQLModel + service
+- **New:** `migrations/versions/{rev}_add_hyperadmin_saved_view.py` — Alembic forward-only
+- **Modified:** `src/hyperadmin/core/options.py` — `saved_views_enabled: bool = True`
+- **Modified:** `tests/unit/test_dynamic_views.py` — list-view filter + saved-view coverage
+
+## Scenarios
+
+```
+Scenario: HTMX list request returns tbody fragment with HX-Push-Url
+  Given DateRangeFilter and request HX-Request: true
+  When  GET /admin/orders/?created_at__gte=2026-01-01
+  Then  response body starts with "<tbody"
+  And   HX-Push-Url header is "/admin/orders/?created_at__gte=2026-01-01"
+
+Scenario: POST /saved-views creates a row for the current user
+  Given alice is authenticated
+  When  POST /admin/orders/saved-views with name="Late this month" and querystring="?status=late"
+  Then  a SavedView row exists with (user_id=alice.id, model="order", name="Late this month")
+
+Scenario: GET /saved-views returns only the user's own rows
+  Given alice has 2 saved views and bob has 1
+  When  bob requests GET /admin/orders/saved-views
+  Then  the response contains only bob's row
+
+Scenario: DELETE /saved-views/{id} fails for non-owner
+  Given alice has saved view id=42
+  When  bob issues DELETE /admin/orders/saved-views/42
+  Then  response is 404
+
+Scenario: CurrentPeriodDefault redirects on first load
+  Given CurrentPeriodDefault(field="created_at", period="month") and no querystring
+  When  GET /admin/orders/
+  Then  response includes HX-Push-Url with ?created_at__gte=<first of month>&created_at__lte=<today>
+```
+
+## Acceptance Criteria
+
+- [ ] Filter pipeline applies all configured filters in order
+- [ ] HTMX request → `<tbody>` fragment + `HX-Push-Url`
+- [ ] Non-HTMX request → full page render
+- [ ] `SavedView` table created via Alembic migration
+- [ ] Three saved-view endpoints (list/create/delete) scoped to `request.user.id`
+- [ ] DB unique constraint `(user_id, model, name)`
+- [ ] `CurrentPeriodDefault` redirect on first load implemented
+- [ ] Unit tests for all five scenarios
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `featfilters-add-package-with-six-filters`
+
+## Parent
+
+- Epic: `epic-v056-filter-library`

--- a/.meta/epics/epic-v056-filter-library/stories/reviewspec-approve-sdd-filter-library.md
+++ b/.meta/epics/epic-v056-filter-library/stories/reviewspec-approve-sdd-filter-library.md
@@ -1,0 +1,44 @@
+---
+type: story
+id: st-v056-fl-00
+title: "review(spec): approve SDD for filter library"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - needs-human
+  - upstream-readiness
+  - H12
+estimate: null
+epic_ref:
+  id: ep-v056-fl-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+**Human gate** — review and approve `docs/specs/filter-library.md` before
+implementation sub-tasks may start.
+
+## Checklist
+
+- [ ] Six built-in filters cover the H12 acceptance check
+- [ ] `filters/` as a top-level module (not under `core/`) — boundary acceptable
+- [ ] Legacy `list[str]` retained — backward compatible
+- [ ] `hyperadmin_saved_view` schema acceptable; Alembic forward-only migration acceptable
+- [ ] Per-user scoping policy correct (no shared views in v0.5.6)
+- [ ] HTMX swap of `<tbody>` (not full list) — confirmed
+- [ ] Open Questions resolved (multi-owner-field, redirect strategy, sidebar load)
+
+## Open Questions to resolve
+
+1. `IsOwnerFilter` — single or multi owner fields?
+2. `CurrentPeriodDefault` — redirect with `HX-Push-Url` or hidden inputs only?
+3. Saved-views sidebar — render server-side or HTMX-load?
+
+## Parent
+
+- Epic: `epic-v056-filter-library`

--- a/.meta/epics/epic-v057-permissions-matrix/epic.md
+++ b/.meta/epics/epic-v057-permissions-matrix/epic.md
@@ -1,0 +1,81 @@
+---
+type: epic
+id: ep-v057-pmx-01
+title: "epic(permissions): tabular permission-matrix UI + examples/full-demo umbrella"
+status: todo
+priority: high
+owner: null
+labels:
+  - size:L
+  - planned
+  - backend
+  - frontend
+  - upstream-readiness
+  - H20
+milestone_ref:
+  id: v057-pmx-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Overview
+
+Implements upstream readiness capability **H20**: tabular model × action grid
+editor for groups, integrated object-permission popover, optimistic-
+concurrency bulk save, per-cell audit logging. Also bundles
+`examples/full-demo/` — the umbrella app that runs every H# qualification
+check end-to-end.
+
+**SDD:** [`docs/specs/permission-matrix-ui.md`](../../../docs/specs/permission-matrix-ui.md)
+(required — new view module, schema change, multi-module integration).
+
+## Tracks
+
+### Track A: Matrix data layer (permissions/)
+- `permissions/matrix.py` — load grid, compute diff, save with version check.
+- `permissions/audit.py` — reuse v0.5.1 audit writer.
+- `Group.permissions_version` column + Alembic migration.
+
+### Track B: View module + routes
+- `views/permissions_matrix.py` — grid, save, object popover, conflict (409).
+- Permission gate via `permissions_matrix_codename`.
+- Disable switch via `permissions_matrix_enabled`.
+
+### Track C: Templates + UX
+- `templates/permissions/matrix.html`, `object_popover.html`, `_diff_row.html`.
+- Select-all column toggle, group dropdown, save bar with conflict banner.
+- `data-testid`: `pmatrix-cell-{model}-{codename}`, `pmatrix-save-btn`,
+  `pmatrix-group-select`, `pmatrix-conflict-banner`, `pmatrix-object-cell-{model}`.
+
+### Track D: `examples/full-demo/` umbrella + E2E qualification
+- Generic schema: `Order`, `Invoice`, `Product`, `Supplier`.
+- One bundled E2E suite that exercises **every H#** in sequence.
+- Becomes the readiness gate from this milestone onward.
+
+## Scenarios
+
+See SDD `## BDD Scenarios` (seven scenarios: matrix load, diff save,
+conflict, object popover, gate, audit log, detail-page reflection).
+
+## Acceptance Criteria
+
+- [ ] `Group.permissions_version` migration applies cleanly
+- [ ] Matrix loads with current grid for the selected group
+- [ ] Save sends diff-only payload (`{group_id, version, changes:[...]}`)
+- [ ] Optimistic-concurrency 409 on version mismatch
+- [ ] Object popover lists per-row perms and supports add/remove
+- [ ] Permission codename gates access (default `change_groups_permissions`)
+- [ ] Audit row written per (group, model, codename, before, after)
+- [ ] `examples/full-demo/` runs the 10-step qualification check via `poe test:e2e -k qualification`
+- [ ] Seven SDD scenarios pass
+- [ ] `poe lint` and `poe test` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-permission-matrix-ui`
+- All prior upstream-readiness epics (the umbrella demo requires every H# in place)
+
+## Parent
+
+- Milestone: `v057-permissions-matrix`
+- Tracking: `epic-upstream-readiness` (H20)

--- a/.meta/epics/epic-v057-permissions-matrix/stories/featexamples-full-demo-umbrella.md
+++ b/.meta/epics/epic-v057-permissions-matrix/stories/featexamples-full-demo-umbrella.md
@@ -1,0 +1,76 @@
+---
+type: story
+id: st-v057-pmx-04
+title: "feat(examples): full-demo umbrella app + qualification E2E suite"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:L
+  - planned
+  - examples
+  - tests
+  - upstream-readiness
+estimate: null
+epic_ref:
+  id: ep-v057-pmx-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Ship `examples/full-demo/` — the umbrella example app exercising every H#
+capability with framework-neutral domain models (`Order`, `Invoice`,
+`Product`, `Supplier`). Per-feature `examples/<name>/` apps remain. Add a
+`poe test:e2e -k qualification` suite that runs the ten readiness checks
+end-to-end against the umbrella app; this becomes the readiness gate.
+
+**Spec:** [`docs/specs/permission-matrix-ui.md`](../../../../docs/specs/permission-matrix-ui.md)
+(only as the umbrella-bundle decision lives here)
+
+## Files to Change
+
+- **New:** `examples/full-demo/main.py`
+- **New:** `examples/full-demo/models.py` — `Order`, `Invoice`, `Product`, `Supplier` (generic)
+- **New:** `examples/full-demo/admins.py` — `OrderAdmin`, `InvoiceAdmin`, etc.
+- **New:** `examples/full-demo/seed.py`
+- **New:** `examples/full-demo/static/sample.pdf` — for the H4 PDF panel demo
+- **New:** `tests/e2e/test_qualification.py` — ten checks per `epic-upstream-readiness` epic body
+- **Modified:** `pyproject.toml` — `poe test:e2e:qualification` task
+
+## Scenarios → Qualification Checks
+
+Each check maps directly to one row in `epic-upstream-readiness`'s
+acceptance list:
+
+| # | Capability | Test function |
+|---|---|---|
+| 1 | H2 polish (row error highlight) | `test_h2_inline_row_error_highlight` |
+| 2 | H3 bulk action 5 rows, 1 fails | `test_h3_bulk_action_per_row_outcome` |
+| 3 | H4 detail panels w/ PDF demo | `test_h4_detail_panels_with_pdf` |
+| 4 | H5 IsOwnerFilter | `test_h5_list_filter_by_owner` |
+| 5 | H6 dependent FK + popup | `test_h6_dependent_fk_autocomplete_and_popup` |
+| 6 | H12 sidebar + saved view | `test_h12_filter_sidebar_and_saved_view` |
+| 7 | H13 JPEG upload thumbnail | `test_h13_jpeg_upload_thumbnail` |
+| 8 | H14 OLAP report + CSV/XLSX | `test_h14_olap_report_csv_xlsx` |
+| 9 | H15 chart bound to dataset | `test_h15_chart_bound_to_report` |
+| 10 | H20 matrix flip view-but-not-edit | `test_h20_matrix_flips_view_not_edit` |
+
+## Acceptance Criteria
+
+- [ ] `uv run examples/full-demo/main.py` boots without errors
+- [ ] Generic schema only — no consumer-specific names (per project rule)
+- [ ] Per-feature `examples/<name>/` apps remain untouched
+- [ ] All ten qualification tests pass on develop
+- [ ] `poe test:e2e:qualification` defined and wired into CI
+- [ ] README under `examples/full-demo/` documents the boot + qualification flow
+
+## Blocked by
+
+- `feattemplates-matrix-and-popover`
+- All prior upstream-readiness epics
+
+## Parent
+
+- Epic: `epic-v057-permissions-matrix`

--- a/.meta/epics/epic-v057-permissions-matrix/stories/featpermissions-matrix-data-layer.md
+++ b/.meta/epics/epic-v057-permissions-matrix/stories/featpermissions-matrix-data-layer.md
@@ -1,0 +1,76 @@
+---
+type: story
+id: st-v057-pmx-01
+title: "feat(permissions): matrix data layer + Group.permissions_version migration"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - upstream-readiness
+  - H20
+estimate: null
+epic_ref:
+  id: ep-v057-pmx-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Add `permissions/matrix.py` with three functions — `load_grid(group_id)`,
+`compute_diff(current, submitted)`, `save_diff(group_id, version, changes)` —
+plus the `Group.permissions_version` column and forward-only Alembic
+migration. `save_diff` is atomic and bumps the version.
+
+**Spec:** [`docs/specs/permission-matrix-ui.md`](../../../../docs/specs/permission-matrix-ui.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/permissions/__init__.py`
+- **New:** `src/hyperadmin/permissions/matrix.py`
+- **Modified:** `src/hyperadmin/core/auth.py` — `Group.permissions_version` field
+- **New:** `migrations/versions/{rev}_add_group_permissions_version.py`
+- **New:** `tests/unit/test_permissions_matrix.py`
+
+## Scenarios
+
+```
+Scenario: load_grid returns one entry per registered model × action
+  Given Editors group and registered models [Order, Invoice]
+  When  load_grid("Editors") is called
+  Then  the result has 2 × 4 cells (view/add/change/delete) per model
+  And   each cell carries (granted: bool, codename: str)
+
+Scenario: save_diff with matching version commits and bumps
+  Given Editors.permissions_version == 5
+  When  save_diff("Editors", version=5, changes=[{model:"order", codename:"change_order", granted:false}])
+  Then  the change_order permission for Editors is removed
+  And   Editors.permissions_version == 6
+
+Scenario: save_diff with stale version raises ConflictError
+  Given Editors.permissions_version == 6
+  When  save_diff("Editors", version=5, changes=[...])
+  Then  ConflictError is raised
+  And   no permission rows are mutated
+```
+
+## Acceptance Criteria
+
+- [ ] `Group.permissions_version` added with default 0
+- [ ] Alembic migration applies cleanly (up + down)
+- [ ] `load_grid`, `compute_diff`, `save_diff` implemented
+- [ ] `save_diff` is transactional and bumps the version atomically
+- [ ] `ConflictError` raised on version mismatch
+- [ ] Unit tests cover all three scenarios
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `reviewspec-approve-sdd-permission-matrix-ui`
+
+## Parent
+
+- Epic: `epic-v057-permissions-matrix`

--- a/.meta/epics/epic-v057-permissions-matrix/stories/feattemplates-matrix-and-popover.md
+++ b/.meta/epics/epic-v057-permissions-matrix/stories/feattemplates-matrix-and-popover.md
@@ -1,0 +1,67 @@
+---
+type: story
+id: st-v057-pmx-03
+title: "feat(templates): matrix grid, object popover, conflict banner"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - frontend
+  - upstream-readiness
+  - H20
+estimate: null
+epic_ref:
+  id: ep-v057-pmx-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Render the matrix grid, the object-permission popover, and the conflict
+banner. Include a per-column "select all" toggle. Keep tests accessibility-
+first.
+
+**Spec:** [`docs/specs/permission-matrix-ui.md`](../../../../docs/specs/permission-matrix-ui.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/templates/permissions/matrix.html`
+- **New:** `src/hyperadmin/templates/permissions/object_popover.html`
+- **New:** `src/hyperadmin/templates/permissions/_diff_row.html`
+- **Modified:** `src/hyperadmin/templates/_sidebar.html` — link to the matrix when enabled
+
+## data-testid Reference
+
+| Element | testid |
+|---|---|
+| Group dropdown | `pmatrix-group-select` |
+| Cell checkbox | `pmatrix-cell-{model}-{codename}` |
+| Column "select all" | `pmatrix-select-all-{codename}` |
+| Save button | `pmatrix-save-btn` |
+| Conflict banner | `pmatrix-conflict-banner` |
+| Object column trigger | `pmatrix-object-cell-{model}` |
+| Object popover entry | `pmatrix-object-entry-{id}` |
+| Object popover Add | `pmatrix-object-add` |
+
+## Acceptance Criteria
+
+- [ ] Grid renders per the SDD shape (rows = models, cols = actions + object)
+- [ ] Group dropdown swaps the grid via HTMX without page reload
+- [ ] Save button posts the diff payload (changed cells only)
+- [ ] Conflict banner appears on 409 with a "Reload" affordance
+- [ ] Object popover loads via `hx-get` and supports Add / Remove
+- [ ] Per-column "select all" toggles every cell in that column
+- [ ] `data-testid` exports match the table above
+- [ ] Visual snapshots committed
+- [ ] `poe lint` passes
+
+## Blocked by
+
+- `featviews-matrix-routes-and-audit`
+
+## Parent
+
+- Epic: `epic-v057-permissions-matrix`

--- a/.meta/epics/epic-v057-permissions-matrix/stories/featviews-matrix-routes-and-audit.md
+++ b/.meta/epics/epic-v057-permissions-matrix/stories/featviews-matrix-routes-and-audit.md
@@ -1,0 +1,80 @@
+---
+type: story
+id: st-v057-pmx-02
+title: "feat(views): matrix routes, conflict handling, audit log integration"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:M
+  - planned
+  - backend
+  - upstream-readiness
+  - H20
+estimate: null
+epic_ref:
+  id: ep-v057-pmx-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+Add `views/permissions_matrix.py` with five routes (grid load, save, object
+GET, object POST, conflict-banner fragment). Wire audit-log entries per
+diff cell (reusing the v0.5.1 audit writer). Permission gate via
+`permissions_matrix_codename`. Disable via `permissions_matrix_enabled=False`.
+
+**Spec:** [`docs/specs/permission-matrix-ui.md`](../../../../docs/specs/permission-matrix-ui.md)
+
+## Files to Change
+
+- **New:** `src/hyperadmin/views/permissions_matrix.py`
+- **Modified:** `src/hyperadmin/core/app.py` — register the matrix routes when enabled
+- **Modified:** `src/hyperadmin/core/options.py` — `permissions_matrix_codename`, `permissions_matrix_enabled`
+- **New:** `tests/unit/test_permissions_matrix_views.py`
+
+## Scenarios
+
+```
+Scenario: save returns 200 with HX-Trigger when version matches
+  Given the user has change_groups_permissions and version=5
+  When  POST /admin/permissions-matrix/save with diff and version=5
+  Then  response is 200 and HX-Trigger header is "permissions-saved"
+
+Scenario: save returns 409 when version is stale
+  When  POST with version=4 while current is 5
+  Then  response is 409 and body contains "Permissions changed elsewhere"
+
+Scenario: matrix gated by permissions_matrix_codename
+  Given user lacks "change_groups_permissions"
+  When  GET /admin/permissions-matrix/
+  Then  response is 403
+
+Scenario: audit log is written per diff cell on save
+  Given a save diff of 3 cells
+  When  the save commits
+  Then  3 audit rows exist with action="permission_change" and matching payloads
+
+Scenario: matrix disabled at config returns 404
+  Given AdminOptions(permissions_matrix_enabled=False)
+  When  GET /admin/permissions-matrix/
+  Then  response is 404
+```
+
+## Acceptance Criteria
+
+- [ ] Five routes registered behind the matrix-codename gate
+- [ ] Save returns 200 / 409 / 403 per scenarios
+- [ ] Audit log row per diff cell
+- [ ] `permissions_matrix_enabled=False` disables the route
+- [ ] Unit tests cover all five scenarios
+- [ ] `poe lint` and `poe test:unit` pass
+
+## Blocked by
+
+- `featpermissions-matrix-data-layer`
+
+## Parent
+
+- Epic: `epic-v057-permissions-matrix`

--- a/.meta/epics/epic-v057-permissions-matrix/stories/reviewspec-approve-sdd-permission-matrix-ui.md
+++ b/.meta/epics/epic-v057-permissions-matrix/stories/reviewspec-approve-sdd-permission-matrix-ui.md
@@ -1,0 +1,44 @@
+---
+type: story
+id: st-v057-pmx-00
+title: "review(spec): approve SDD for permission-matrix UI"
+status: todo
+priority: high
+assignee: null
+labels:
+  - size:S
+  - planned
+  - needs-human
+  - upstream-readiness
+  - H20
+estimate: null
+epic_ref:
+  id: ep-v057-pmx-01
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+## Summary
+
+**Human gate** — review and approve `docs/specs/permission-matrix-ui.md`
+before implementation sub-tasks may start.
+
+## Checklist
+
+- [ ] H20 scope (model × action grid + object column + bulk save + audit)
+- [ ] Standalone view module (not a `ModelAdmin`) — boundary acceptable
+- [ ] `Group.permissions_version` schema addition acceptable
+- [ ] Optimistic concurrency strategy (per-group version) acceptable
+- [ ] Object permission popover (not modal / drawer) — confirmed
+- [ ] Bundling `examples/full-demo/` here — confirmed (or move to a separate epic?)
+- [ ] Open Questions resolved (groups-only vs roles, CSRF, select-all)
+
+## Open Questions to resolve
+
+1. Ship roles in v0.5.7 or groups-only?
+2. CSRF: rely on global middleware or per-save token?
+3. Add per-column "select all" toggle?
+
+## Parent
+
+- Epic: `epic-v057-permissions-matrix`

--- a/.meta/roadmap/milestones/v054-dashboard-builder.md
+++ b/.meta/roadmap/milestones/v054-dashboard-builder.md
@@ -1,7 +1,7 @@
 ---
 type: milestone
 id: 8DidH5NiN6cP
-title: v0.5.4 — Dashboard Builder
+title: v0.5.4 — Reporting & Charts
 status: in_progress
 github:
   milestone_id: 22
@@ -9,5 +9,19 @@ github:
   last_sync_hash: sha256:3ba2173be78db3e6aff2215a420cdcbde415e8c1df238076ede716c87e2712ed
   synced_at: 2026-04-07T17:23:23.788Z
 created_at: 2026-04-02T13:44:25Z
-updated_at: 2026-04-02T13:44:25Z
+updated_at: 2026-05-11T00:00:00Z
 ---
+
+H14 + H15 from upstream readiness — re-scoped from "Dashboard Builder" to
+match the framework-neutral capability vocabulary. New
+`src/hyperadmin/reports/` module: `ReportView`, declarative aggregates
+(`Sum`, `Count`, `StringAggComma`, `Min`, `Max`, `Many2One`), crosstab
+dimensions (one row group, N column groups), time-series bucketing
+(day / week / month / quarter / year auto), filter-form integration via
+H12, CSV / XLSX export, permission-aware via H5, cached materialisation
+hook so a fact table can back a `ReportView`. SVG bar/line/stacked-bar/pie
+components and an HTMX-loaded Chart.js widget bound to a `ReportView`
+dataset.
+
+Spec: `docs/specs/olap-reporting.md`, `docs/specs/chart-components.md`.
+Tracking: `.meta/epics/epic-upstream-readiness/` (H14, H15).

--- a/.meta/roadmap/milestones/v056-detail-panels-filter-library.md
+++ b/.meta/roadmap/milestones/v056-detail-panels-filter-library.md
@@ -1,0 +1,23 @@
+---
+type: milestone
+id: v056-dpfl-01
+title: v0.5.6 — Detail Panels & Filter Library
+status: planned
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+H4 + H12 from upstream readiness. Declarative `panels` registry on
+`AdminOptions` with a tabbed detail layout supporting `HTMLResponse` /
+`StreamingResponse` per panel (PDF-streaming demo included). New
+`src/hyperadmin/filters/` module with `DateRangeFilter`, `MultiFKFilter`,
+`MultiChoiceFilter`, `BooleanFilter`, `IsOwnerFilter`, `CurrentPeriodDefault`,
+plus URL-shareable querystring state, HTMX partial reload of the filtered
+list, and per-user named saved views (table `hyperadmin_saved_view`).
+
+Scope decision recorded in the H4 SDD: HyperAdmin ships the panel registry,
+tabbed detail layout, and a PDF-streaming demo panel. History/Transitions
+panel *content* remains an extension point exercised by downstream apps.
+
+Spec: `docs/specs/detail-panels.md`, `docs/specs/filter-library.md`.
+Tracking: `.meta/epics/epic-upstream-readiness/` (H4, H12).

--- a/.meta/roadmap/milestones/v057-permissions-matrix.md
+++ b/.meta/roadmap/milestones/v057-permissions-matrix.md
@@ -1,0 +1,18 @@
+---
+type: milestone
+id: v057-pmx-01
+title: v0.5.7 — Permissions Matrix
+status: planned
+created_at: 2026-05-11T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+---
+
+H20 from upstream readiness. Tabular model × action grid editor for groups
+and roles; object-permission column integrates with H5; bulk save with
+optimistic concurrency; audit logging for every edit. Last milestone in the
+readiness sequence — depends on H5 surface area being stable (shipped v0.5.1)
+and ships the `examples/full-demo/` umbrella so all ten qualification checks
+are reproducible.
+
+Spec: `docs/specs/permission-matrix-ui.md`.
+Tracking: `.meta/epics/epic-upstream-readiness/` (H20).

--- a/docs/specs/chart-components.md
+++ b/docs/specs/chart-components.md
@@ -1,0 +1,180 @@
+# SDD: Chart Components (`hyperadmin.widgets.charts`)
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD |
+| Milestone | v0.5.4 — Reporting & Charts |
+| Created | 2026-05-11 |
+| Last updated | 2026-05-11 |
+
+---
+
+## Problem
+
+The H15 upstream check requires a chart bound to the same OLAP dataset H14
+produces. HyperAdmin currently has no chart primitives. Consumers bolt on
+chart libraries inconsistently — some pull in Chart.js, others build SVG by
+hand, and dashboards diverge visually and behaviourally.
+
+We want a built-in surface that (a) keeps simple cases dependency-free
+(server-rendered SVG bar/line/stacked-bar/pie), (b) supports interactive
+charts via Chart.js when richer affordances are needed, and (c) binds
+declaratively to a `ReportView` from H14 so charts and tables share the same
+data path.
+
+## Goals
+
+- New module `src/hyperadmin/widgets/charts.py` with four SVG primitives:
+  `BarChart`, `LineChart`, `StackedBarChart`, `PieChart`.
+- A `Chart` widget that wraps a `ReportView` and renders either SVG (default,
+  no JS) or a Chart.js canvas (`mode="chartjs"`).
+- HTMX-loaded chart fragment so the same chart can appear standalone, inside
+  a detail panel (v0.5.6), or inside a future dashboard.
+- Accessibility: SVG charts carry `role="img"`, `<title>`, `<desc>`, and a
+  `<table>` data fallback collapsed under `<details>` for screen readers.
+- No new JavaScript build pipeline — Chart.js is loaded via the existing
+  vendored static asset slot (`templates/_base.html` already has a
+  `{% block extra_js %}`).
+
+## Non-Goals
+
+- A full dashboard composer. v0.5.4 ships chart primitives + per-report chart.
+  Composing several charts on one page is a thin consumer task (a Jinja
+  template iterating widgets).
+- Real-time / WebSocket-driven charts. Live updates land with the real-time
+  milestone (v0.6.0).
+- Custom theme system for charts. v0.5.4 uses the project's existing CSS
+  variables; full theme support is later.
+- Drill-down interactions (clicking a bar to filter the report). Deferred.
+- Map / geospatial charts. Out of scope.
+
+## BDD Scenarios
+
+```
+Scenario: SVG bar chart renders from a ReportView dataset
+  Given OrderRevenueReport with rows=[Group("sku")] values=[Sum("amount")]
+  And   a Chart(BarChart, report=OrderRevenueReport, mode="svg") widget
+  When  GET /admin/reports/orders-revenue/chart returns the widget fragment
+  Then  the body contains "<svg" with role="img" and aria-label "Orders revenue"
+  And   the bar count equals the distinct sku count
+
+Scenario: Chart.js mode renders a canvas with a data payload
+  Given the same widget with mode="chartjs"
+  When  the fragment renders
+  Then  the body contains "<canvas data-testid=\"chart-orders-revenue\">"
+  And   the body contains a <script type="application/json" data-chart-data=\"orders-revenue\"> with the dataset
+
+Scenario: stacked bar chart renders one stack per column dimension
+  Given the report has cols=[Group("status")] values=[Sum("amount")]
+  And   the chart type is StackedBarChart
+  When  the chart renders
+  Then  the SVG has one <g class="stack"> per distinct status
+  And   each bar's total equals SUM(amount) for that sku across all statuses
+
+Scenario: chart fragment lazy-loads via HTMX in a host template
+  Given a panel template referencing the chart with hx-get and hx-trigger="revealed once"
+  When  the host page renders
+  Then  the GET /admin/reports/orders-revenue/chart is NOT issued at first paint
+  And   the GET fires only when the chart container scrolls into view
+
+Scenario: SVG chart includes accessible data table fallback
+  When  the SVG fragment renders
+  Then  the body contains a <details data-testid="chart-data-table-orders-revenue"> with a <table> of (label, value) rows
+  And   the table is in DOM order after the SVG so screen readers reach it
+
+Scenario: chart respects the report's filter context
+  Given the same chart and a CurrentPeriodDefault filter
+  When  the chart is requested with ?status=late
+  Then  the rendered bars reflect only the filtered subset
+  And   the dataset shape matches GET /admin/reports/orders-revenue/?status=late
+```
+
+## Design
+
+### Architecture
+
+```
+widgets/charts.py            — NEW: BarChart, LineChart, StackedBarChart, PieChart, Chart wrapper
+templates/widgets/charts/    — bar.svg.html, line.svg.html, stacked_bar.svg.html, pie.svg.html, chartjs.html
+templates/widgets/chart_fallback.html  — accessible <details><table>
+views/dynamic.py             — minor: chart fragment route on each ReportView ("/chart")
+static/vendor/chart-js/      — vendored chart.umd.js (small footprint, only loaded when mode="chartjs")
+```
+
+The `Chart` wrapper is a small Python class consumed by Jinja:
+
+```python
+class Chart:
+    def __init__(
+        self,
+        kind: type[BarChart | LineChart | StackedBarChart | PieChart],
+        *,
+        report: type[ReportView],
+        mode: Literal["svg", "chartjs"] = "svg",
+        title: str | None = None,
+        height: int = 280,
+    ): ...
+
+    def fragment_url(self) -> str: ...  # f"/admin/reports/{slug}/chart"
+```
+
+In templates, an admin author writes:
+
+```jinja
+{{ chart(BarChart, report=OrderRevenueReport, mode="chartjs") }}
+```
+
+…or, more typically, lets the report's auto-generated chart render via
+`{% include "widgets/charts/auto.html" %}` on the report detail page.
+
+### Data Model Changes
+
+No DB changes.
+
+### API / Protocol Changes
+
+- New chart-fragment route per `ReportView`:
+  `GET /admin/reports/{slug}/chart` → HTML fragment (SVG or Chart.js canvas).
+- `Chart` widget exported from `hyperadmin.widgets`.
+- Chart classes (`BarChart`, etc.) exported from `hyperadmin.widgets.charts`.
+
+### Configuration Changes
+
+`Admin()` gains `chart_mode: Literal["svg", "chartjs"] = "svg"` as the default
+when a report's chart doesn't specify one. No env var.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Report returns empty dataset | SVG renders an axis frame with "No data" label; Chart.js canvas renders empty axes |
+| `PieChart` with negative values | values clamped to 0 with a warning logged once per chart per process |
+| `StackedBarChart` with `cols=[]` | falls back to plain `BarChart` (logs once) |
+| Long category labels in SVG | truncated mid-character with ellipsis at a configurable width (default 18 chars) |
+| Chart.js mode requested but static asset missing | server-rendered SVG fallback rendered; log at WARNING |
+| HTMX request lazy-load with `revealed once` | endpoint serves fragment only on visible trigger; no eager prefetch |
+| Filter querystring passed through | forwarded to the underlying `ReportView` request unchanged |
+
+## Migration & Backward Compatibility
+
+Additive. No existing surface changes. The `chart_mode` default is `svg`, so
+existing reports (none yet exist) and admins that don't use charts pay zero
+cost.
+
+## Open Questions
+
+- [ ] Vendor Chart.js (UMD bundle, ~70KB gzip) or load from a public CDN? Proposal: vendor — air-gapped deployments matter; one extra file in `static/`.
+- [ ] Should the SVG palette use CSS variables for colours (`--ha-chart-1` … `--ha-chart-7`) or hard-code? Proposal: CSS variables — consumers can override without forking templates.
+- [ ] Should the data-table fallback be on by default or opt-in? Proposal: on by default — accessibility wins over visual purity.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Default to SVG, opt into Chart.js | No JS for the common case; interactivity available when needed | Chart.js for everything (bundle bloat); D3 (steeper API surface, build pipeline) |
+| Charts live under `widgets/` not `reports/` | They are presentation primitives reusable outside reports (e.g. a stat in a panel) | `reports/charts.py` (couples; can't reuse) |
+| Bind charts to a `ReportView` by class reference | Single source of truth — chart can't drift from the table | Bind to raw dataset / dict (fragile across changes) |
+| Vendor Chart.js (when mode="chartjs") | Predictable in air-gapped CI and on-prem | CDN (network dependency); custom canvas charts (too much work) |
+| Per-report `/chart` fragment route | Trivial HTMX integration; cacheable independently of the table | One mega route returning JSON consumed by browser JS (loses server-rendered SVG path) |

--- a/docs/specs/detail-panels.md
+++ b/docs/specs/detail-panels.md
@@ -1,0 +1,196 @@
+# SDD: Detail-page Panels & Tabbed Layout
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD |
+| Milestone | v0.5.6 — Detail Panels & Filter Library |
+| Created | 2026-05-11 |
+| Last updated | 2026-05-11 |
+
+---
+
+## Problem
+
+Today `detail_view` (`src/hyperadmin/views/dynamic.py:detail_view`) renders one
+template (`detail.html`) with a fixed `detail_fields` block. There is no way
+for an admin author to compose multiple, optionally-async sections under the
+same detail URL — e.g. "Invoice" (stream a PDF), "History" (custom rendered
+event log), "Transitions" (state-machine diagram). Downstream consumers always
+need at least one of those, and today they fork the detail template.
+
+The H4 upstream check requires HyperAdmin to ship the **panel registry +
+tabbed detail layout + one PDF-streaming demo panel**. Panel *content* for
+History / Transitions is intentionally an extension point — consumer apps
+register their own panels.
+
+## Goals
+
+- Declarative `panels: list[PanelDef]` on `AdminOptions` with a `@panel`
+  decorator counterpart for class-defined panels.
+- Tabbed detail layout that lazy-loads each panel's body via HTMX
+  (`hx-get` + `hx-trigger="revealed once"`).
+- Panel handlers may return `HTMLResponse` or `StreamingResponse` — the layout
+  embeds HTML; streaming responses redirect the tab body to a dedicated
+  download/inline URL (`Content-Disposition: inline`).
+- One bundled demo: a built-in `PDFStreamPanel` factory that streams a
+  static PDF stored in-tree, so the qualification check can exercise the
+  streaming path without consumer code.
+- Permission re-check per panel: `view_{model}_panel_{slug}` codename.
+
+## Non-Goals
+
+- WebSocket-driven live panels. Panels are HTTP fragments only.
+- Cross-model panels. A panel is attached to one `ModelAdmin`.
+- Editable panels. Panels are read-only in v0.5.6. Inline edit lives in its
+  own epic (`epic-inline-cell-editing`).
+- Persisted panel ordering per user. The order is whatever the admin author
+  declares.
+
+## BDD Scenarios
+
+```
+Scenario: detail page renders configured panel tabs
+  Given AdminOptions(panels=[PanelDef(slug="invoice", label="Invoice", handler=...)])
+  When  the user opens /admin/orders/42/
+  Then  the page has a tab strip with one tab "Invoice"
+  And   the tab's hx-get is "/admin/orders/42/panels/invoice"
+
+Scenario: panel body lazy-loads when its tab becomes visible
+  Given the same configuration
+  When  the user clicks the "Invoice" tab
+  Then  GET /admin/orders/42/panels/invoice is issued exactly once
+  And   the response body replaces the tab content area
+
+Scenario: streaming panel returns Content-Disposition inline
+  Given a PDF panel returning StreamingResponse with media_type="application/pdf"
+  When  the user clicks the tab
+  Then  the tab content is replaced with an <iframe src="/admin/orders/42/panels/invoice/stream">
+  And   GET on that stream URL returns "Content-Disposition: inline" and the PDF bytes
+
+Scenario: panel handler raising HTTPException(403) surfaces a forbidden body
+  Given a panel handler that raises HTTPException(403)
+  When  the user clicks the tab
+  Then  the tab body renders the standard 403 partial
+  And   sibling tabs remain functional
+
+Scenario: panel slug collision raises at registration
+  Given AdminOptions(panels=[PanelDef(slug="x", ...), PanelDef(slug="x", ...)])
+  When  the model is registered
+  Then  ValueError is raised: "duplicate panel slug 'x'"
+
+Scenario: permission codename gates panel access
+  Given user lacks "view_order_panel_invoice"
+  When  GET /admin/orders/42/panels/invoice is issued
+  Then  response is 403
+```
+
+## Design
+
+### Architecture
+
+Touched modules:
+
+```
+core/panels.py        — NEW: PanelDef dataclass, @panel decorator, registry helper
+core/options.py       — add panels: list[PanelDef] | None
+views/dynamic.py      — _resolve_panels(), render_panel_view, stream_panel_view, route registration
+templates/detail.html — tab strip + content slot
+templates/components/panel_tab_strip.html — NEW
+examples/full-demo/   — bundled PDF in tests/_fixtures/ to drive the streaming demo
+```
+
+No new top-level module — `panels` lives under `core/` next to `actions.py`.
+
+### Data Model Changes
+
+No DB tables. `PanelDef`:
+
+```python
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PanelDef:
+    slug: str
+    label: str
+    handler: Callable[..., Awaitable[Response]]
+    icon: str | None = None
+    permission: str | None = None   # default derived as f"view_{model}_panel_{slug}"
+```
+
+The `@panel(slug=..., label=...)` decorator marks a `ModelAdmin` method as a
+panel handler with the same semantics as `@action`.
+
+### API / Protocol Changes
+
+**New view methods on `DynamicModelView`:**
+
+```python
+async def render_panel_view(
+    self, request: Request, item_id: int, slug: str
+) -> Response: ...
+
+async def stream_panel_view(
+    self, request: Request, item_id: int, slug: str
+) -> Response: ...
+```
+
+Routes:
+
+```
+GET /{model}/{id}/panels/{slug}          → render_panel_view (HTML fragment)
+GET /{model}/{id}/panels/{slug}/stream   → stream_panel_view (binary stream)
+```
+
+The render view inspects the handler's return type. If the handler returns a
+`StreamingResponse`, the rendered fragment is `<iframe src=".../stream">` and
+the actual stream is served from the dedicated `/stream` sub-route on demand.
+
+`PDFStreamPanel` factory (bundled):
+
+```python
+def pdf_stream_panel(*, slug: str, label: str, path_resolver: Callable[[Any], Path]) -> PanelDef: ...
+```
+
+`path_resolver(instance) -> Path` returns the on-disk path; the factory wraps
+it in a `StreamingResponse` with `Content-Disposition: inline` and
+`media_type="application/pdf"`.
+
+### Configuration Changes
+
+`AdminOptions` gains `panels: list[PanelDef] | None = None`. When `None`, the
+existing `detail.html` renders unchanged — no tab strip, no extra routes.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Duplicate slug at registration | `ValueError("duplicate panel slug 'x'")` |
+| Slug not in registry | 404 with `"Unknown panel"` |
+| Handler raises HTTPException | propagate; HTMX swap shows the error fragment |
+| Handler returns non-`Response` | `TypeError` raised at request time, logged |
+| Streaming handler returns wrong media type | accepted; the iframe wrapper hands display to the browser |
+| Permission codename missing | derived default applied silently |
+| Item not found | 404 before any panel handler runs |
+| Multiple panels race-load | each is a separate request; no shared mutable state |
+
+## Migration & Backward Compatibility
+
+Backward compatible. Admins with no `panels` keep rendering `detail.html`
+exactly as before. The tab strip template only renders when `panels` is set.
+No database migration. `detail.html` gains a `{% if panels %}` guard around
+the new tab markup.
+
+## Open Questions
+
+- [ ] Should panel handlers receive the loaded instance (`obj: Any`) directly, or only `request, item_id` like `@action`? Proposal: pass `obj` — saves every panel re-fetching, matches Django's `ModelAdmin.get_object()` ergonomics.
+- [ ] Should the bundled `PDFStreamPanel` ship in `hyperadmin.panels.streams` or directly under `hyperadmin`? Proposal: `hyperadmin.panels` namespace (new package re-exported from `hyperadmin.__init__`).
+- [ ] Should panels support an `enabled` predicate `(obj) -> bool` so a tab disappears for instances in the wrong state (e.g. an unpaid order has no Invoice tab)? Proposal: yes — `PanelDef.enabled: Callable[[Any], bool] | None`.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Lazy-load each tab via HTMX | Detail page stays fast; panel handlers can do expensive work without blocking initial render | Render all panels server-side up front; preload only the first |
+| Streaming bodies live on a separate `/stream` sub-route, iframed | Browsers' Content-Disposition handling assumes a top-level navigation or iframe; HTMX swap of a binary body is ambiguous | Inline the stream in the swap (fails for binary); force download (breaks "Invoice in-tab" UX) |
+| Default permission codename `view_{model}_panel_{slug}` | Lines up with object-permission machinery from v0.5.1 | Free-form perm string per panel; no perm by default (insecure) |
+| Bundle one demo factory only (`PDFStreamPanel`) | Just enough to make the qualification check executable; History/Transitions live downstream | Ship History/Transitions stubs (out of scope per plan); ship no factory (fails the check) |

--- a/docs/specs/filter-library.md
+++ b/docs/specs/filter-library.md
@@ -1,0 +1,213 @@
+# SDD: Filter Library with Saved Views
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD |
+| Milestone | v0.5.6 — Detail Panels & Filter Library |
+| Created | 2026-05-11 |
+| Last updated | 2026-05-11 |
+
+---
+
+## Problem
+
+`AdminOptions.list_filter` (`src/hyperadmin/core/options.py:52`) accepts a flat
+`list[str]` of field names. The renderer compiles each into a generic exact-
+match `<select>`. Real admin work requires richer filter kinds — date ranges,
+multi-FK, multi-choice, booleans, "rows owned by me", and "current period"
+defaults — plus URL-shareable state and per-user named saved views. Today,
+consumers fork the list view to add any of this.
+
+## Goals
+
+- New `src/hyperadmin/filters/` module with six built-in filters:
+  `DateRangeFilter`, `MultiFKFilter`, `MultiChoiceFilter`, `BooleanFilter`,
+  `IsOwnerFilter`, `CurrentPeriodDefault`.
+- `AdminOptions.list_filter` accepts `list[FilterDef | str]` — strings keep the
+  legacy auto-classification path; explicit `FilterDef` instances drive the
+  new behaviour.
+- Filter sidebar rendered as a Jinja partial; submitting it triggers an HTMX
+  request that swaps just the table body.
+- All filter state lives in the querystring — URLs are shareable, the back
+  button works, and refresh preserves state.
+- Per-user named saved views persisted in `hyperadmin_saved_view` (the only
+  new table). A user can save the current filter set under a name, list their
+  saved views, and load one with a single click.
+- Permission-aware: `IsOwnerFilter` reuses `ObjectPermissionChecker` from
+  v0.5.1 so it honours object-level rules.
+
+## Non-Goals
+
+- Cross-model filters. Each filter operates on one field/relationship of the
+  current model.
+- Shared (cross-user) saved views. v0.5.6 saves per-user only.
+- Filter expression builder / `OR` / nested groups. The sidebar applies
+  filters as `AND`. A boolean expression UI is a later milestone.
+- Server-side full-text search over multi-column. That's `search_fields`.
+
+## BDD Scenarios
+
+```
+Scenario: legacy string list_filter still classifies fields
+  Given AdminOptions(list_filter=["status", "supplier_id"])
+  When  the list view renders
+  Then  the sidebar renders auto-classified filters for those two fields
+
+Scenario: explicit DateRangeFilter renders two date inputs
+  Given AdminOptions(list_filter=[DateRangeFilter(field="created_at")])
+  When  the user opens /admin/orders/
+  Then  the sidebar exposes inputs created_at__gte and created_at__lte
+  And   each input has data-testid="filter-created_at-gte" / "-lte"
+
+Scenario: applying a filter swaps only the table body
+  Given the same DateRangeFilter
+  When  the user submits created_at__gte=2026-01-01
+  Then  an HTMX GET /admin/orders/?created_at__gte=2026-01-01 is issued
+  And   the response is a fragment containing only the new <tbody>
+  And   the URL is updated via HX-Push-Url
+
+Scenario: IsOwnerFilter restricts to objects the user owns
+  Given IsOwnerFilter(owner_field="created_by") and the user is alice
+  When  the user toggles "Mine only" and submits
+  Then  the request includes ?is_owner=1
+  And   the result rows all have created_by == alice.id
+
+Scenario: CurrentPeriodDefault preselects the current month on first load
+  Given CurrentPeriodDefault(field="created_at", period="month") and no querystring
+  When  the user opens /admin/orders/
+  Then  the URL is redirected (HX-Push-Url) to ?created_at__gte=<first of month>&created_at__lte=<today>
+
+Scenario: saving the current filter set creates a SavedView row
+  Given the user has filters applied
+  When  the user posts /admin/orders/saved-views with name="Late this month"
+  Then  a hyperadmin_saved_view row exists with (user_id=alice, model="order", name="Late this month", querystring=...)
+  And   the sidebar shows "Late this month" as a clickable view
+
+Scenario: loading a saved view applies its querystring
+  Given alice has a saved view "Late this month"
+  When  alice clicks the saved view
+  Then  the list view is requested with that view's querystring
+  And   the resulting table body matches the saved filter
+
+Scenario: another user does not see alice's saved views
+  Given alice has a saved view "Late this month" and bob is logged in
+  When  bob opens /admin/orders/
+  Then  the saved-views panel does not list "Late this month"
+```
+
+## Design
+
+### Architecture
+
+```
+core/options.py            — list_filter type widens to list[FilterDef | str]
+core/filters_compat.py     — NEW: adapter that wraps legacy strings into FilterDef
+filters/                   — NEW package
+  __init__.py              — re-export public filter classes
+  base.py                  — FilterDef protocol/ABC, render hook, querystring parse hook, apply hook
+  date.py                  — DateRangeFilter, CurrentPeriodDefault
+  relation.py              — MultiFKFilter
+  choice.py                — MultiChoiceFilter
+  boolean.py               — BooleanFilter, IsOwnerFilter
+  saved_views.py           — SavedView model + service
+views/dynamic.py           — list_view passes filter sidebar context; saved-views endpoints
+templates/components/      — filter_sidebar.html, saved_views.html
+templates/list.html        — sidebar slot
+```
+
+The dependency direction is strict: `filters/` imports from `core/auth.py`
+(for `IsOwnerFilter`) but `core/` never imports `filters/`. The adapter
+`core/filters_compat.py` is the only seam: it knows how to turn a legacy
+string into a concrete `FilterDef` instance from `filters/`.
+
+### Data Model Changes
+
+New SQLModel table:
+
+```python
+class SavedView(SQLModel, table=True):
+    __tablename__ = "hyperadmin_saved_view"
+    id: int | None = Field(default=None, primary_key=True)
+    user_id: int = Field(index=True)
+    model: str = Field(index=True, max_length=255)
+    name: str = Field(max_length=255)
+    querystring: str = Field()
+    is_default: bool = Field(default=False)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+```
+
+Migration ships in `migrations/versions/` (Alembic), forward-only. Existing
+deployments are unaffected until they upgrade.
+
+### API / Protocol Changes
+
+**`FilterDef` protocol** (in `filters/base.py`):
+
+```python
+class FilterDef(Protocol):
+    field: str                                           # column this filter binds to
+    @property
+    def slug(self) -> str: ...                           # urlsafe key, defaults to field
+    def render(self, ctx: FilterRenderContext) -> str: ...
+    def parse(self, qs: MultiDict[str, str]) -> dict[str, Any]: ...
+    def apply(self, query: Any, parsed: dict[str, Any]) -> Any: ...
+```
+
+**New view methods on `DynamicModelView`** (saved views):
+
+```python
+GET    /{model}/saved-views          → list current user's saved views (JSON or HTML)
+POST   /{model}/saved-views          → create with name + current querystring
+DELETE /{model}/saved-views/{id}     → delete one (must belong to current user)
+```
+
+Permission check on every endpoint: only the owning user can read/write their
+saved views. Superusers can list everyone's only if `AdminOptions.saved_views_shared = True` (defaults to False — v0.5.6 is per-user).
+
+### Configuration Changes
+
+- `AdminOptions.list_filter` widened to `list[FilterDef | str] | None` (backward compatible).
+- `AdminOptions.saved_views_enabled: bool = True`.
+- No new env vars.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Legacy string references unknown field | unchanged from today: classifier raises at registration |
+| `DateRangeFilter` invalid date input | filter parse returns empty dict; sidebar re-renders with inline `data-testid="filter-{slug}-error"` |
+| `MultiFKFilter` choice points to deleted row | classifier rebuilds choices on every list render; stale querystring values are filtered out silently |
+| `IsOwnerFilter` with anonymous user | parsing yields `is_owner=False`; filter applies nothing (no leak) |
+| `CurrentPeriodDefault` already overridden by user querystring | default is skipped — explicit user input wins |
+| Saved view name collision per user | uniqueness enforced via DB unique `(user_id, model, name)` |
+| User loads another user's saved-view id | 404 — endpoint scopes to `request.user.id` |
+| HTMX request without filters | full list is returned (no filters applied), URL unchanged |
+| Non-HTMX request | full page rendered (sidebar + table) |
+| Filter applied via HX-Push-Url then user refreshes | querystring fully reconstructs the result |
+
+## Migration & Backward Compatibility
+
+- `list_filter` type widened; old `list[str]` configs keep working.
+- New table `hyperadmin_saved_view` added via Alembic migration.
+- `AdminOptions.saved_views_enabled` defaults True; consumers who don't run
+  Alembic must set it False to avoid 500s on the new endpoints — documented
+  in the upgrade guide.
+- No `__init__.py` removals; only additions (`hyperadmin.filters.*` re-exports).
+
+## Open Questions
+
+- [ ] Should `IsOwnerFilter` accept multiple owner fields (e.g. `created_by` *or* `assigned_to`)? Proposal: yes — `owner_fields: list[str] | str`. Single field is the common case.
+- [ ] Should `CurrentPeriodDefault` issue a redirect (HX-Push-Url) or just emit the right hidden inputs on first load? Proposal: redirect, so the URL is always source-of-truth.
+- [ ] Should the saved-view sidebar be HTMX-loaded or rendered with the page? Proposal: rendered with the page — small payload, avoids extra round-trip on every list view.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Filters as a separate top-level package | Boundary kept clean from `core/`; consumers can import filter primitives directly | Stash filters under `core/filters/` (couples core to a richer surface) |
+| All state in querystring | Matches Django admin convention; URLs are shareable; back/refresh stay correct | Server-side session-scoped filters (breaks deep links) |
+| Per-user saved views in v0.5.6 | Smallest scope that satisfies the H12 acceptance check | Cross-user shared views (out of scope; opens permission model questions) |
+| HTMX swap of `<tbody>` (not full list) | Filter sidebar stays stable, mobile keeps scroll position | OOB swap of full list (more bytes; flashes the sidebar) |
+| Legacy `list[str]` retained | Avoids a breaking change in `AdminOptions` | Force migration to `FilterDef` (semver-major) |

--- a/docs/specs/olap-reporting.md
+++ b/docs/specs/olap-reporting.md
@@ -1,0 +1,209 @@
+# SDD: OLAP / Pivot Reporting (`hyperadmin.reports`)
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD |
+| Milestone | v0.5.4 — Reporting & Charts |
+| Created | 2026-05-11 |
+| Last updated | 2026-05-11 |
+
+---
+
+## Problem
+
+HyperAdmin has no first-class way to declare an aggregated, pivoted, time-
+bucketed report. Consumers reinvent it: hand-written endpoints that
+`SELECT`/`GROUP BY` raw SQL, ship ad-hoc CSV exports, and skip the admin's
+permission/audit machinery. The H14 upstream check is: "OLAP report
+sales-by-SKU × month, quarter bucketing, CSV+XLSX export, charted." Without a
+declarative report layer, every consumer carries an ad-hoc copy of this.
+
+## Goals
+
+- New `src/hyperadmin/reports/` package: declarative `ReportView` registered
+  on the admin alongside `ModelAdmin`.
+- Declarative aggregates: `Sum`, `Count`, `StringAggComma`, `Min`, `Max`,
+  `Many2One` (resolves to the related row's display).
+- Crosstab dimensions: one row group, N column groups (e.g. row = SKU, cols =
+  year/quarter/month).
+- Time-series bucketing: `day`, `week`, `month`, `quarter`, `year`, plus
+  `auto` that picks based on the requested date range.
+- Filter integration: a `ReportView` can declare a filter set via `filters/`
+  from v0.5.6 — the H12 sidebar drives the report.
+- CSV and XLSX export endpoints, permission-aware (`view_report_{slug}`).
+- Cached materialisation seam: a `ReportView` can opt into reading from a
+  pre-built fact table without changing the calling code — the dispatcher
+  picks the source.
+
+## Non-Goals
+
+- Self-service report builder UI. v0.5.4 ships declarative reports defined in
+  code. A drag-and-drop editor is later milestone material.
+- Materialised-view refresh scheduling. The cache seam is invocation-only; a
+  scheduler is consumer-side.
+- Multi-fact joins beyond simple FK-to-display. Composite OLAP cubes are out
+  of scope.
+- ROLAP query optimisation tuning. The default uses the adapter's `select`
+  with `selectinload`; consumers tune at the SQL layer.
+- Pivot drill-down to row-level detail. v0.5.4 surfaces aggregates only; a
+  "click a cell to see the rows" interaction is deferred.
+
+## BDD Scenarios
+
+```
+Scenario: report registers and lists in the admin nav
+  Given OrderRevenueReport(ReportView, model=Order, slug="orders-revenue") is registered
+  When  the user opens /admin/
+  Then  the sidebar has a "Reports" group containing "Orders revenue"
+  And   the link targets /admin/reports/orders-revenue/
+
+Scenario: sum aggregate over one row group renders a grid
+  Given the report declares rows=[Group("sku")] cols=[] values=[Sum("amount")]
+  When  the user opens /admin/reports/orders-revenue/
+  Then  the response is a table with one row per distinct sku
+  And   the value column equals SUM(amount) per sku
+
+Scenario: time-bucketed crosstab renders rows × month columns
+  Given rows=[Group("sku")] cols=[TimeBucket("created_at", period="month")] values=[Sum("amount")]
+  And   the dataset spans Jan to Mar 2026
+  When  the user opens the report
+  Then  the table has columns "2026-01", "2026-02", "2026-03" and SKU rows
+  And   each cell equals SUM(amount) for that (sku, month)
+
+Scenario: auto bucketing picks quarter for a year-range request
+  Given the same report with cols=[TimeBucket("created_at", period="auto")]
+  And   the user filters to 2025-01-01 .. 2025-12-31
+  When  the report renders
+  Then  the column headers are "2025-Q1" .. "2025-Q4"
+
+Scenario: CSV export streams the same dataset
+  When  GET /admin/reports/orders-revenue/export.csv with the same filters
+  Then  the response Content-Type is "text/csv"
+  And   Content-Disposition is "attachment; filename=orders-revenue.csv"
+  And   the first row is the column header
+
+Scenario: XLSX export streams the same dataset
+  When  GET /admin/reports/orders-revenue/export.xlsx
+  Then  the response Content-Type is "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  And   opening the file with openpyxl yields the same rows as the CSV
+
+Scenario: permission codename gates report access
+  Given user lacks "view_report_orders_revenue"
+  When  GET /admin/reports/orders-revenue/
+  Then  response is 403
+
+Scenario: cached fact-table source replaces the live query
+  Given OrderRevenueReport.cache = FactTableSource(model=OrderRevenueFact)
+  When  the report is rendered
+  Then  the SQL executed reads from OrderRevenueFact, not Order
+  And   the rendered grid equals the live-query reference set
+```
+
+## Design
+
+### Architecture
+
+```
+reports/                   — NEW top-level package
+  __init__.py              — re-exports: ReportView, Group, TimeBucket, Sum, Count, ...
+  aggregates.py            — Sum, Count, Min, Max, StringAggComma, Many2One
+  view.py                  — ReportView base class + registration
+  crosstab.py              — pivot builder (rows × cols → grid)
+  bucketing.py             — TimeBucket, auto-period resolver
+  export.py                — CSV/XLSX streamers
+  cache.py                 — FactTableSource seam
+views/dynamic.py           — minor: registry exposes report routes alongside model routes
+templates/reports/         — list.html, detail.html, export buttons
+```
+
+The dispatch order on a request:
+
+1. Permission check (codename derived from slug).
+2. Filter parse (reuses `filters/` from v0.5.6).
+3. Source selection — live adapter query vs `FactTableSource`.
+4. Aggregate execution.
+5. Crosstab assembly.
+6. Render: HTML grid, CSV stream, or XLSX stream.
+
+### Data Model Changes
+
+No required DB tables. `FactTableSource` operates on a consumer-owned SQLModel —
+HyperAdmin does not create or migrate fact tables.
+
+### API / Protocol Changes
+
+```python
+class ReportView:
+    slug: str
+    label: str
+    model: type[SQLModel]
+    rows: list[Group | TimeBucket]
+    cols: list[Group | TimeBucket]
+    values: list[Aggregate]
+    filters: list[FilterDef | str] | None = None
+    cache: FactTableSource | None = None
+    permission: str | None = None     # default f"view_report_{slug}"
+
+class Aggregate(Protocol):
+    field: str
+    def sql(self, dialect: str) -> str: ...
+
+class Group:
+    def __init__(self, field: str, *, label: str | None = None): ...
+
+class TimeBucket:
+    def __init__(self, field: str, *, period: Literal["day","week","month","quarter","year","auto"]): ...
+```
+
+Routes (per registered `ReportView`):
+
+```
+GET /admin/reports/{slug}/             → HTML grid
+GET /admin/reports/{slug}/export.csv   → CSV stream
+GET /admin/reports/{slug}/export.xlsx  → XLSX stream
+```
+
+Reports are registered via `admin.register_report(ReportClass)` mirroring
+`admin.register(ModelAdmin)`.
+
+### Configuration Changes
+
+No new `Admin()` arg. No env vars. Reports are discovered via the existing
+admin registry pattern.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Empty result set | renders an empty grid with a "No data" cell |
+| `TimeBucket(period="auto")` with no date filter | range falls back to the column's min/max in the dataset; if either is null, single-bucket grid |
+| Aggregate references unknown field | raised at `register_report` time (`ValueError`) |
+| FK in `Group` (`Group("supplier_id")`) | grouped by FK id; column header uses related row's display when joinable, else raw id |
+| XLSX export with >1M cells | streamed in chunks via `openpyxl.write_only` (no memory blowup) |
+| Filter parse error | report renders with the inline filter-error decoration (same UX as list views) |
+| Permission denied | 403 — same template fragment as model views |
+| `cache` returns wrong shape | sanity-check at register time: cache's columns must be a superset of `rows + cols + values` |
+
+## Migration & Backward Compatibility
+
+Additive. No existing public API surface changes. The dashboard-builder
+milestone is renamed to "Reporting & Charts"; no past commits or PRs are
+affected since the milestone has not yet shipped.
+
+## Open Questions
+
+- [ ] Should reports be served under `/admin/reports/` (sibling of model routes) or `/admin/<model>/reports/` (nested)? Proposal: top-level — a report can span multiple models in v0.5.4+ (a `FactTableSource`) so nesting under one model is wrong.
+- [ ] Should `Many2One` aggregate render the related row's display or its pk? Proposal: display, falling back to pk if no display available.
+- [ ] Should XLSX export include a "Filters used" cover sheet for audit? Proposal: yes — small, helpful for downstream audit trails.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| `reports/` as a top-level package | Mirrors `filters/` boundary; reports can compose multiple models | Stash under `core/reports/` (couples core); under `views/reports/` (couples to view layer) |
+| Pivot in memory after a single grouped query | Predictable, portable across adapters; avoids DB-specific PIVOT syntax | DB-side `PIVOT` (SQL Server) / `crosstab` (Postgres) — non-portable |
+| Cache seam at the `ReportView` level | Drop-in fact table swap, no calling-code change | Plumb caching into every aggregate (more surface, less win) |
+| CSV + XLSX in v0.5.4 | Both are required by the H14 acceptance check | CSV-only (fails the check); JSON-only (consumer-side conversion burden) |
+| Auto bucketing rule: range ≤ 31d → day, ≤ 90d → week, ≤ 366d → month, ≤ 1100d → quarter, else year | Matches operator expectations; predictable | Always month (loses fidelity for short ranges); operator-must-pick (breaks "auto" promise) |

--- a/docs/specs/permission-matrix-ui.md
+++ b/docs/specs/permission-matrix-ui.md
@@ -1,0 +1,208 @@
+# SDD: Tabular Permission-Matrix UI
+
+| Field | Value |
+|---|---|
+| Author | Claude Code |
+| Status | Draft |
+| Issue | TBD |
+| Milestone | v0.5.7 — Permissions Matrix |
+| Created | 2026-05-11 |
+| Last updated | 2026-05-11 |
+
+---
+
+## Problem
+
+Object-level permissions and the auth model shipped in v0.5.1
+(`docs/specs/object-permissions-mfa.md`). Editing them today requires
+clicking into individual permission records one at a time. With even a small
+catalogue (say, 30 models × 4 actions × 6 groups = 720 cells), this is
+impractical. The H20 upstream check requires a tabular **model × action**
+grid editor for groups / roles, with the **object-permission column**
+integrated from H5, **bulk save**, and **audit logging** of every change.
+
+## Goals
+
+- A single-page grid editor at `/admin/permissions-matrix/` with rows = models,
+  cols = actions (`view`, `add`, `change`, `delete`, plus any extras from
+  `@action`), one matrix per group / role selectable via a dropdown.
+- A separate object-permission column for each row that opens an inline
+  popover listing per-row permission entries for the selected group; values
+  editable in place.
+- Bulk save that POSTs only the diff (cells the operator actually changed),
+  not the entire grid.
+- Optimistic concurrency: every save carries a per-group `version` stamp
+  loaded with the grid; conflicting saves return 409 with a "reload to see
+  changes" message.
+- Audit log entry per (group, model, action, old → new) tuple written into
+  the existing audit-trail table (v0.5.1 already audits CRUD; this just
+  reuses the writer).
+- Permission to access the matrix itself: superuser-only by default,
+  configurable via `AdminOptions.permissions_matrix_codename` (defaults to
+  `change_groups_permissions`).
+- Bundled `examples/full-demo/` umbrella app exercising every H# end-to-end
+  (`uv run examples/full-demo/main.py`).
+
+## Non-Goals
+
+- Inline create of new groups from the matrix. Group management remains in
+  the existing model admin.
+- Cross-group bulk edit ("apply this row to groups A and B"). The matrix
+  edits one group at a time.
+- Permission inheritance / hierarchical groups. Out of scope; flat groups
+  only.
+- Time-bound permissions ("Alice can edit Orders until 2026-12-31"). Future.
+- Diff visualisation between two groups. Future "compare view".
+
+## BDD Scenarios
+
+```
+Scenario: matrix loads with current grid for selected group
+  Given groups [Editors, Viewers] and models [Order, Invoice, Product]
+  When  the user opens /admin/permissions-matrix/ and selects "Editors"
+  Then  the grid renders 3 rows × 4 cols (view/add/change/delete)
+  And   each cell shows the current granted value as a checkbox
+
+Scenario: bulk save posts only changed cells
+  Given the Editors group has 12 currently checked cells
+  When  the user toggles two cells off and clicks Save
+  Then  POST /admin/permissions-matrix/save carries exactly two diff entries
+  And   the response is 200 with HX-Trigger "permissions-saved"
+
+Scenario: conflicting save returns 409
+  Given the user has the grid loaded with version=5
+  And   another user has saved a change, bumping version to 6
+  When  the user clicks Save
+  Then  response is 409 with body "Permissions changed elsewhere — reload"
+  And   no permission rows are mutated
+
+Scenario: object-permission column opens an inline popover
+  Given the Editors group has 2 per-row object permissions on Order
+  When  the user clicks the "Object" cell on the Order row
+  Then  a popover loads /admin/permissions-matrix/object/Editors/Order with the two entries listed
+  And   each entry has a remove button and the popover has an "Add" affordance
+
+Scenario: permission codename gates access to the matrix
+  Given the user lacks "change_groups_permissions"
+  When  GET /admin/permissions-matrix/
+  Then  response is 403
+
+Scenario: audit log records every (group, model, action, old, new) tuple
+  Given the user toggles 3 cells and saves
+  When  the save commits
+  Then  3 new rows exist in the audit trail with action="permission_change"
+  And   each row carries the (group_id, model, codename, before, after) payload
+
+Scenario: detail page reflects a freshly-flipped view-but-not-edit role
+  Given the user logs in as a member of "Viewers"
+  And   the matrix has Viewers with view=true, change=false for Order
+  When  the user opens /admin/orders/1/
+  Then  the page renders without an Edit button
+  And   POST /admin/orders/1/update would return 403
+```
+
+## Design
+
+### Architecture
+
+```
+permissions/                      — NEW package (auth-adjacent)
+  matrix.py                       — Matrix data model: load, diff, save, conflict-detect
+  audit.py                        — Reuses existing audit writer from v0.5.1
+views/permissions_matrix.py       — NEW view module: grid, save, object popover, conflict
+templates/permissions/            — NEW: matrix.html, object_popover.html, _diff_row.html
+core/options.py                   — permissions_matrix_codename
+examples/full-demo/               — NEW umbrella app exercising every H#
+```
+
+The matrix is **not** mounted as a `ModelAdmin` — it is its own view module
+because rows / columns are derived from the admin's *registry*, not from a
+single model. This sidesteps awkward conflation of meta-admin with model-admin.
+
+### Data Model Changes
+
+No new tables. Reuses:
+
+- `Group` / `Role` (from v0.5.1).
+- Permission rows (from v0.5.1).
+- Audit table (from v0.5.1).
+
+Adds an optimistic-concurrency column to the existing `Group` table:
+
+```python
+class Group(SQLModel, table=True):
+    ...
+    permissions_version: int = Field(default=0)
+```
+
+Bumped atomically on every successful matrix save. Forward-only Alembic
+migration adds the column with `server_default='0'`.
+
+### API / Protocol Changes
+
+```
+GET    /admin/permissions-matrix/                              → grid (full page)
+GET    /admin/permissions-matrix/?group_id=<id>                → grid for that group
+POST   /admin/permissions-matrix/save                          → diff save; body {group_id, version, changes: [...]}
+GET    /admin/permissions-matrix/object/{group}/{model}        → popover fragment
+POST   /admin/permissions-matrix/object/{group}/{model}        → add / remove object permission entries
+```
+
+The save payload uses a tiny diff envelope:
+
+```json
+{
+  "group_id": 7,
+  "version": 5,
+  "changes": [
+    {"model": "order",   "codename": "change_order",  "granted": false},
+    {"model": "invoice", "codename": "add_invoice",   "granted": true}
+  ]
+}
+```
+
+### Configuration Changes
+
+`AdminOptions` gains:
+
+```python
+permissions_matrix_codename: str = "change_groups_permissions"
+permissions_matrix_enabled: bool = True
+```
+
+Disable via `permissions_matrix_enabled=False` for projects without groups.
+
+## Edge Cases & Error Handling
+
+| Case | Handling |
+|---|---|
+| Empty admin registry | matrix renders an empty grid with a "No registered models" notice |
+| Version mismatch | 409 + reload prompt; no rows mutated; not retried |
+| Cell change touches a permission the user can't grant (privilege escalation) | reject the whole save with 403 and a per-cell error listing rejected entries |
+| Group deleted mid-edit | save returns 404 "Group not found"; client resets selection |
+| `permissions_matrix_enabled=False` | route returns 404 |
+| Audit writer raises | save rolls back the permission diff (atomic transaction); user sees a 500 with a generic "save failed" message; the error is logged |
+| Concurrent object-popover edits | versionless — the popover writes are idempotent (add / remove keyed on (group, model, action, obj_pk)) |
+| Browser sends a tampered version (e.g. -1) | treated as version mismatch — returns 409 |
+
+## Migration & Backward Compatibility
+
+- Adds `Group.permissions_version` via Alembic; defaults to 0 for existing rows.
+- Adds routes; no existing route changes.
+- Adds `AdminOptions` fields with safe defaults; no breaking change.
+
+## Open Questions
+
+- [ ] Should the matrix support **roles** (named bundles assigned to groups) in v0.5.7, or only groups? Proposal: groups only — roles are a separate v0.5.8 epic. The plan lists "groups/roles" but H20 acceptance only needs groups.
+- [ ] Should the saved-diff payload carry a CSRF token or rely on the existing global CSRF middleware? Proposal: rely on the existing middleware.
+- [ ] Should we add a "select-all" toggle per column? Proposal: yes — saves operator time; trivial UI.
+
+## Decision Log
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| Matrix as a standalone view module, not a `ModelAdmin` | Rows / cols span the entire admin registry; a single-model abstraction is the wrong shape | Stretch `ModelAdmin` to a "meta-admin" type (awkward, leaks abstraction) |
+| Optimistic concurrency via per-group `permissions_version` | Cheap, no row-level locks; common case is single editor | Row-level `updated_at` per permission (more rows, more writes); pessimistic locks (blocks concurrent edits) |
+| Diff-only POST (not full-grid POST) | Smaller payload, clearer audit log entries, harder to accidentally overwrite unrelated cells | Full-grid POST (loses intent; audit becomes "everything changed") |
+| Bundle `examples/full-demo/` here, not earlier | This is the milestone where the readiness suite must run end-to-end | Ship the demo with v0.5.5 (premature — would change shape each milestone) |
+| Object permissions edited via popover, not inline | Popover keeps the grid scannable; inline would make rows variable-height | Modal (heavier, breaks flow); side-drawer (eats grid width) |


### PR DESCRIPTION
## Summary

Completes the upstream readiness planning surface started in PR #556.
Plan-only — no application code changes. Five new SDDs, three milestones
(one renamed), five new implementation epics with bottom-up sub-tasks.

### Milestones

- **v0.5.6** (new) — Detail Panels & Filter Library → H4, H12
- **v0.5.4** (renamed) — Dashboard Builder → **Reporting & Charts** → H14, H15
- **v0.5.7** (new) — Permissions Matrix + \`examples/full-demo/\` umbrella → H20

### SDDs (all Draft, behind spec-review gates)

| Spec | H# | Scope |
|---|---|---|
| \`docs/specs/detail-panels.md\` | H4 | panel registry, \`@panel\` decorator, tabbed detail layout, lazy HTMX load, bundled \`PDFStreamPanel\` |
| \`docs/specs/filter-library.md\` | H12 | new \`filters/\` package (6 filter types), querystring-state HTMX swap, per-user saved views (\`hyperadmin_saved_view\` table) |
| \`docs/specs/olap-reporting.md\` | H14 | \`reports/\` package, aggregates, crosstab, time-bucketing (incl. auto), CSV/XLSX export, fact-table cache seam |
| \`docs/specs/chart-components.md\` | H15 | SVG primitives (bar/line/stacked-bar/pie) + opt-in Chart.js mode bound to a \`ReportView\` |
| \`docs/specs/permission-matrix-ui.md\` | H20 | model × action grid editor, optimistic concurrency, diff-only save, audit log, \`examples/full-demo/\` umbrella |

### Open H4 scope decision (resolved)

Confirmed in this PR: HyperAdmin ships **panel registry + tabbed detail
layout + one PDF-streaming demo**. History / Transitions panel *content*
remains an extension point for downstream apps. Recorded in
\`docs/specs/detail-panels.md\` Decision Log.

### Epics and stories

- \`epic-v056-detail-panels\` — SDD-review + 3 stories (core / views+streaming / templates+E2E)
- \`epic-v056-filter-library\` — SDD-review + 3 stories (filters/ package / HTMX views + saved views / templates+E2E)
- \`epic-v054-olap-reporting\` — SDD-review + 4 stories (aggregates+crosstab / source dispatch+filters / routes+export / E2E)
- \`epic-v054-chart-components\` — SDD-review + 3 stories (SVG primitives / Chart.js mode / chart route+E2E)
- \`epic-v057-permissions-matrix\` — SDD-review + 4 stories (data layer / views+audit / templates / examples/full-demo)

Every epic has \`size:L\`, \`upstream-readiness\`, and the matching H# label.
Every implementation story is \`blocked_by\` the spec-review story. Every
SDD includes Decision Log + Open Questions to resolve at review.

### Methodology compliance

- SDD-first — five spec-review gates, all behind a human approval task
- BDD — every SDD has a \`## BDD Scenarios\` section; every E2E story maps 1:1
- Bottom-up — every epic's stories sequence \`core → views → templates → e2e\`
- Framework-neutral — no consumer-specific names; \`examples/full-demo/\` uses
  generic \`Order\`/\`Invoice\`/\`Product\`/\`Supplier\` per the project rule

## What ships together when merged

Combined with PR #556, the complete planning surface for upstream readiness:
- Tracking epic + 10 capabilities indexed
- 6 milestones (5 new, 1 renamed)
- 7 SDDs in Draft
- 8 implementation epics with 26 stories

Ready to dispatch implementation as humans approve each spec-review gate.

## Test plan

- [ ] Verify \`.meta/\` tree validates (\`./scripts/gitpm.sh validate\` when CLI available)
- [ ] Render each new SDD in docs preview — confirm Markdown / table layout
- [ ] Confirm milestone v0.5.4 title change ("Dashboard Builder" → "Reporting & Charts") is mirrored on GitHub on next \`gitpm push\`
- [ ] Sequence sanity check: v0.5.5 → v0.5.6 → v0.5.4 → v0.5.7 matches the plan
- [ ] Human review of all five SDDs against \`docs/specs/TEMPLATE.md\`