### PR TITLE
feat(views): add bulk action endpoint with per-row outcome (v0.5.5)

### DIFF
--- a/src/hyperadmin/core/bulk_results.py
+++ b/src/hyperadmin/core/bulk_results.py
@@ -1,0 +1,28 @@
+"""Per-row outcome record for bulk-action execution.
+
+See ``docs/specs/bulk-actions.md`` for the parent contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, NamedTuple
+
+BulkRowStatus = Literal["ok", "failed", "forbidden"]
+
+
+class BulkRowResult(NamedTuple):
+    """A single row's outcome from a bulk action run.
+
+    Args:
+        id: The primary key the bulk action targeted.
+        status: ``"ok"`` (handler returned successfully),
+            ``"failed"`` (handler raised a non-permission exception), or
+            ``"forbidden"`` (object-level permission denied, or the handler
+            raised ``HTTPException(403)``).
+        detail: Optional human-readable detail (typically the exception's
+            ``detail``/``str``). ``None`` for ``"ok"`` rows.
+    """
+
+    id: Any
+    status: BulkRowStatus
+    detail: str | None

--- a/src/hyperadmin/routing.py
+++ b/src/hyperadmin/routing.py
@@ -174,6 +174,19 @@ def create_admin_router(  # noqa: PLR0913
             methods=["POST"],
             name=f"{model_name}-action",
         )
+        if any(a.bulk for a in actions):
+            router.add_api_route(
+                f"{prefix}/actions/{{action_name}}/bulk",
+                view.run_bulk_action,
+                methods=["POST"],
+                name=f"{model_name}-bulk-action",
+            )
+            router.add_api_route(
+                f"{prefix}/actions/{{action_name}}/bulk/confirm",
+                view.confirm_bulk_action,
+                methods=["POST"],
+                name=f"{model_name}-bulk-action-confirm",
+            )
 
     if storage:
         router.add_api_route(

--- a/src/hyperadmin/templates/components/bulk_form.html
+++ b/src/hyperadmin/templates/components/bulk_form.html
@@ -1,0 +1,43 @@
+{#- Parameter-collection form for a bulk action (H3, v0.5.5).
+
+    Context:
+      - action: ActionDef (has .name, .label, .form)
+      - ids: list[int] — preserved as hidden inputs
+      - fields: list[dict(name,label,required,input_type,errors)] — built from action.form
+      - confirm_url: URL of the /bulk/confirm endpoint
+-#}
+<form method="post" action="{{ confirm_url }}" data-testid="bulk-form"
+      class="ha-bulk-form">
+  <h2 class="ha-bulk-form__title">{{ action.label }}</h2>
+  <p class="ha-bulk-form__lede">
+    {{ _("This action will run on") }} <strong>{{ ids|length }}</strong>
+    {{ _("selected row(s)") }}.
+  </p>
+
+  {% for pk in ids -%}
+  <input type="hidden" name="ids" value="{{ pk }}" />
+  {%- endfor %}
+
+  {% for field in fields %}
+  <div class="ha-form-field" data-testid="bulk-form-field-{{ field.name }}">
+    <label for="bulk-{{ field.name }}">{{ field.label }}{% if field.required %} *{% endif %}</label>
+    <input id="bulk-{{ field.name }}"
+           name="{{ field.name }}"
+           type="{{ field.input_type }}"
+           {% if field.input_type == 'number' %}step="any"{% endif %}
+           class="ha-input"
+           aria-invalid="{{ 'true' if field.errors else 'false' }}" />
+    {% if field.errors %}
+    <ul class="ha-field-errors" aria-live="polite"
+        data-testid="bulk-form-{{ field.name }}-errors">
+      {% for e in field.errors %}<li>{{ e }}</li>{% endfor %}
+    </ul>
+    {% endif %}
+  </div>
+  {% endfor %}
+
+  <div class="ha-bulk-form__actions">
+    <button type="submit" class="ha-btn ha-btn-primary"
+            data-testid="bulk-confirm-btn">{{ _("Run") }}</button>
+  </div>
+</form>

--- a/src/hyperadmin/templates/components/bulk_result.html
+++ b/src/hyperadmin/templates/components/bulk_result.html
@@ -1,0 +1,38 @@
+{#- Per-row result page for a completed bulk action (H3, v0.5.5).
+
+    Context:
+      - action: ActionDef
+      - outcomes: list[BulkRowResult]
+      - bulk_endpoint_url: URL of the /bulk endpoint (for "Retry failures")
+      - failed_ids: list[int] — non-"ok" outcome ids
+-#}
+<section class="ha-bulk-result" data-testid="bulk-result">
+  <h2 class="ha-bulk-result__title">{{ action.label }} — {{ _("Results") }}</h2>
+
+  <table class="ha-bulk-result__table">
+    <thead>
+      <tr><th>{{ _("ID") }}</th><th>{{ _("Status") }}</th><th>{{ _("Detail") }}</th></tr>
+    </thead>
+    <tbody>
+      {% for outcome in outcomes %}
+      <tr data-testid="bulk-result-row">
+        <td>{{ outcome.id }}</td>
+        <td>
+          <span class="ha-bulk-status ha-bulk-status--{{ outcome.status }}"
+                data-testid="bulk-result-status-{{ outcome.id }}">{{ outcome.status }}</span>
+        </td>
+        <td>{{ outcome.detail or "" }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {% if failed_ids %}
+  <form method="post" action="{{ bulk_endpoint_url }}"
+        data-testid="bulk-retry-form" class="ha-bulk-retry">
+    {% for pk in failed_ids %}<input type="hidden" name="ids" value="{{ pk }}" />{% endfor %}
+    <button type="submit" class="ha-btn ha-btn-secondary"
+            data-testid="bulk-retry-link">{{ _("Retry failures") }}</button>
+  </form>
+  {% endif %}
+</section>

--- a/src/hyperadmin/views/dynamic.py
+++ b/src/hyperadmin/views/dynamic.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Union, cast, get_args, get_origin
 
 from fastapi import HTTPException, Query, Request
 from fastapi.templating import Jinja2Templates
+from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError
 from starlette.responses import RedirectResponse, Response
 
@@ -18,6 +19,7 @@ from starlette.datastructures import UploadFile as StarletteUpload
 
 from hyperadmin.adapters import SQLAlchemyAdapter, SQLModelAdapter
 from hyperadmin.core.actions import ActionDef
+from hyperadmin.core.bulk_results import BulkRowResult, BulkRowStatus
 from hyperadmin.core.choices import ChoiceItem, SelectFieldMeta
 from hyperadmin.core.discovery import build_filter_metadata
 from hyperadmin.core.display import get_display_name
@@ -1359,6 +1361,188 @@ class DynamicModelView:
         if "hx-request" in request.headers:
             return Response(status_code=200, headers={"HX-Redirect": str(redirect_url)})
         return RedirectResponse(url=redirect_url, status_code=303)
+
+    def _resolve_bulk_action(self, action_name: str) -> ActionDef:
+        """Return the bulk ``ActionDef`` for ``action_name`` or raise 404."""
+        action_def = self._action_map.get(action_name)
+        if action_def is None or not action_def.bulk:
+            raise HTTPException(status_code=404, detail=f"Bulk action '{action_name}' not found")
+        return action_def
+
+    @staticmethod
+    def _parse_ids(form: Any) -> list[int]:
+        """Parse the ``ids`` multi-valued form field into a list of ints.
+
+        Silently drops entries that aren't parseable as integers — those would
+        not match any row anyway.
+        """
+        raw = form.getlist("ids") if hasattr(form, "getlist") else []
+        parsed: list[int] = []
+        for value in raw:
+            try:
+                parsed.append(int(value))
+            except (TypeError, ValueError):
+                continue
+        return parsed
+
+    async def _execute_bulk(
+        self,
+        request: Request,
+        action_def: ActionDef,
+        ids: list[int],
+        params: Any | None,
+    ) -> list[BulkRowResult]:
+        """Run ``action_def.handler`` over ``ids`` with per-row outcome capture.
+
+        Each row is wrapped in object-permission re-check + exception capture so
+        a single failure cannot abort the whole bulk run.
+        """
+        outcomes: list[BulkRowResult] = []
+        permission_codename = f"action_{action_def.name}"
+        for item_id in ids:
+            try:
+                item = await self.adapter.get(pk=item_id)
+            except Exception as exc:
+                outcomes.append(BulkRowResult(id=item_id, status="failed", detail=str(exc)))
+                continue
+            if item is None:
+                outcomes.append(BulkRowResult(id=item_id, status="failed", detail="not found"))
+                continue
+            try:
+                await self._check_object_permission(request, item, permission_codename)
+            except HTTPException as exc:
+                outcomes.append(
+                    BulkRowResult(id=item_id, status="forbidden", detail=str(exc.detail))
+                )
+                continue
+            try:
+                await action_def.handler(self._admin_instance, request, item_id, params=params)
+            except HTTPException as exc:
+                status: BulkRowStatus = "forbidden" if exc.status_code == 403 else "failed"
+                outcomes.append(BulkRowResult(id=item_id, status=status, detail=str(exc.detail)))
+            except Exception as exc:
+                logger.warning(
+                    "Bulk action %r failed on row %s: %s",
+                    action_def.name,
+                    item_id,
+                    exc,
+                )
+                outcomes.append(BulkRowResult(id=item_id, status="failed", detail=str(exc)))
+            else:
+                outcomes.append(BulkRowResult(id=item_id, status="ok", detail=None))
+        return outcomes
+
+    def _render_bulk_result(
+        self,
+        request: Request,
+        action_def: ActionDef,
+        outcomes: list[BulkRowResult],
+    ) -> Response:
+        """Render the per-row result page (or HTMX fragment)."""
+        context = {
+            "request": request,
+            "action": action_def,
+            "outcomes": outcomes,
+            "model_name": self._model_name_lower,
+            "bulk_endpoint_url": request.url_for(
+                f"{self._model_name_lower}-bulk-action", action_name=action_def.name
+            ),
+            "failed_ids": [o.id for o in outcomes if o.status != "ok"],
+        }
+        return self.templates.TemplateResponse(request, "components/bulk_result.html", context)
+
+    def _render_bulk_form(
+        self,
+        request: Request,
+        action_def: ActionDef,
+        ids: list[int],
+        errors: dict[str, list[str]] | None = None,
+    ) -> Response:
+        """Render the Pydantic-derived parameter form before bulk execution."""
+        form_model = action_def.form
+        fields: list[dict[str, Any]] = []
+        if form_model is not None:
+            for name, info in form_model.model_fields.items():
+                fields.append(
+                    {
+                        "name": name,
+                        "label": info.title or name.replace("_", " ").capitalize(),
+                        "required": info.is_required,
+                        "input_type": "number" if info.annotation is int else "text",
+                        "errors": (errors or {}).get(name, []),
+                    }
+                )
+        context = {
+            "request": request,
+            "action": action_def,
+            "ids": ids,
+            "fields": fields,
+            "model_name": self._model_name_lower,
+            "confirm_url": request.url_for(
+                f"{self._model_name_lower}-bulk-action-confirm",
+                action_name=action_def.name,
+            ),
+        }
+        return self.templates.TemplateResponse(request, "components/bulk_form.html", context)
+
+    async def run_bulk_action(self, request: Request, action_name: str) -> Response:
+        """Entry point for bulk actions.
+
+        ``POST /{model}/actions/{name}/bulk``
+
+        - When the action declares a Pydantic ``form``, this endpoint renders the
+          parameter-collection form with the selected ids preserved.
+        - Otherwise it executes the handler per row and renders the per-row
+          result page.
+        """
+        action_def = self._resolve_bulk_action(action_name)
+        await self._check_permission(request, f"action_{action_name}")
+
+        form = await request.form()
+        ids = self._parse_ids(form)
+
+        if action_def.requires_selection and not ids:
+            raise HTTPException(status_code=400, detail="Selection required")
+
+        if action_def.form is not None:
+            return self._render_bulk_form(request, action_def, ids)
+
+        outcomes = await self._execute_bulk(request, action_def, ids, params=None)
+        return self._render_bulk_result(request, action_def, outcomes)
+
+    async def confirm_bulk_action(self, request: Request, action_name: str) -> Response:
+        """Validate the Pydantic param form and execute the bulk handler.
+
+        ``POST /{model}/actions/{name}/bulk/confirm``
+        """
+        action_def = self._resolve_bulk_action(action_name)
+        await self._check_permission(request, f"action_{action_name}")
+
+        if action_def.form is None:
+            raise HTTPException(
+                status_code=404, detail=f"Bulk action '{action_name}' has no confirm step"
+            )
+
+        form = await request.form()
+        ids = self._parse_ids(form)
+
+        if action_def.requires_selection and not ids:
+            raise HTTPException(status_code=400, detail="Selection required")
+
+        form_model = action_def.form
+        payload = {key: value for key, value in form.items() if key not in {"ids"}}
+        try:
+            params = form_model(**payload)
+        except ValidationError as exc:
+            errors: dict[str, list[str]] = {}
+            for err in exc.errors():
+                loc = err.get("loc") or ("__all__",)
+                field = str(loc[0])
+                errors.setdefault(field, []).append(str(err.get("msg", "invalid")))
+            return self._render_bulk_form(request, action_def, ids, errors=errors)
+
+        outcomes = await self._execute_bulk(request, action_def, ids, params=params)
+        return self._render_bulk_result(request, action_def, outcomes)
 
 
 async def admin_dashboard(request: Request, templates: Jinja2Templates):

--- a/tests/unit/test_bulk_actions.py
+++ b/tests/unit/test_bulk_actions.py
@@ -1,0 +1,372 @@
+"""Unit tests for the bulk action endpoint (H3, v0.5.5).
+
+Mirrors the four BDD scenarios in
+``.meta/epics/epic-v055-bulk-actions/stories/featviews-add-run-bulk-action-endpoint.md``
+plus a small handful of dispatch tests for the surrounding plumbing.
+"""
+
+from __future__ import annotations
+
+import anyio
+import pytest
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlmodel import Field, SQLModel
+
+from hyperadmin.adapters.sqlmodel import SQLModelAdapter
+from hyperadmin.core.actions import action
+from hyperadmin.core.auth import DefaultObjectPermissionChecker
+from hyperadmin.core.bulk_results import BulkRowResult
+from hyperadmin.core.model import ModelAdmin
+from hyperadmin.core.options import AdminOptions
+from hyperadmin.core.registry import site
+from hyperadmin.core.settings import HyperAdminSettings
+from hyperadmin.main import Admin
+
+
+class BulkWidget(SQLModel, table=True):
+    __tablename__ = "test_bulk_widget"
+    id: int | None = Field(default=None, primary_key=True)
+    name: str
+
+
+class _ReassignParams(BaseModel):
+    operator: int
+
+
+_calls: list[tuple[int, _ReassignParams | None]] = []
+_fail_ids: set[int] = set()
+_forbid_ids: set[int] = set()
+
+
+class BulkWidgetAdmin(ModelAdmin):
+    adapter_class = SQLModelAdapter
+
+    @action(label="Archive", bulk=True)
+    async def archive(self, request: Request, item_id: int, *, params=None) -> None:
+        if item_id in _forbid_ids:
+            raise HTTPException(status_code=403, detail="permission denied")
+        if item_id in _fail_ids:
+            raise RuntimeError("boom")
+        _calls.append((item_id, params))
+
+    @action(label="Reassign", bulk=True, form=_ReassignParams)
+    async def reassign(self, request: Request, item_id: int, *, params=None) -> None:
+        _calls.append((item_id, params))
+
+    @action(label="Archive overdue", bulk=True, requires_selection=False)
+    async def archive_overdue(self, request: Request, item_id: int, *, params=None) -> None:
+        _calls.append((item_id, params))
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_registry():
+    site._registry = {}
+    _calls.clear()
+    _fail_ids.clear()
+    _forbid_ids.clear()
+    yield
+    site._registry = {}
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async def setup_database():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+        from sqlalchemy.orm import sessionmaker
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with session_factory() as session:
+            for name in ("alpha", "beta", "gamma", "delta", "epsilon"):
+                session.add(BulkWidget(name=name))
+            await session.commit()
+
+    anyio.run(setup_database)
+
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
+    site.register(BulkWidget, BulkWidgetAdmin)
+    admin.mount(path="/admin")
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# BulkRowResult shape
+# ---------------------------------------------------------------------------
+
+
+def test_bulkrowresult_carries_id_status_detail():
+    r = BulkRowResult(id=1, status="ok", detail=None)
+    assert r.id == 1
+    assert r.status == "ok"
+    assert r.detail is None
+
+
+# ---------------------------------------------------------------------------
+# BDD: empty selection
+# ---------------------------------------------------------------------------
+
+
+def test_empty_ids_with_requires_selection_returns_400(client: TestClient):
+    """
+    Scenario: empty ids with requires_selection returns 400
+      Given a ModelAdmin with @action(bulk=True) (requires_selection defaults to True)
+      When  POST /admin/bulkwidget/actions/archive/bulk with no ids
+      Then  response is 400 and body contains "Selection required"
+      And   the handler is not invoked
+    """
+    # Given / When
+    response = client.post("/admin/bulkwidget/actions/archive/bulk", data={})
+
+    # Then
+    assert response.status_code == 400
+    assert "Selection required" in response.text
+    assert _calls == []
+
+
+def test_requires_selection_false_allows_empty_ids(client: TestClient):
+    """`bulk=True` actions can opt out of the auto-selection requirement."""
+    # Given an action with requires_selection=False
+    # When the bulk endpoint runs with no ids
+    response = client.post(
+        "/admin/bulkwidget/actions/archive_overdue/bulk", data={}, follow_redirects=False
+    )
+
+    # Then the endpoint does not reject the request as "Selection required".
+    assert response.status_code != 400 or "Selection required" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# BDD: per-row outcomes (success + 403 + generic exception)
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_handler_runs_per_row_and_captures_forbidden(client: TestClient):
+    """
+    Scenario: bulk handler runs per-row, captures HTTPException(403) as forbidden
+      Given handler raises HTTPException(403) for id=2
+      When  POST .../bulk with ids=[1,2,3]
+      Then  result rows are ok / forbidden / ok in order
+    """
+    # Given
+    _forbid_ids.update({2})
+
+    # When
+    response = client.post(
+        "/admin/bulkwidget/actions/archive/bulk",
+        data={"ids": ["1", "2", "3"]},
+    )
+
+    # Then
+    assert response.status_code == 200
+    body = response.text
+    # The result page renders one row per outcome with a status badge.
+    assert body.count('data-testid="bulk-result-row"') == 3
+    assert "ok" in body
+    assert "forbidden" in body
+    # The handler was invoked for ids 1 and 3 only.
+    invoked = sorted(item_id for item_id, _ in _calls)
+    assert invoked == [1, 3]
+
+
+def test_bulk_handler_captures_generic_exception_as_failed(client: TestClient):
+    """
+    Scenario: bulk handler runs per-row, captures generic exception as failed
+      Given handler raises RuntimeError("boom") for id=2
+      When  POST .../bulk with ids=[1,2,3]
+      Then  result rows are ok / failed / ok in order
+      And   the "failed" row carries detail "boom"
+    """
+    # Given
+    _fail_ids.update({2})
+
+    # When
+    response = client.post(
+        "/admin/bulkwidget/actions/archive/bulk",
+        data={"ids": ["1", "2", "3"]},
+    )
+
+    # Then
+    assert response.status_code == 200
+    body = response.text
+    assert "failed" in body
+    assert "boom" in body
+
+
+# ---------------------------------------------------------------------------
+# BDD: param form workflow
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_with_form_renders_param_form_with_hidden_ids(client: TestClient):
+    """
+    Scenario: bulk action with param form prompts before running
+      Given @action(bulk=True, form=ReassignParams) with field operator: int
+      When  POST /admin/bulkwidget/actions/reassign/bulk with ids=[1,2,3]
+      Then  the response renders a form with operator input
+      And   the form preserves the selected ids in hidden inputs
+      And   the handler is NOT invoked
+    """
+    # Given / When
+    response = client.post(
+        "/admin/bulkwidget/actions/reassign/bulk",
+        data={"ids": ["1", "2", "3"]},
+    )
+
+    # Then
+    assert response.status_code == 200
+    body = response.text
+    assert 'data-testid="bulk-form"' in body
+    assert 'name="operator"' in body
+    # Hidden ids preserved.
+    for pk in ("1", "2", "3"):
+        assert f'value="{pk}"' in body
+    assert _calls == []
+
+
+def test_bulk_with_form_confirm_runs_handler_with_validated_params(client: TestClient):
+    """
+    Scenario: bulk action with valid params runs over selected rows
+      Given the param form has operator: int
+      When  POST .../bulk/confirm with operator=42 and ids=[1,2,3]
+      Then  the handler runs 3 times with params.operator == 42
+      And   the response is the per-row result page
+    """
+    # Given / When
+    response = client.post(
+        "/admin/bulkwidget/actions/reassign/bulk/confirm",
+        data={"ids": ["1", "2", "3"], "operator": "42"},
+    )
+
+    # Then
+    assert response.status_code == 200
+    assert response.text.count('data-testid="bulk-result-row"') == 3
+    operators = [params.operator for _, params in _calls if params is not None]
+    assert operators == [42, 42, 42]
+
+
+def test_bulk_with_form_confirm_rejects_invalid_params(client: TestClient):
+    """Form re-renders with validation errors when params are invalid."""
+    # Given / When operator is not an int
+    response = client.post(
+        "/admin/bulkwidget/actions/reassign/bulk/confirm",
+        data={"ids": ["1"], "operator": "not-a-number"},
+    )
+
+    # Then the form re-renders with the same ids preserved, and no handler runs.
+    assert response.status_code in {200, 422}
+    assert _calls == []
+
+
+# ---------------------------------------------------------------------------
+# BDD: object-level permissions
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_object_permission_denial_surfaces_per_row():
+    """
+    Scenario: object-permission denial surfaces per row
+      Given an ObjectPermissionChecker that denies "archive" on id=2
+      When  POST .../bulk with ids=[1,2,3]
+      Then  result rows are ok / forbidden / ok
+      And   the handler is invoked only for ids 1 and 3
+    """
+    app = FastAPI()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    @app.middleware("http")
+    async def _inject_user(request: Request, call_next):
+        request.state.user = {"id": 1, "username": "alice"}
+        return await call_next(request)
+
+    class _DenyForId2(DefaultObjectPermissionChecker):
+        async def has_object_permission(self, user, obj, action):  # type: ignore[override]
+            if getattr(obj, "id", None) == 2 and action.startswith("action_"):
+                return False
+            return True
+
+    class _ScopedAdmin(ModelAdmin):
+        adapter_class = SQLModelAdapter
+        options_class = AdminOptions
+
+        @action(label="Archive", bulk=True)
+        async def archive(self, request: Request, item_id: int, *, params=None) -> None:
+            _calls.append((item_id, params))
+
+    async def setup_database():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+        from sqlalchemy.orm import sessionmaker
+        from sqlmodel.ext.asyncio.session import AsyncSession
+
+        session_factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        async with session_factory() as session:
+            for name in ("a", "b", "c"):
+                session.add(BulkWidget(name=name))
+            await session.commit()
+
+    anyio.run(setup_database)
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
+    site.register(
+        BulkWidget,
+        _ScopedAdmin,
+        options=AdminOptions(object_permission_checker=_DenyForId2()),
+    )
+    admin.mount(path="/admin")
+    client = TestClient(app)
+
+    # When
+    response = client.post(
+        "/admin/bulkwidget/actions/archive/bulk",
+        data={"ids": ["1", "2", "3"]},
+    )
+
+    # Then
+    assert response.status_code == 200
+    invoked = sorted(item_id for item_id, _ in _calls)
+    assert invoked == [1, 3]
+    assert "forbidden" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_bulk_action_returns_404(client: TestClient):
+    response = client.post("/admin/bulkwidget/actions/nope/bulk", data={"ids": ["1"]})
+    assert response.status_code == 404
+
+
+def test_non_bulk_action_at_bulk_endpoint_returns_404(client: TestClient):
+    """A single-record action (no `bulk=True`) is not exposed via the bulk endpoint."""
+
+    class _SingleAdmin(ModelAdmin):
+        adapter_class = SQLModelAdapter
+
+        @action(label="Single")
+        async def single(self, request: Request, item_id: int) -> None:
+            pass
+
+    site._registry = {}
+    app = FastAPI()
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async def setup():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    anyio.run(setup)
+    admin = Admin(app=app, engine=engine, settings=HyperAdminSettings(create_tables=False))
+    site.register(BulkWidget, _SingleAdmin)
+    admin.mount(path="/admin")
+    client = TestClient(app)
+
+    response = client.post("/admin/bulkwidget/actions/single/bulk", data={"ids": ["1"]})
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

Wires the bulk-action endpoints onto `DynamicModelView` (milestone v0.5.5). Adds `core/bulk_results.py` (a `BulkRowResult` NamedTuple plus a `BulkRowStatus` literal), and extends `views/dynamic.py` with helpers to resolve a bulk-capable action (404 for missing or non-bulk actions), parse the multi-valued `ids` form param, and dispatch per row. Each row is processed independently with an object-permission re-check and exception capture, so a `403` becomes a `forbidden` outcome and any other error becomes `failed` while sibling rows still succeed. Two new routes are registered — `POST /{model}/actions/{name}/bulk` and `POST /{model}/actions/{name}/bulk/confirm` — but only when a registered action declares `bulk=True`. New Jinja components render the Pydantic-derived parameter form (`bulk_form.html`) and the per-row status grid with a retry form (`bulk_result.html`). The single-record `/action/{name}` endpoint is unchanged, so the change is backward compatible. 11 unit tests cover all four BDD scenarios plus dispatch edge cases.

**Milestone:** v0.5.5
**Spec:** docs/specs/bulk-actions.md (Approved 2026-05-11)

## Manual test scenarios

**Scenario: bulk action applies to every selected row**
  Given a model registered with a `bulk=True` action and several rows
  When  the reviewer selects multiple rows and POSTs to `/{model}/actions/{name}/bulk/confirm` with the `ids`
  Then  the result grid shows one `success` row per selected id

**Scenario: a forbidden row is isolated from successful rows**
  Given a bulk action where the current user lacks object permission on one of the selected rows
  When  the bulk action is confirmed
  Then  the offending row shows `forbidden` while the remaining rows show `success`

**Scenario: a non-bulk or missing action returns 404**
  Given a model whose action is not declared `bulk=True` (or does not exist)
  When  a request hits `/{model}/actions/{name}/bulk`
  Then  the server responds with HTTP 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)