### PR TITLE
feat(core): extend AdminOptions with relation_filters and relation_display

### DIFF
--- a/src/hyperadmin/core/options.py
+++ b/src/hyperadmin/core/options.py
@@ -1,11 +1,34 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field
 
 from hyperadmin.core.auth import ObjectPermissionChecker
 from hyperadmin.core.fieldsets import FieldsetSpec
 from hyperadmin.core.inlines import InlineModelSpec
 from hyperadmin.core.layouts import FormLayout
+
+
+class RelationDependency(BaseModel):
+    """Declarative cascading-select wiring for a FK/M2M autocomplete widget.
+
+    See ``docs/specs/htmx-autocomplete.md``. When set on
+    :class:`AdminOptions.relation_filters`, the widget for the keyed child
+    field forwards ``depends_on``'s current value via ``hx-include`` so that
+    its options narrow against the parent's selection.
+
+    Args:
+        depends_on: Name of the parent field on the same form. Validated
+            against the bound model via :meth:`AdminOptions.validate_against_model`.
+        placeholder: Hint shown when the parent has no value yet.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    depends_on: str
+    placeholder: str | None = None
 
 
 class AdminOptions(BaseModel):
@@ -130,3 +153,66 @@ class AdminOptions(BaseModel):
     declaring it here lets model registrations adopt object-level checks ahead
     of the wiring.
     """
+    relation_filters: dict[str, RelationDependency] | None = None
+    """Declarative dependent-filtering for FK/M2M autocomplete widgets.
+
+    Keys are child field names; values describe which parent field on the
+    same form the child depends on. The widget for each keyed child
+    forwards the parent's value via ``hx-include`` so the dropdown narrows
+    automatically. See ``docs/specs/htmx-autocomplete.md``.
+
+    Example:
+        ```python
+        AdminOptions(
+            relation_filters={
+                "variant_id": RelationDependency(depends_on="supplier_id"),
+            }
+        )
+        ```
+    """
+    relation_display: dict[str, str | Callable[[Any], str]] | None = None
+    """Per-relation option-label rendering.
+
+    Maps a FK/M2M field name to either a Python format string or a callable
+    that receives the related instance and returns its display label. Format
+    strings are the recommended path; callables are an escape hatch for
+    computed properties unreachable via ``getattr``.
+
+    Example:
+        ```python
+        AdminOptions(relation_display={"supplier_id": "{name} — {city}"})
+        ```
+    """
+    use_autocomplete_widget: bool = True
+    """Whether FK/M2M fields render via :class:`AutocompleteWidget`.
+
+    Defaults to ``True``: the new widget is a strict superset of the legacy
+    ``<select>`` rendering. Set to ``False`` to opt back into the legacy
+    widget on a per-model basis.
+    """
+
+    def validate_against_model(self, model: type) -> None:
+        """Validate options that reference field names against a concrete model.
+
+        Called by the registry when the options are bound to ``model``. Raises
+        :class:`ValueError` if any ``relation_filters[child].depends_on``
+        references a field that does not exist on the model.
+
+        Args:
+            model: The SQLModel / Pydantic class these options are bound to.
+
+        Raises:
+            ValueError: If a referenced field name does not exist on the model.
+        """
+        if not self.relation_filters:
+            return
+
+        field_names = set(getattr(model, "model_fields", {}).keys()) | {
+            attr for attr in dir(model) if not attr.startswith("_")
+        }
+        for child, dep in self.relation_filters.items():
+            if dep.depends_on not in field_names:
+                raise ValueError(
+                    f"relation_filters[{child!r}].depends_on={dep.depends_on!r} "
+                    f"not in form fields of {model.__name__}"
+                )

