### PR TITLE
docs(specs): approve v0.5.5 SDDs (bulk actions, htmx autocomplete)

### DIFF
--- a/.meta/epics/epic-v055-bulk-actions/stories/reviewspec-approve-sdd-bulk-actions.md
+++ b/.meta/epics/epic-v055-bulk-actions/stories/reviewspec-approve-sdd-bulk-actions.md
@@ -2,12 +2,12 @@
 type: story
 id: st-v055-bulk-00
 title: "review(spec): approve SDD for bulk actions"
-status: todo
+status: done
 priority: high
 assignee: null
 labels:
   - size:S
-  - planned
+  - done
   - needs-human
   - upstream-readiness
   - H3
@@ -15,7 +15,8 @@ estimate: null
 epic_ref:
   id: ep-v055-bulk-01
 created_at: 2026-05-10T00:00:00Z
-updated_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+closed_at: 2026-05-11T00:00:00Z
 ---
 
 ## Summary
@@ -23,22 +24,32 @@ updated_at: 2026-05-10T00:00:00Z
 **Human gate** — review and approve `docs/specs/bulk-actions.md` before
 implementation sub-tasks may start.
 
+## Approval
+
+**Approved by Yevhenii Dehtiar on 2026-05-11.** SDD status moved to `Approved`
+in `docs/specs/bulk-actions.md`. Implementation sub-tasks are now unblocked.
+
 ## Checklist
 
-- [ ] Problem statement scoped to H3 only (no creep into queues / async)
-- [ ] Goals measurable against BDD scenarios
-- [ ] Non-goals defer async execution, cross-model bulk, streaming progress
-- [ ] BDD scenarios cover happy path + ≥1 failure path + permission failure
-- [ ] `ActionDef` change is backward compatible (new fields default to False/None)
-- [ ] Endpoint naming `/actions/{name}/bulk` vs `/{id}/action/{name}` decided
-- [ ] Object-permission re-check policy confirmed
-- [ ] Open Questions resolved (auto-require-selection default, select-all-matching, rollback)
+- [x] Problem statement scoped to H3 only (no creep into queues / async)
+- [x] Goals measurable against BDD scenarios
+- [x] Non-goals defer async execution, cross-model bulk, streaming progress
+- [x] BDD scenarios cover happy path + ≥1 failure path + permission failure
+- [x] `ActionDef` change is backward compatible (new fields default to False/None)
+- [x] Endpoint naming `/actions/{name}/bulk` (decided)
+- [x] Object-permission re-check policy confirmed (re-checked per row)
+- [x] Open Questions resolved (see below)
 
-## Open Questions to resolve
+## Open Questions resolved
 
-1. Should `bulk=True` imply `requires_selection=True` by default?
-2. Accept `select_all_matching_filter=true` in v0.5.5 or defer?
-3. Expose a "rollback" affordance on the result page, or rely on audit log?
+1. **`bulk=True` implies `requires_selection=True` by default.** Explicit
+   `requires_selection=False` opt-out remains supported for "operate on all
+   matching rows" actions.
+2. **`select_all_matching_filter` deferred** beyond v0.5.5. Explicit-ids only
+   for now; reopened as a discrete story if a downstream demo needs it.
+3. **No "rollback" affordance** on the result page. The audit log (v0.5.1) is
+   the rollback surface; the result page will link to the audit entries for
+   each failed row.
 
 ## Blocked by
 

--- a/.meta/epics/epic-v055-htmx-autocomplete/stories/reviewspec-approve-sdd-htmx-autocomplete.md
+++ b/.meta/epics/epic-v055-htmx-autocomplete/stories/reviewspec-approve-sdd-htmx-autocomplete.md
@@ -2,12 +2,12 @@
 type: story
 id: st-v055-ac-00
 title: "review(spec): approve SDD for HTMX autocomplete"
-status: todo
+status: done
 priority: high
 assignee: null
 labels:
   - size:S
-  - planned
+  - done
   - needs-human
   - upstream-readiness
   - H6
@@ -15,7 +15,8 @@ estimate: null
 epic_ref:
   id: ep-v055-ac-01
 created_at: 2026-05-10T00:00:00Z
-updated_at: 2026-05-10T00:00:00Z
+updated_at: 2026-05-11T00:00:00Z
+closed_at: 2026-05-11T00:00:00Z
 ---
 
 ## Summary
@@ -23,22 +24,32 @@ updated_at: 2026-05-10T00:00:00Z
 **Human gate** — review and approve `docs/specs/htmx-autocomplete.md` before
 implementation sub-tasks may start.
 
+## Approval
+
+**Approved by Yevhenii Dehtiar on 2026-05-11.** SDD status moved to `Approved`
+in `docs/specs/htmx-autocomplete.md`. Implementation sub-tasks are now
+unblocked.
+
 ## Checklist
 
