### PR TITLE
ci(demo): add examples/erp deployment workflow + docs live-demo link

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy Demo
+
+# Builds the examples/erp ERP demo image and deploys it to Fly.io.
+#
+# Triggers:
+#   - workflow_dispatch: manual deploy from the Actions tab
+#   - push tags matching 'demo-*': e.g. `git tag demo-2026-06-02 && git push --tags`
+#
+# Required secrets (a maintainer must set these for deployment to actually run):
+#   - FLY_API_TOKEN          Fly.io deploy token (flyctl auth token / fly tokens create deploy)
+#   - HYPERADMIN_SECRET_KEY  Session signing key for the demo app
+#
+# Deployment is inert until FLY_API_TOKEN is configured: the deploy step
+# detects the missing secret and no-ops cleanly instead of failing.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "demo-*"
+
+jobs:
+  deploy:
+    name: Build & deploy ERP demo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Build the image locally first so a broken Dockerfile fails the run
+      # regardless of whether deploy secrets are configured.
+      - name: Build demo image
+        run: |
+          docker build \
+            -f examples/erp/Dockerfile \
+            -t hyperadmin-demo:${{ github.sha }} \
+            .
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          HYPERADMIN_SECRET_KEY: ${{ secrets.HYPERADMIN_SECRET_KEY }}
+        run: |
+          if [ -z "${FLY_API_TOKEN}" ]; then
+            echo "::warning::FLY_API_TOKEN is not set — skipping deploy (no-op)."
+            echo "Set the FLY_API_TOKEN repository secret to enable the live demo deployment."
+            exit 0
+          fi
+
+          # Push the session secret as a Fly secret if provided (best effort).
+          if [ -n "${HYPERADMIN_SECRET_KEY}" ]; then
+            flyctl secrets set "HYPERADMIN_SECRET_KEY=${HYPERADMIN_SECRET_KEY}" \
+              --app hyperadmin-demo --stage || true
+          fi
+
+          # Run from the repo root so the Docker build context includes
+          # src/, pyproject.toml, and examples/erp/ (see examples/erp/Dockerfile).
+          flyctl deploy --remote-only --config examples/erp/fly.toml --dockerfile examples/erp/Dockerfile .

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,78 @@
+# Live Demo
+
+HyperAdmin ships with a runnable **ERP (bookkeeping) demo** — a small FastAPI
+application that wires up several sub-apps (contacts, sales, purchases,
+accounting, reports) behind the HyperAdmin admin interface. It is the fastest
+way to see HyperAdmin in action.
+
+The source lives in [`examples/erp/`](https://github.com/yevheniidehtiar/hyper-admin/tree/develop/examples/erp).
+
+## Hosted demo
+
+A hosted instance is deployed to [Fly.io](https://fly.io) as the
+`hyperadmin-demo` app. Once a maintainer has configured the deployment secrets
+(see below), the admin UI is available at:
+
+```
+https://hyperadmin-demo.fly.dev/admin
+```
+
+!!! note "Deployment is opt-in"
+    The deployment pipeline (`.github/workflows/demo-deploy.yml`) is **inert
+    until secrets are configured**. If the `FLY_API_TOKEN` secret is not set,
+    the deploy step logs a warning and no-ops cleanly, so the workflow never
+    fails on forks or unconfigured repositories.
+
+## Run it locally
+
+The demo is fully self-contained and seeds its own SQLite database on startup.
+
+### With Docker Compose (recommended)
+
+```bash
+cd examples/erp
+docker compose up --build
+```
+
+Then open <http://localhost:8000/admin>.
+
+### Without Docker
+
+From the repository root:
+
+```bash
+uv sync --all-extras
+uv run fastapi dev examples/erp/main.py
+```
+
+The app listens on port **8000** and the admin interface is mounted at
+`/admin`. The root path (`/`) returns a small pointer to the admin UI.
+
+## Deploying the hosted demo (maintainers)
+
+Deployment runs via the `Deploy Demo` GitHub Actions workflow, triggered by:
+
+- **Manual dispatch** — run it from the **Actions** tab (`workflow_dispatch`).
+- **A `demo-*` tag** — for example:
+
+  ```bash
+  git tag demo-2026-06-02
+  git push origin demo-2026-06-02
+  ```
+
+The workflow always builds the image from `examples/erp/Dockerfile` (so a
+broken Dockerfile fails the run regardless of secrets), then deploys to Fly.io
+only when `FLY_API_TOKEN` is present.
+
+### Required GitHub secrets
+
+To enable the live deployment, a maintainer must set the following repository
+secrets (**Settings → Secrets and variables → Actions**):
+
+| Secret | Purpose | How to obtain |
+|---|---|---|
+| `FLY_API_TOKEN` | Authenticates `flyctl` for deploys. Without it the deploy step no-ops. | `fly tokens create deploy` (scoped to the `hyperadmin-demo` app) |
+| `HYPERADMIN_SECRET_KEY` | Session signing key for the demo app. Optional but recommended; pushed to Fly as an app secret. | Any high-entropy string, e.g. `python -c "import secrets; print(secrets.token_urlsafe(48))"` |
+
+The Fly app itself is defined in [`examples/erp/fly.toml`](https://github.com/yevheniidehtiar/hyper-admin/tree/develop/examples/erp/fly.toml)
+(app name `hyperadmin-demo`, internal port `8000`).

--- a/examples/erp/fly.toml
+++ b/examples/erp/fly.toml
@@ -1,0 +1,29 @@
+# Fly.io configuration for the HyperAdmin ERP demo.
+#
+# This deploys the runnable example in examples/erp/ as a live, hosted demo.
+# The image is built from examples/erp/Dockerfile (build context = repo root,
+# so it can copy src/, pyproject.toml, and examples/erp/).
+#
+# Deployment is driven by .github/workflows/demo-deploy.yml and only runs
+# when the FLY_API_TOKEN secret is configured. See docs/demo.md.
+
+app = "hyperadmin-demo"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  ENVIRONMENT = "production"
+
+[http_service]
+  # main.py runs the app on port 8000 (EXPOSE 8000, --host 0.0.0.0).
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
       - Getting Started: getting-started.md
       - Tutorial: tutorial.md
       - File Uploads: guides/file-uploads.md
+      - Live Demo: demo.md
       - Examples:
           - Overview: examples.md
           - ERP (Bookkeeping): examples/erp.md


### PR DESCRIPTION
## Summary

Closes the gap of having **no live demo deployment** for HyperAdmin. The repo
already ships a runnable ERP demo at `examples/erp/` (FastAPI + Docker), but
nothing deployed it anywhere. This PR adds a Fly.io deployment pipeline,
the Fly app config, and docs — all **inert until a maintainer configures
secrets**.

## What changed

- **`.github/workflows/demo-deploy.yml`** — builds the `examples/erp` Docker
  image and deploys it to Fly.io via `flyctl`.
  - Triggers: `workflow_dispatch` (manual) + pushing a `demo-*` tag.
  - Always builds the image first, so a broken Dockerfile fails the run even
    without secrets.
  - Deploy step is **guarded**: if `FLY_API_TOKEN` is absent it logs a warning
    and exits 0 (clean no-op) instead of failing.
- **`examples/erp/fly.toml`** — minimal Fly config for app `hyperadmin-demo`,
  internal port `8000` (matches `main.py`'s `EXPOSE 8000` / `--host 0.0.0.0`),
  pointing at the existing `examples/erp/Dockerfile`.
- **`mkdocs.yml`** — adds a **Live Demo** nav entry under the Guide section.
- **`docs/demo.md`** — explains the hosted demo, how to run it locally
  (`docker compose up` in `examples/erp/`), and the secrets a maintainer must
  set to enable deployment.

## Required GitHub secrets (deployment is inert until set)

| Secret | Purpose |
|---|---|
| `FLY_API_TOKEN` | Authenticates `flyctl`. Without it, the deploy step no-ops. |
| `HYPERADMIN_SECRET_KEY` | Session signing key, pushed to Fly as an app secret (optional but recommended). |

Until `FLY_API_TOKEN` is configured, the workflow builds the image and then
no-ops the deploy — nothing is deployed and nothing fails.

## Validation

- `uv run mkdocs build --strict` passes; `demo.md` renders and the new nav
  entry resolves. (Pre-existing INFO notes about developer-only `docs/specs/*`
  files being outside the nav are unchanged by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
