### PR TITLE
feat(views): add create_popup_view returning HX-Trigger payload

### DIFF
--- a/src/hyperadmin/routing.py
+++ b/src/hyperadmin/routing.py
@@ -151,6 +151,14 @@ def create_admin_router(  # noqa: PLR0913
         name=f"{model_name}-choices",
     )
 
+    if options.can_create:
+        router.add_api_route(
+            f"{prefix}/create-popup",
+            view.create_popup_view,
+            methods=["GET", "POST"],
+            name=f"{model_name}-create-popup",
+        )
+
     if options.inlines:
         router.add_api_route(
             f"{prefix}/inline/{{inline_prefix}}/add-row",

--- a/src/hyperadmin/templates/widgets/popup_form.html
+++ b/src/hyperadmin/templates/widgets/popup_form.html
@@ -1,0 +1,43 @@
+{#- Inline-create popup form for FK/M2M autocomplete (H6, v0.5.5).
+
+    Loaded into <div id="ha-popup-root"> via HTMX. On submit, the same URL is
+    POSTed and either returns this fragment again (validation errors) or an
+    empty 200 carrying an `HX-Trigger: hyperadminPopupCreated` header that the
+    widget JS listens for.
+
+    Context:
+      - form: PydanticForm — bound, with .errors populated on re-render
+      - target: str — the parent form field that triggered the popup
+      - post_url: URL of the popup endpoint
+      - model_name: str — used for the dialog heading
+-#}
+<form method="post" action="{{ post_url }}" data-testid="popup-form"
+      class="ha-popup-form" hx-post="{{ post_url }}" hx-target="this" hx-swap="outerHTML">
+  <h2 class="ha-popup-form__title">{{ _("Create") }} {{ model_name }}</h2>
+  <input type="hidden" name="target" value="{{ target }}" />
+
+  {% for field in form.fields %}
+  <div class="ha-form-field" data-testid="popup-form-field-{{ field.name }}">
+    <label for="popup-{{ field.name }}">
+      {{ field.label }}{% if field.required %} *{% endif %}
+    </label>
+    <input id="popup-{{ field.name }}"
+           name="{{ field.name }}"
+           type="{{ field.widget.input_type }}"
+           value="{{ field.value or '' }}"
+           class="ha-input"
+           aria-invalid="{{ 'true' if field.errors else 'false' }}" />
+    {% if field.errors %}
+    <ul class="ha-field-errors" aria-live="polite"
+        data-testid="popup-form-{{ field.name }}-errors">
+      {% for e in field.errors %}<li>{{ e }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+  </div>
+  {% endfor %}
+
+  <div class="ha-popup-form__actions">
+    <button type="submit" class="ha-btn ha-btn-primary"
+            data-testid="popup-form-submit">{{ _("Save") }}</button>
+  </div>
+</form>

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -924,6 +924,165 @@ class DynamicModelView:
         html = template.render(context)
         return Response(content=html, media_type="text/html")
 
+    def _resolve_relation_label(self, instance: Any, target_field: str) -> str:
+        """Render the option label for ``instance`` per ``AdminOptions.relation_display``.
+
+        Falls back to ``str(instance)`` when no template / callable is configured
+        or when rendering raises. The view never crashes a popup response over a
+        cosmetic label.
+        """
+        relation_display = getattr(self.options, "relation_display", None) or {}
+        template = relation_display.get(target_field)
+        if template is None:
+            return str(instance)
+        if callable(template):
+            try:
+                return str(template(instance))
+            except Exception:
+                logger.warning(
+                    "relation_display callable for %r raised; falling back to str()",
+                    target_field,
+                )
+                return str(instance)
+        try:
+            return template.format(
+                **{name: getattr(instance, name, "") for name in instance.model_fields}
+            )
+        except Exception:
+            logger.warning(
+                "relation_display template %r raised; falling back to str()", target_field
+            )
+            return str(instance)
+
+    async def create_popup_view(self, request: Request) -> Response:
+        """Inline-create endpoint for FK/M2M autocomplete widgets.
+
+        GET  /{model}/create-popup?target=<field>
+            Renders the popup form fragment for the modal.
+        POST /{model}/create-popup
+            Creates the row. On success returns 200 with an empty body and an
+            ``HX-Trigger`` header carrying
+            ``{"hyperadminPopupCreated": {"target": <field>, "id": <pk>, "label": <display>}}``
+            so the parent widget can insert the new option and close the modal.
+
+        Validation failures keep the modal open by re-rendering the form
+        fragment with field-level errors. Permission failures propagate through
+        :meth:`_check_permission`.
+        """
+        await self._check_permission(request, "add")
+
+        if request.method == "GET":
+            target = request.query_params.get("target")
+            if not target:
+                raise HTTPException(status_code=400, detail="target query param required")
+            return self._render_popup_form(request, target=target)
+
+        form_data = await request.form()
+        target_value = form_data.get("target")
+        if not target_value or not isinstance(target_value, str):
+            raise HTTPException(status_code=400, detail="target form field required")
+        target = target_value
+
+        create_include = self.form_include
+        if create_include and self.form_create_exclude:
+            create_include = [f for f in create_include if f not in self.form_create_exclude]
+        relation_widgets = await self._build_relation_widgets(field_names=create_include or [])
+        form = PydanticForm(
+            self.model,
+            widgets=relation_widgets,
+            include=create_include,
+            exclude=self.form_create_exclude,
+            fieldsets=getattr(self.options, "fieldsets", None) or None,
+            form_layout=getattr(self.options, "form_layout", None),
+            form_fields=getattr(self.options, "form_fields", None) or None,
+        )
+        data = self._extract_form_data(form_data, form)
+        data.pop("target", None)
+        file_uploads = self._pop_file_uploads(data, form)
+        form.bind(data)
+        instance, errs = form.validate(data)
+
+        if errs or not instance:
+            legacy_errs = {k: v[0] for k, v in (errs or {}).items() if v}
+            return self._render_popup_form(
+                request, target=str(target), values=data, errors=legacy_errs, status_code=200
+            )
+
+        try:
+            create_data = instance.model_dump()
+            create_data.update(file_uploads)
+            new_item = await self.adapter.create(data=create_data)
+        except IntegrityError as exc:
+            logger.exception("IntegrityError during popup create")
+            field_errors = _integrity_error_to_field_errors(exc)
+            return self._render_popup_form(
+                request,
+                target=str(target),
+                values=data,
+                errors=field_errors,
+                status_code=200,
+            )
+
+        new_pk = getattr(new_item, "id", None)
+        label = self._resolve_relation_label(new_item, str(target))
+        payload = {
+            "hyperadminPopupCreated": {
+                "target": str(target),
+                "id": new_pk,
+                "label": label,
+            }
+        }
+        import json as _json  # noqa: PLC0415
+
+        return Response(
+            content="",
+            status_code=200,
+            headers={"HX-Trigger": _json.dumps(payload)},
+        )
+
+    def _render_popup_form(
+        self,
+        request: Request,
+        target: str,
+        values: dict[str, Any] | None = None,
+        errors: dict[str, str] | None = None,
+        status_code: int = 200,
+    ) -> Response:
+        """Render the popup-form fragment used both for initial GET and error re-renders."""
+        create_include = self.form_include
+        if create_include and self.form_create_exclude:
+            create_include = [f for f in create_include if f not in self.form_create_exclude]
+        form = PydanticForm(
+            self.model,
+            include=create_include,
+            exclude=self.form_create_exclude,
+            initial=values or {},
+            fieldsets=getattr(self.options, "fieldsets", None) or None,
+            form_layout=getattr(self.options, "form_layout", None),
+            form_fields=getattr(self.options, "form_fields", None) or None,
+        )
+        if errors:
+            form.bind(values or {})
+            norm = {k: [v] for k, v in errors.items()}
+            form.errors = norm
+            for fld in form.fields:
+                fld.errors = norm.get(fld.name)
+        context = {
+            "request": request,
+            "model_name": self.model.__name__,
+            "form": form,
+            "target": target,
+            "values": values or {},
+            "errors": errors or {},
+            "post_url": request.url_for(f"{self._model_name_lower}-create-popup"),
+        }
+        return self.templates.TemplateResponse(
+            request,
+            "widgets/popup_form.html",
+            context,
+            status_code=status_code,
+        )
+
     async def upload_file_view(
         self,
         request: Request,

--- a/tests/unit/test_create_popup_view.py
+++ b/tests/unit/test_create_popup_view.py
@@ -1,0 +1,171 @@
+"""Unit tests for the FK/M2M create-popup endpoint (H6, v0.5.5).
+
+Mirrors the BDD scenarios in
+``.meta/epics/epic-v055-htmx-autocomplete/stories/featviews-add-create-popup-view.md``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import anyio
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
+from hyperadmin.main import Admin
+
+
+class Supplier(SQLModel, table=True):
+    __tablename__ = "test_popup_supplier"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+    city: str | None = None
+
+
+class SupplierAdmin(ModelAdmin):
+    adapter_class = SQLModelAdapter
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_registry():
+    site._registry = {}
+    yield
+    site._registry = {}
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async def setup_database():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    anyio.run(setup_database)
+
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
+    site.register(Supplier, SupplierAdmin)
+    admin.mount(path="/admin")
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET — initial popup form render
+# ---------------------------------------------------------------------------
+
+
+def test_popup_get_renders_form_fragment(client: TestClient):
+    """The widget's "+" button issues `hx-get` to this endpoint to open the modal."""
+    response = client.get("/admin/supplier/create-popup?target=supplier_id")
+
+    assert response.status_code == 200
+    body = response.text
+    assert 'data-testid="popup-form"' in body
+    # The form posts back to the same URL with `target` preserved.
+    assert "supplier_id" in body
+
+
+# ---------------------------------------------------------------------------
+# POST — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_popup_post_with_valid_data_returns_hx_trigger(client: TestClient):
+    """
+    Scenario: popup create with valid data returns HX-Trigger payload
+      Given Supplier is registered
+      When  POST /admin/supplier/create-popup with valid form data + target=supplier_id
+      Then  response status is 200 and body is empty
+      And   HX-Trigger header contains "hyperadminPopupCreated" with id=<new pk> and target="supplier_id"
+    """
+    # Given / When
+    response = client.post(
+        "/admin/supplier/create-popup",
+        data={"name": "Acme", "city": "Paris", "target": "supplier_id"},
+    )
+
+    # Then
+    assert response.status_code == 200
+    assert response.text == ""
+    trigger = response.headers.get("HX-Trigger")
+    assert trigger is not None
+    payload = json.loads(trigger)
+    assert "hyperadminPopupCreated" in payload
+    event = payload["hyperadminPopupCreated"]
+    assert event["target"] == "supplier_id"
+    assert isinstance(event["id"], int)
+    assert event["id"] >= 1
+    # Label falls back to str(instance) — SQLModel default is the repr.
+    assert event["label"]
+
+
+def test_popup_post_with_validation_error_re_renders_form(client: TestClient):
+    """Pydantic validation error keeps the modal open with field-level errors."""
+    # Given / When name is missing (required field)
+    response = client.post(
+        "/admin/supplier/create-popup",
+        data={"target": "supplier_id"},
+    )
+
+    # Then the form re-renders (no HX-Trigger event yet).
+    assert "HX-Trigger" not in response.headers or "hyperadminPopupCreated" not in (
+        response.headers.get("HX-Trigger") or ""
+    )
+    assert 'data-testid="popup-form"' in response.text
+    # The selected target is preserved through the re-render.
+    assert "supplier_id" in response.text
+
+
+def test_popup_post_without_target_returns_400(client: TestClient):
+    """`target` is required — the modal cannot know which field to populate without it."""
+    response = client.post(
+        "/admin/supplier/create-popup",
+        data={"name": "Acme"},
+    )
+    assert response.status_code == 400
+    assert "target" in response.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Permission denied — `_check_permission` is the same gate used by `create_view`,
+# already covered by the broader permission integration tests. We assert it is
+# wired in by monkey-patching the view's permission_checker after mount.
+# ---------------------------------------------------------------------------
+
+
+def test_popup_post_invokes_permission_check_with_add_codename(client: TestClient):
+    """The view must call ``_check_permission(request, "add")`` before creating."""
+    calls: list[str] = []
+
+    class _AllowAddDenyOthers:
+        async def has_permission(self, user, codename):
+            calls.append(codename)
+            return codename.startswith("add_")
+
+    for route in client.app.router.routes:
+        endpoint = getattr(route, "endpoint", None)
+        view = getattr(endpoint, "__self__", None) if endpoint else None
+        if view is not None and hasattr(view, "permission_checker"):
+            view.permission_checker = _AllowAddDenyOthers()
+
+    # Authenticated request — middleware-set user required when a checker is wired.
+    @client.app.middleware("http")
+    async def _user(request, call_next):
+        request.state.user = {"id": 1}
+        return await call_next(request)
+
+    response = client.post(
+        "/admin/supplier/create-popup",
+        data={"name": "Acme", "target": "supplier_id"},
+    )
+
+    assert response.status_code == 200
+    assert "add_supplier" in calls


### PR DESCRIPTION
## Summary

Second implementation story under \`epic-v055-htmx-autocomplete\`. Adds the
inline-create endpoint that the FK/M2M autocomplete widget's "+" button will
drive. Templates for the widget itself land in the next story.

- \`DynamicModelView.create_popup_view\` — handles GET + POST at
  \`/{model}/create-popup\`
  - **GET** \`?target=<field>\` — renders the popup_form fragment for the modal
  - **POST** — creates the row; success returns 200 with empty body and an
    \`HX-Trigger\` header carrying
    \`{hyperadminPopupCreated: {target, id, label}}\`
- \`_render_popup_form\` — shared renderer used for the initial GET and for
  validation-error re-renders (keeps the modal open with field errors)
- \`_resolve_relation_label\` — applies \`AdminOptions.relation_display\` per the
  approved SDD decision (format string OR \`Callable[[Any], str]\`, with safe
  fallback to \`str(instance)\` on any rendering failure)
- \`routing.py\` — registers GET+POST \`/{model}/create-popup\` when \`can_create\`
- \`templates/widgets/popup_form.html\` — minimal form fragment; widget story
  will refine the modal chrome

Backward compatible — no existing endpoint or template touched.

## Spec

\`docs/specs/htmx-autocomplete.md\` (Approved 2026-05-11)

## Story

\`.meta/epics/epic-v055-htmx-autocomplete/stories/featviews-add-create-popup-view.md\`

## BDD scenarios covered

- GET renders the popup-form fragment with \`data-testid="popup-form"\`
- POST with valid data returns 200 + empty body + \`HX-Trigger\` payload
  (\`target\`, \`id\`, \`label\` from \`relation_display\` or \`str(instance)\`)
- POST with validation error re-renders the form (modal stays open, ids/target
  preserved)
- POST without \`target\` returns 400
- \`_check_permission(request, "add")\` is invoked before any DB writes

## Test plan

- [x] \`uv run pytest tests/unit/test_create_popup_view.py\` — 5 new tests pass
- [x] \`uv run pytest tests/unit/\` — 813 passed, no regressions
- [x] \`poe lint\` — all checks pass (ruff / ruff-format / mypy / basedpyright)