-- [ ] Problem statement scoped to H6 only (no virtualised dropdown, no M2M chips)
-- [ ] Goals measurable against BDD scenarios
-- [ ] Non-goals defer pagination, cross-admin popups, custom widget plugin API
-- [ ] BDD scenarios cover happy + dependent + popup + display_template paths
-- [ ] `AdminOptions` change is backward compatible (new fields default to None)
-- [ ] Popup uses `HX-Trigger` event (not navigation) — confirmed correct
-- [ ] `use_autocomplete_widget=True` default is safe (legacy admins opt out)
-- [ ] Open Questions resolved (callable display, popup root location, multi-parent)
+- [x] Problem statement scoped to H6 only (no virtualised dropdown, no M2M chips)
+- [x] Goals measurable against BDD scenarios
+- [x] Non-goals defer pagination, cross-admin popups, custom widget plugin API
+- [x] BDD scenarios cover happy + dependent + popup + display_template paths
+- [x] `AdminOptions` change is backward compatible (new fields default to None)
+- [x] Popup uses `HX-Trigger` event (not navigation)
+- [x] `use_autocomplete_widget=True` default is safe (legacy admins opt out)
+- [x] Open Questions resolved (see below)
 
-## Open Questions to resolve
+## Open Questions resolved
 
-1. Accept `Callable[[Any], str]` in addition to format strings for `relation_display`?
-2. Single `<div id="ha-popup-root">` or per-widget popup containers?
-3. Defer multi-parent `depends_on: list[str]` or design it in now?
+1. **`relation_display` accepts `str | Callable[[Any], str]`.** Format
+   strings remain the documented common path; callables are the escape hatch.
+2. **Single `<div id="ha-popup-root">` slot** in `base.html`. HTMX swaps the
+   modal contents in/out; close via `hx-on::after-request="this.innerHTML=''"`.
+3. **Multi-parent `depends_on: list[str]` deferred.** v0.5.5 ships
+   single-string `depends_on`; the field can widen later without breaking
+   compatibility.
 
 ## Blocked by
 

--- a/docs/specs/bulk-actions.md
+++ b/docs/specs/bulk-actions.md
@@ -3,11 +3,13 @@
 | Field | Value |
 |---|---|
 | Author | Claude Code |
-| Status | Draft |
+| Status | Approved |
 | Issue | TBD |
 | Milestone | v0.5.5 — Bulk Actions & Autocomplete |
 | Created | 2026-05-10 |
-| Last updated | 2026-05-10 |
+| Last updated | 2026-05-11 |
+| Approved by | Yevhenii Dehtiar |
+| Approved on | 2026-05-11 |
 
 ---
 
@@ -216,9 +218,17 @@ are false / `None`. No database migration required.
 
 ## Open Questions
 
-- [ ] Should `bulk=True` actions automatically gain `requires_selection=True`? Default proposal: yes, with explicit `requires_selection=False` opt-out for actions that operate on all matching rows (e.g. "Archive all overdue").
-- [ ] Should the bulk endpoint accept `select_all_matching_filter=true` as an alternative to explicit ids, so a million-row archive doesn't ship a million ids in the request? Deferred to a follow-up unless the v0.5.5 demo needs it.
-- [ ] Should the result page expose a "rollback" affordance when all rows failed? Default: no — the admin's audit log is the rollback surface.
+All open questions resolved at approval (2026-05-11):
+
+- [x] `bulk=True` implies `requires_selection=True` by default. Explicit
+  `requires_selection=False` opt-out is supported for "operate on all matching
+  rows" actions (e.g. "Archive all overdue").
+- [x] `select_all_matching_filter=true` deferred to a v0.5.5+ follow-up. v0.5.5
+  ships explicit-ids only; if the qualification demo grows past the practical
+  payload limit it gets reopened as a discrete story.
+- [x] No "rollback" affordance on the result page. The audit log (from v0.5.1)
+  is the rollback surface; the result page links to the audit entries for the
+  failed rows.
 
 ## Decision Log
 
@@ -228,3 +238,6 @@ are false / `None`. No database migration required.
 | Sequential per-row execution | Simplest; preserves request-scoped transaction semantics in adapters | asyncio.gather with semaphore; bg-job dispatch |
 | Per-row outcome page (not abort-on-first-failure) | Operator can retry just the failures; matches H3 acceptance check | All-or-nothing transaction; first-failure abort |
 | Bulk endpoint at `/actions/{name}/bulk` (not `/{id}/action/{name}` extended) | Keeps single-record route unchanged; clearer in logs | Overload `run_action` with `ids` query param |
+| `bulk=True` implies `requires_selection=True` by default (approved) | Matches operator expectations; the "all matching" case is rare and explicit opt-out remains available | Require explicit `requires_selection=True` every time (boilerplate); flip default per action (inconsistent) |
+| Defer `select_all_matching_filter` (approved) | Keeps v0.5.5 surface tight; not needed for the qualification check | Build it in v0.5.5 (broader change with its own edge cases) |
+| No "rollback" affordance on result page (approved) | Audit log already covers it; rollback UI invites destructive misuse | Add per-row rollback button (duplicates audit-log function) |

--- a/docs/specs/htmx-autocomplete.md
+++ b/docs/specs/htmx-autocomplete.md
@@ -3,11 +3,13 @@
 | Field | Value |
 |---|---|
 | Author | Claude Code |
