### PR TITLE
fix(inlines): row-level error highlighting in nested formsets (H2 polish)

### DIFF
--- a/src/hyperadmin/static/css/_inlines.css
+++ b/src/hyperadmin/static/css/_inlines.css
@@ -46,6 +46,11 @@
   display: none;
 }
 
+.ha-inline-row-error {
+  background-color: var(--ha-color-danger-subtle, rgba(220, 38, 38, 0.06));
+  box-shadow: inset 4px 0 0 var(--ha-color-danger, #dc2626);
+}
+
 .ha-inline-input {
   width: 100%;
 }

--- a/src/hyperadmin/templates/components/inline_row.html
+++ b/src/hyperadmin/templates/components/inline_row.html
@@ -3,8 +3,9 @@
       - row: InlineFormRow instance
       - inline: InlineFormset instance
 -#}
-<tr class="ha-inline-row{% if row.delete %} ha-inline-row-deleted{% endif %}"
+<tr class="ha-inline-row{% if row.delete %} ha-inline-row-deleted{% endif %}{% if row.has_errors %} ha-inline-row-error{% endif %}"
     data-testid="inline-{{ inline.prefix }}-row-{{ row.index }}"
+    {% if row.has_errors %}aria-invalid="true"{% endif %}
     id="inline-{{ inline.prefix }}-row-{{ row.index }}">
     {%- if row.pk -%}
     <input type="hidden" name="{{ inline.prefix }}-{{ row.index }}-pk" value="{{ row.pk }}" />
@@ -29,6 +30,9 @@
     </td>
     {%- endfor -%}
     <td class="ha-inline-actions" data-label="{{ _('Actions') }}">
+        {%- if row.has_errors -%}
+        <span hidden aria-hidden="true" data-testid="inline-{{ inline.prefix }}-row-{{ row.index }}-error"></span>
+        {%- endif -%}
         <button type="button"
                 class="ha-btn ha-btn-danger ha-btn-sm ha-inline-remove-btn"
                 data-testid="inline-{{ inline.prefix }}-remove-{{ row.index }}"

--- a/src/hyperadmin/views/forms.py
+++ b/src/hyperadmin/views/forms.py
@@ -537,6 +537,11 @@ class InlineFormRow:
     pk: int | None = None
     delete: bool = False
 
+    @property
+    def has_errors(self) -> bool:
+        """Whether any field on this row carries a validation error."""
+        return any(field.errors for field in self.fields)
+
 
 @dataclass
 class InlineFormset:

--- a/tests/unit/test_inline_row_error_markers.py
+++ b/tests/unit/test_inline_row_error_markers.py
@@ -1,0 +1,84 @@
+"""Template rendering tests for inline_row.html row-level error markers (H2 polish).
+
+The BDD scenarios from
+``.meta/epics/epic-v050-h2-inline-row-errors/stories/fixinlines-row-level-error-highlighting.md``
+are exercised here at the template-rendering level. A full E2E suite will be
+added when an example app exposes inline formsets end-to-end; this template
+test pins the contract that downstream UI tests can rely on.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.core.inlines import InlineModelSpec
+from hyperadmin.views.forms import InlineFormset
+
+
+class _Child(SQLModel):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    parent_id: int
+
+
+def _render_inline_row(row, fs) -> str:
+    """Render ``components/inline_row.html`` standalone for assertion-level testing."""
+    templates_dir = Path(__file__).resolve().parents[2] / "src" / "hyperadmin" / "templates"
+    env = Environment(
+        loader=FileSystemLoader(str(templates_dir)),
+        autoescape=select_autoescape(["html"]),
+    )
+    env.globals["_"] = lambda s: s  # identity gettext for tests
+    tpl = env.get_template("components/inline_row.html")
+    return tpl.render(row=row, inline=fs)
+
+
+@pytest.fixture
+def _formset() -> InlineFormset:
+    spec = InlineModelSpec(model=_Child, fk_field="parent_id")
+    return InlineFormset(spec=spec)
+
+
+def test_row_with_field_error_emits_row_level_error_markers(_formset: InlineFormset) -> None:
+    # Given a row whose first field carries a validation error
+    row = _formset._build_row(1)
+    row.fields[0].errors = ["Required"]
+
+    # When the inline_row template renders
+    html = _render_inline_row(row, _formset)
+
+    # Then the row exposes a row-level error testid, aria-invalid, and CSS class
+    expected_testid = f'data-testid="inline-{_formset.prefix}-row-1-error"'
+    assert expected_testid in html
+    assert 'aria-invalid="true"' in html
+    assert "ha-inline-row-error" in html
+
+
+def test_all_valid_row_renders_no_row_level_error_marker(_formset: InlineFormset) -> None:
+    # Given a row with no field errors
+    row = _formset._build_row(2)
+    for field in row.fields:
+        field.errors = None
+
+    # When the inline_row template renders
+    html = _render_inline_row(row, _formset)
+
+    # Then no row-level error markers appear
+    assert "-row-2-error" not in html
+    assert 'aria-invalid="true"' not in html
+    assert "ha-inline-row-error" not in html
+
+
+def test_existing_row_testid_is_unchanged(_formset: InlineFormset) -> None:
+    """The legacy row-finding testid must keep working for current selectors."""
+    row = _formset._build_row(0)
+    row.fields[0].errors = ["bad"]
+
+    html = _render_inline_row(row, _formset)
+
+    expected = f'data-testid="inline-{_formset.prefix}-row-0"'
+    assert expected in html

--- a/tests/unit/test_inlines.py
+++ b/tests/unit/test_inlines.py
@@ -332,6 +332,30 @@ class TestInlineFormRow:
         row = InlineFormRow(index=1, fields=[], pk=42)
         assert row.pk == 42
 
+    def test_has_errors_false_when_all_fields_clean(self) -> None:
+        spec = InlineModelSpec(model=ChildModel, fk_field="parent_id")
+        fs = InlineFormset(spec=spec)
+        row = fs._build_row(0)
+        for field in row.fields:
+            field.errors = None
+        assert row.has_errors is False
+
+    def test_has_errors_true_when_any_field_has_errors(self) -> None:
+        spec = InlineModelSpec(model=ChildModel, fk_field="parent_id")
+        fs = InlineFormset(spec=spec)
+        row = fs._build_row(0)
+        # Mark exactly one field as carrying a validation error.
+        row.fields[0].errors = ["Required"]
+        assert row.has_errors is True
+
+    def test_has_errors_false_when_errors_list_is_empty(self) -> None:
+        spec = InlineModelSpec(model=ChildModel, fk_field="parent_id")
+        fs = InlineFormset(spec=spec)
+        row = fs._build_row(0)
+        for field in row.fields:
+            field.errors = []  # falsy — explicit empty list
+        assert row.has_errors is False
+
 
 # ---------------------------------------------------------------------------
 # InlineFormset with ItemModel (optional fields)


### PR DESCRIPTION
## Summary

Closes the only remaining gap on the shipped H2 capability (nested forms,
v0.5.0). Today \`inline_row.html\` marks individual fields as invalid but the
operator scanning a long formset has no row-level cue.

- \`InlineFormRow.has_errors\` — derived property: \`any(field.errors for field in fields)\`
- \`inline_row.html\` — when \`row.has_errors\`:
  - \`<tr>\` gains class \`ha-inline-row-error\`
  - \`<tr>\` gains \`aria-invalid="true"\`
  - hidden marker span carries \`data-testid="inline-{prefix}-row-{i}-error"\`
- \`_inlines.css\` — visual accent (subtle background + 4px danger inset border)
- 3 unit tests for \`InlineFormRow.has_errors\`
- 3 template-rendering tests covering the two BDD scenarios from the story

Backward compatible — existing per-field error markup, \`aria-invalid\`, and
the row's base \`data-testid\` are unchanged.

## Note on E2E

Full Playwright coverage is gated on having an example app with inline
formsets registered. When that lands (\`examples/full-demo\` in v0.5.7),
the two BDD scenarios will be promoted to E2E tests; the template
assertions here pin the contract for that work.

## Spec

This story is \`size:S\` / bugfix-sized — no SDD required per
\`.claude/rules/sdd-conventions.md\`. BDD scenarios live in the story body.

## Story

\`.meta/epics/epic-v050-h2-inline-row-errors/stories/fixinlines-row-level-error-highlighting.md\`

## Test plan

- [x] \`uv run pytest tests/unit/test_inline_row_error_markers.py\` — 3 new template tests pass
- [x] \`uv run pytest tests/unit/test_inlines.py -k TestInlineFormRow\` — 5 pass (2 existing + 3 new)
- [x] \`uv run pytest tests/unit/\` — 802 passed, no regressions
- [x] \`poe lint\` — clean

## New test coverage

- \`test_has_errors_false_when_all_fields_clean\`
- \`test_has_errors_true_when_any_field_has_errors\`
- \`test_has_errors_false_when_errors_list_is_empty\`
- \`test_row_with_field_error_emits_row_level_error_markers\`
- \`test_all_valid_row_renders_no_row_level_error_marker\`
- \`test_existing_row_testid_is_unchanged\`