### PR TITLE
feat(core): extend ActionDef and @action with bulk/form parameters

### DIFF
--- a/src/hyperadmin/core/actions.py
+++ b/src/hyperadmin/core/actions.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from pydantic import BaseModel
+
+
+_UNSET: Any = object()
 
 
 @dataclass(frozen=True, slots=True)
@@ -20,51 +26,88 @@ class ActionDef:
         name: Unique slug for the action, derived from the decorated function's name.
         label: Human-readable label shown on the action button.
         handler: The unbound function (method) that implements the action.
-        requires_selection: Reserved for future bulk-action support. When ``True``
-            the action requires one or more items to be selected before running.
+        requires_selection: When ``True`` the action requires one or more items
+            to be selected before running. Auto-set to ``True`` for ``bulk=True``
+            actions unless explicitly overridden.
+        bulk: When ``True``, the action operates over multiple selected rows
+            via the bulk endpoint at ``POST /{model}/actions/{name}/bulk``.
+            The handler signature must accept a ``params`` keyword-only argument.
+        form: Optional Pydantic model collected from the operator before the
+            bulk handler runs. Only valid when ``bulk=True``.
     """
 
     name: str
     label: str
     handler: Callable[..., Any]
     requires_selection: bool = False
+    bulk: bool = False
+    form: type[BaseModel] | None = None
 
 
 def action(
     label: str,
     *,
-    requires_selection: bool = False,
+    requires_selection: bool = _UNSET,
+    bulk: bool = False,
+    form: type[BaseModel] | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator that marks a :class:`~hyperadmin.core.model.ModelAdmin` method as a custom action.
 
-    The decorated method must be ``async`` and accept ``(self, request, item_id)`` as
-    its signature.  It may return a :class:`starlette.responses.Response` to override
-    the default post-action redirect, or return ``None`` to accept the default
-    behaviour (HTMX redirect to the model list view).
+    For single-record actions (``bulk=False``, default) the decorated method must
+    be ``async`` and accept ``(self, request, item_id)``.
+
+    For bulk actions (``bulk=True``) the handler must additionally accept a
+    keyword-only ``params`` argument, which is the validated Pydantic instance
+    when ``form`` is set, or ``None`` otherwise. ``bulk=True`` implies
+    ``requires_selection=True`` unless the caller passes
+    ``requires_selection=False`` explicitly (e.g. for "operate on all matching
+    rows" actions).
 
     Example::
 
         from hyperadmin.core.actions import action
 
 
-        class UserAdmin(ModelAdmin):
-            @action(label="Deactivate")
-            async def deactivate(self, request, item_id):
-                user = await self.adapter.get(pk=item_id)
-                if user:
-                    await self.adapter.update(user, {"is_active": False})
+        class OrderAdmin(ModelAdmin):
+            @action(label="Archive", bulk=True)
+            async def archive(self, request, item_id, *, params=None): ...
 
     Args:
         label: Human-readable label shown on the action button.
-        requires_selection: Reserved for future bulk-action support.
+        requires_selection: Override the auto-derived selection requirement.
+        bulk: Whether this is a multi-row action invoked from the list view.
+        form: Pydantic model used to collect parameters before the handler runs.
+
+    Raises:
+        TypeError: If ``form`` is set without ``bulk=True``, or if a
+            ``bulk=True`` handler signature does not accept a ``params``
+            keyword-only argument.
     """
 
+    if form is not None and not bulk:
+        raise TypeError("form= requires bulk=True")
+
+    resolved_requires_selection: bool = (
+        bool(bulk) if requires_selection is _UNSET else bool(requires_selection)
+    )
+
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        if bulk:
+            sig = inspect.signature(fn)
+            params_kw = sig.parameters.get("params")
+            if params_kw is None or params_kw.kind is not inspect.Parameter.KEYWORD_ONLY:
+                raise TypeError(
+                    f"bulk=True handler {fn.__name__!r} must accept a 'params' "
+                    "keyword-only argument"
+                )
+
         fn._action_def = ActionDef(  # type: ignore[attr-defined]
             name=fn.__name__,
             label=label,
             handler=fn,
-            requires_selection=requires_selection,
+            requires_selection=resolved_requires_selection,
+            bulk=bulk,
+            form=form,
         )
         return fn
 

--- a/tests/unit/test_actions.py
+++ b/tests/unit/test_actions.py
@@ -3,6 +3,7 @@
 import dataclasses
 
 import pytest
+from pydantic import BaseModel
 
 from hyperadmin.core.actions import ActionDef, action, collect_actions
 
@@ -150,3 +151,93 @@ def test_collect_actions_returns_action_def_instances():
 
     result = collect_actions(Admin)
     assert all(isinstance(a, ActionDef) for a in result)