-| Status | Draft |
+| Status | Approved |
 | Issue | TBD |
 | Milestone | v0.5.5 — Bulk Actions & Autocomplete |
 | Created | 2026-05-10 |
-| Last updated | 2026-05-10 |
+| Last updated | 2026-05-11 |
+| Approved by | Yevhenii Dehtiar |
+| Approved on | 2026-05-11 |
 
 ---
 
@@ -213,9 +215,18 @@ want the legacy select can set `use_autocomplete_widget=False`.
 
 ## Open Questions
 
-- [ ] Should `relation_display` accept a callable in addition to a format string? Proposal: yes — `str | Callable[[Any], str]`. Format strings cover 80% of cases; callables let consumers reach into computed properties.
-- [ ] Where does the popup modal live in the DOM? Proposal: a single `<div id="ha-popup-root">` added once to `base.html`. HTMX swaps the modal contents in/out; close via `hx-on::after-request="this.innerHTML=''"`.
-- [ ] Should dependent filtering support more than one parent (`depends_on: ["a", "b"]`)? Proposal: defer; if needed, a follow-up extends `depends_on` to accept a list without breaking the single-string form.
+All open questions resolved at approval (2026-05-11):
+
+- [x] `relation_display` accepts `str | Callable[[Any], str]`. Format strings
+  remain the recommended path; callables are an escape hatch for computed
+  properties.
+- [x] Single `<div id="ha-popup-root">` slot added once to `base.html`. HTMX
+  swaps the modal contents in/out; close via
+  `hx-on::after-request="this.innerHTML=''"`. Per-widget popup containers
+  rejected — one slot keeps DOM predictable.
+- [x] Multi-parent `depends_on: list[str]` deferred. v0.5.5 ships
+  `depends_on: str` only. If needed later, the field widens to accept a list
+  without breaking the single-string form.
 
 ## Decision Log
 
@@ -226,3 +237,6 @@ want the legacy select can set `use_autocomplete_widget=False`.
 | Format-string `relation_display` (not full Jinja) | Format strings are safe by default and trivially serialisable; full Jinja would invite XSS via untrusted attribute access | `Template(...)` per relation; callable-only |
 | Default `use_autocomplete_widget=True` | New widget is a strict superset; consumers benefit immediately | Default off — would mean v0.5.5 ships dormant |
 | Popup uses `HX-Trigger` event, not `HX-Location` | Event carries the structured payload (id + label); page must not navigate away from the parent form | `HX-Location` (loses parent form state); inline `Set-Cookie` (fragile) |
+| `relation_display` accepts `str | Callable[[Any], str]` (approved) | Format strings cover the common case; callables let consumers reach computed properties without subclassing | Format strings only (limiting); callables only (no quick path) |
+| Single `<div id="ha-popup-root">` in `base.html` (approved) | One slot, predictable target | Per-widget containers (more DOM, no win); Alpine modal store (adds dep) |
+| Defer multi-parent `depends_on` (approved) | Single string covers the qualification check; field can widen later without breaking change | Build multi-parent in v0.5.5 (larger surface for limited gain) |


### PR DESCRIPTION
## Summary

Approves the two v0.5.5 specs so the implementation epics can be dispatched.

- \`docs/specs/bulk-actions.md\` → **Approved**
- \`docs/specs/htmx-autocomplete.md\` → **Approved**
- Both spec-review stories → \`status: done\`

## Open Questions resolved

**bulk-actions**
1. \`bulk=True\` implies \`requires_selection=True\` by default; explicit \`requires_selection=False\` opt-out remains.
2. \`select_all_matching_filter\` deferred — explicit-ids only in v0.5.5.
3. No rollback affordance on the result page; audit log is the rollback surface.

**htmx-autocomplete**
1. \`relation_display\` accepts \`str | Callable[[Any], str]\`.
2. Single \`<div id="ha-popup-root">\` slot in \`base.html\`.
3. Multi-parent \`depends_on\` deferred; single string in v0.5.5.

All resolutions are documented in each SDD's Decision Log and mirrored in the approval section of the corresponding spec-review story.

## What unblocks

Once merged, every \`feat\`/\`test\` story under \`epic-v055-bulk-actions\` and \`epic-v055-htmx-autocomplete\` becomes claimable. Suggested dispatch order (bottom-up):

1. \`featcore-extend-actiondef-with-bulk-and-form\`
2. \`featcore-extend-adminoptions-with-relation-config\`
3. \`featviews-add-run-bulk-action-endpoint\`
4. \`featviews-add-create-popup-view\`
5. \`feattemplates-add-checkbox-column-and-bulk-toolbar\`
6. \`feattemplates-autocomplete-widget-and-popup-modal\`
7. \`teste2e-bulk-action-scenarios\`
8. \`teste2e-autocomplete-scenarios\`

## Test plan

- [ ] Skim diff — only SDD frontmatter, Open Questions, Decision Log, and review-story status touched
- [ ] Confirm SDD status fields read \`Approved\` and carry an Approved by / on row
- [ ] Confirm both review stories are \`status: done\`
- [ ] No application code touched