--- a/tests/unit/test_admin_options_relation_config.py
+++ b/tests/unit/test_admin_options_relation_config.py
@@ -1,0 +1,96 @@
+"""Unit tests for AdminOptions relation_filters / relation_display / autocomplete."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.core.options import AdminOptions, RelationDependency
+
+
+class _Product(SQLModel):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    supplier_id: int
+    variant_id: int | None = None
+
+
+def test_relation_filters_defaults_to_none():
+    opts = AdminOptions()
+    assert opts.relation_filters is None
+
+
+def test_relation_display_defaults_to_none():
+    opts = AdminOptions()
+    assert opts.relation_display is None
+
+
+def test_use_autocomplete_widget_defaults_to_true():
+    opts = AdminOptions()
+    assert opts.use_autocomplete_widget is True
+
+
+def test_relation_filters_accepts_dependency_model():
+    opts = AdminOptions(
+        relation_filters={"variant_id": RelationDependency(depends_on="supplier_id")}
+    )
+    assert opts.relation_filters is not None
+    assert opts.relation_filters["variant_id"].depends_on == "supplier_id"
+    assert opts.relation_filters["variant_id"].placeholder is None
+
+
+def test_relation_filters_accepts_dict_payload():
+    """Pydantic coerces a dict into a RelationDependency."""
+    opts = AdminOptions(
+        relation_filters={
+            "variant_id": {"depends_on": "supplier_id", "placeholder": "Pick a supplier first"}
+        }
+    )
+    assert opts.relation_filters is not None
+    assert opts.relation_filters["variant_id"].placeholder == "Pick a supplier first"
+
+
+def test_relation_dependency_rejects_unknown_keys():
+    with pytest.raises(ValidationError):
+        RelationDependency(depends_on="x", unknown="y")  # type: ignore[call-arg]
+
+
+def test_relation_display_accepts_format_string():
+    opts = AdminOptions(relation_display={"supplier_id": "{name} — {city}"})
+    assert opts.relation_display is not None
+    assert opts.relation_display["supplier_id"] == "{name} — {city}"
+
+
+def test_relation_display_accepts_callable():
+    def _label(instance: object) -> str:
+        return str(instance)
+
+    opts = AdminOptions(relation_display={"supplier_id": _label})
+    assert opts.relation_display is not None
+    assert opts.relation_display["supplier_id"] is _label
+
+
+def test_validate_against_model_passes_for_known_field():
+    opts = AdminOptions(
+        relation_filters={"variant_id": RelationDependency(depends_on="supplier_id")}
+    )
+    # supplier_id exists on _Product — should not raise.
+    opts.validate_against_model(_Product)
+
+
+def test_validate_against_model_raises_for_unknown_field():
+    opts = AdminOptions(relation_filters={"variant_id": RelationDependency(depends_on="missing")})
+    with pytest.raises(ValueError, match="depends_on='missing' not in form fields"):
+        opts.validate_against_model(_Product)
+
+
+def test_validate_against_model_noop_when_relation_filters_unset():
+    """No relation_filters → validation is a no-op."""
+    opts = AdminOptions()
+    opts.validate_against_model(_Product)  # must not raise
+
+
+def test_use_autocomplete_widget_can_be_disabled():
+    opts = AdminOptions(use_autocomplete_widget=False)
+    assert opts.use_autocomplete_widget is False


### PR DESCRIPTION
## Summary

First implementation story under \`epic-v055-htmx-autocomplete\`. Adds the
declarative knobs that the autocomplete widget (next story) will consume.
No widget / view wiring yet — that lands in the follow-up.

- \`RelationDependency\` Pydantic model (\`depends_on\`, \`placeholder\`)
- \`AdminOptions.relation_filters: dict[str, RelationDependency] | None\`
- \`AdminOptions.relation_display: dict[str, str | Callable[[Any], str]] | None\`
  — format strings + callable escape hatch, per the approved SDD resolution
- \`AdminOptions.use_autocomplete_widget: bool = True\`
- \`AdminOptions.validate_against_model(model)\` — hook the registry calls
  to surface \`ValueError\` when \`depends_on\` references a missing field

Backward compatible — all new fields default to \`None\` / \`True\`.

## Spec

\`docs/specs/htmx-autocomplete.md\` (Approved 2026-05-11)

## Story

\`.meta/epics/epic-v055-htmx-autocomplete/stories/featcore-extend-adminoptions-with-relation-config.md\`

## Test plan

- [x] \`uv run pytest tests/unit/test_admin_options_relation_config.py\` — 11 new tests pass
- [x] \`uv run pytest tests/unit/\` — full unit sweep, 808 passed, no regressions
- [x] \`poe lint\` — all checks pass

## New test coverage

- defaults: \`relation_filters\` / \`relation_display\` → \`None\`, \`use_autocomplete_widget\` → \`True\`
- \`RelationDependency\` instance and dict-payload coercion
- extra-key rejection on \`RelationDependency\` (catches typos at construction)
- \`relation_display\` accepts both format strings and callables
- \`validate_against_model\` passes for known fields, raises for unknown, no-ops when filters unset
- \`use_autocomplete_widget=False\` opt-out