+
+
+# ---------------------------------------------------------------------------
+# Bulk action support (v0.5.5)
+# ---------------------------------------------------------------------------
+
+
+class _ReassignParams(BaseModel):
+    operator: int
+
+
+def test_action_decorator_defaults_bulk_and_form():
+    @action(label="X")
+    async def fn(self, request, item_id):
+        pass
+
+    assert fn._action_def.bulk is False
+    assert fn._action_def.form is None
+
+
+def test_bulk_action_requires_params_kwarg():
+    @action(label="Archive", bulk=True)
+    async def archive(self, request, item_id, *, params=None):
+        pass
+
+    assert archive._action_def.bulk is True
+    assert archive._action_def.form is None
+
+
+def test_bulk_action_implies_requires_selection_true():
+    @action(label="Archive", bulk=True)
+    async def archive(self, request, item_id, *, params=None):
+        pass
+
+    assert archive._action_def.requires_selection is True
+
+
+def test_bulk_action_explicit_requires_selection_false_opt_out():
+    """`bulk=True` actions can opt out of the auto-selection requirement."""
+
+    @action(label="Archive overdue", bulk=True, requires_selection=False)
+    async def archive_overdue(self, request, item_id, *, params=None):
+        pass
+
+    assert archive_overdue._action_def.bulk is True
+    assert archive_overdue._action_def.requires_selection is False
+
+
+def test_bulk_action_with_form_attaches_pydantic_model():
+    @action(label="Reassign", bulk=True, form=_ReassignParams)
+    async def reassign(self, request, item_id, *, params=None):
+        pass
+
+    assert reassign._action_def.form is _ReassignParams
+
+
+def test_form_without_bulk_raises_typeerror():
+    with pytest.raises(TypeError, match="form= requires bulk=True"):
+
+        @action(label="Reassign", form=_ReassignParams)
+        async def reassign(self, request, item_id):
+            pass
+
+
+def test_bulk_action_handler_without_params_raises_typeerror():
+    with pytest.raises(TypeError, match="must accept a 'params' keyword-only argument"):
+
+        @action(label="Archive", bulk=True)
+        async def archive(self, request, item_id):  # missing *, params=None
+            pass
+
+
+def test_bulk_action_with_positional_params_raises_typeerror():
+    """`params` must be keyword-only; positional `params` is rejected."""
+    with pytest.raises(TypeError, match="must accept a 'params' keyword-only argument"):
+
+        @action(label="Archive", bulk=True)
+        async def archive(self, request, item_id, params=None):  # positional, not kw-only
+            pass
+
+
+def test_actiondef_bulk_and_form_defaults():
+    """`ActionDef` direct construction preserves backward-compatible defaults."""
+
+    async def handler(self, request, item_id):
+        pass
+
+    ad = ActionDef(name="x", label="X", handler=handler)
+    assert ad.bulk is False
+    assert ad.form is None


### PR DESCRIPTION
## Summary

First implementation story under \`epic-v055-bulk-actions\`. Adds the surface
the bulk-action endpoint will rely on; runtime wiring lands in a follow-up
story.

- \`ActionDef.bulk: bool = False\` and \`ActionDef.form: type[BaseModel] | None = None\`
- \`@action(..., bulk=..., form=...)\` with decoration-time validation:
  - \`form=\` without \`bulk=True\` → \`TypeError\`
  - \`bulk=True\` handler signature must accept a keyword-only \`params\` argument
- \`bulk=True\` auto-promotes \`requires_selection=True\` (opt-out via explicit
  \`requires_selection=False\`) per the approved SDD decision

Backward compatible — every existing \`@action\` call site is unchanged.

## Spec

\`docs/specs/bulk-actions.md\` (Approved 2026-05-11)

## Story

\`.meta/epics/epic-v055-bulk-actions/stories/featcore-extend-actiondef-with-bulk-and-form.md\`

## Test plan

- [x] \`uv run pytest tests/unit/test_actions.py\` — 23 passed (8 new)
- [x] \`poe lint\` — all checks pass
- [ ] Manual: \`@action(label="X")\` legacy paths still register \`ActionDef\` with \`bulk=False\`
- [ ] Manual: \`@action(label="X", bulk=True)\` rejected without \`*, params\` kwarg

## New test coverage

- \`test_bulk_action_requires_params_kwarg\`
- \`test_bulk_action_implies_requires_selection_true\`
- \`test_bulk_action_explicit_requires_selection_false_opt_out\`
- \`test_bulk_action_with_form_attaches_pydantic_model\`
- \`test_form_without_bulk_raises_typeerror\`
- \`test_bulk_action_handler_without_params_raises_typeerror\`
- \`test_bulk_action_with_positional_params_raises_typeerror\`
- \`test_actiondef_bulk_and_form_defaults\`