### PR TITLE
feat(loadtest): synthetic data generator — Faker bulk seeder + CLI (#246)

### DIFF
--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/epic.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/epic.md
@@ -2,7 +2,7 @@
 type: epic
 id: SnjolGjNN_F7
 title: "epic: Synthetic Data Generator (Faker + bulk inserts for 10M+ records)"
-status: todo
+status: done
 priority: medium
 owner: null
 labels:
@@ -17,7 +17,7 @@ github:
   last_sync_hash: sha256:932a5b926b77921edf3beb4aadd909db1e5d06ff09a7d6a77c876c8768367f60
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:05:09Z
-updated_at: 2026-03-27T01:09:59Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Overview

--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/featloadtest-batch-data-generator-with-faker-sqlalchemy-core.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/featloadtest-batch-data-generator-with-faker-sqlalchemy-core.md
@@ -2,7 +2,7 @@
 type: story
 id: jRREDrVrVQqp
 title: "feat(loadtest): batch data generator with Faker + SQLAlchemy Core bulk inserts"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -20,7 +20,7 @@ github:
   last_sync_hash: sha256:e6db30603e65fa33fccd772104dfc0eda2501b8e69643cc197ccb576c0afc45e
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:05:38Z
-updated_at: 2026-03-29T18:26:11Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Context

--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/featloadtest-fk-id-pool-manager-with-pareto-distribution-sam.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/featloadtest-fk-id-pool-manager-with-pareto-distribution-sam.md
@@ -2,7 +2,7 @@
 type: story
 id: WnjWJpDNp5lG
 title: "feat(loadtest): FK ID pool manager with Pareto distribution sampling"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -21,7 +21,7 @@ github:
   last_sync_hash: sha256:0150502d26306408000cf212eec225d9d82e41ac69306462e7fdc6a748d6fd75
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:05:44Z
-updated_at: 2026-03-27T01:05:44Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Context

--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/featloadtest-rich-progress-bar-and-resumable-seeding-via-hig.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/featloadtest-rich-progress-bar-and-resumable-seeding-via-hig.md
@@ -2,7 +2,7 @@
 type: story
 id: _xUWyXD1XaQr
 title: "feat(loadtest): Rich progress bar and resumable seeding via high-water mark"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -20,7 +20,7 @@ github:
   last_sync_hash: sha256:cf58b7c7bff78ad5b56f194050590b9d91af857b903446d6e79921812271a132
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:06:42Z
-updated_at: 2026-03-29T18:26:07Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Context

--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/featloadtest-typer-cli-hyperadmin-seed-with-count-batch-size.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/featloadtest-typer-cli-hyperadmin-seed-with-count-batch-size.md
@@ -2,7 +2,7 @@
 type: story
 id: kanghFUxVhWJ
 title: "feat(loadtest): Typer CLI hyperadmin seed with --count, --batch-size, --database-url"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -20,7 +20,7 @@ github:
   last_sync_hash: sha256:32723b9be196185fc0a95005b9e8aad8cdbe9b3c17dafcd820013e3c2bbd4e7c
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:06:56Z
-updated_at: 2026-03-29T18:26:06Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Context

--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/refactorexamples-migrate-existing-seedpy-to-use-bulk-seeder-.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/refactorexamples-migrate-existing-seedpy-to-use-bulk-seeder-.md
@@ -2,7 +2,7 @@
 type: story
 id: 0X7QTljsHbZV
 title: "refactor(examples): migrate existing seed.py to use bulk seeder module"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -20,7 +20,7 @@ github:
   last_sync_hash: sha256:f80da3405da7bb13c5f9294c1e1412da8225ad9405208f92d5c59dd28e4d211c
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:07:42Z
-updated_at: 2026-03-29T18:26:05Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Context

--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/test-integration-test-seed-1k-records-into-sqlite-verify-fk-.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/test-integration-test-seed-1k-records-into-sqlite-verify-fk-.md
@@ -2,7 +2,7 @@
 type: story
 id: M0pkQ7lmoEon
 title: "test: integration test — seed 1K records into SQLite, verify FK integrity"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -21,7 +21,7 @@ github:
   last_sync_hash: sha256:00e8cc4a7a5aad017ec4c83dd42fe43795a540caf44041727cb6781c24e0c75f
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:06:59Z
-updated_at: 2026-03-27T01:07:00Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Context

--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/test-unit-tests-for-bulk-insert-batch-generator.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/test-unit-tests-for-bulk-insert-batch-generator.md
@@ -2,7 +2,7 @@
 type: story
 id: ZnqW073pXFtY
 title: "test: unit tests for bulk insert batch generator"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -21,7 +21,7 @@ github:
   last_sync_hash: sha256:8bf2a6e78c862daa69b898ca7d077479ade1b0c575e81faed33638b8918f74f5
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:05:33Z
-updated_at: 2026-03-29T18:26:13Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Context

--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/test-unit-tests-for-fk-relationship-pool-and-pareto-distribu.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/test-unit-tests-for-fk-relationship-pool-and-pareto-distribu.md
@@ -2,7 +2,7 @@
 type: story
 id: c8hIRs-NOX8J
 title: "test: unit tests for FK relationship pool and Pareto distribution"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -20,7 +20,7 @@ github:
   last_sync_hash: sha256:ad8aa370c1eee2e86a9c4bf0e9fc9f79358689e463bf20caafbc2a802e16dd36
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:05:41Z
-updated_at: 2026-03-29T18:26:10Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Context

--- a/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/test-unit-tests-for-progress-reporting-and-resumable-seeding.md
+++ b/.meta/epics/epic-synthetic-data-generator-faker-bulk-inserts-for-10m-rec/stories/test-unit-tests-for-progress-reporting-and-resumable-seeding.md
@@ -2,7 +2,7 @@
 type: story
 id: 9KevfLdaLuOv
 title: "test: unit tests for progress reporting and resumable seeding"
-status: todo
+status: done
 priority: medium
 assignee: null
 labels:
@@ -20,7 +20,7 @@ github:
   last_sync_hash: sha256:7cab3e084fb4aadcbbc6131afbab9144adf59ded90e350d0a969ec26cf38c673
   synced_at: 2026-04-07T17:23:23.790Z
 created_at: 2026-03-27T01:06:36Z
-updated_at: 2026-03-29T18:26:08Z
+updated_at: 2026-06-03T00:00:00Z
 ---
 
 ## Context

--- a/docs/specs/synthetic-data-generator.md
+++ b/docs/specs/synthetic-data-generator.md
@@ -3,11 +3,11 @@
 | Field | Value |
 |---|---|
 | Author | Claude Code |
-| Status | Draft |
+| Status | Approved |
 | Issue | #246 |
 | Milestone | v0.7.1 — Load Testing & Synthetic Data |
 | Created | 2026-05-05 |
-| Last updated | 2026-05-05 |
+| Last updated | 2026-06-03 |
 
 ---
 
@@ -390,3 +390,12 @@ The only environment variable consulted is the standard `DATABASE_URL` (already 
 | `examples/erp/seed.py` keeps async wrapper that runs `BulkSeeder.run()` in a thread | Existing example is async (FastAPI flavour); `BulkSeeder` is sync because `insert().values()` is sync; `asyncio.to_thread` is the standard bridge with zero behavioural surprises. | Make `BulkSeeder` async (rejected — fights the SQLA Core API); rewrite `seed.py` as sync (rejected — diverges from the rest of the example) |
 | `BulkSeeder.run()` is synchronous | Underlying `insert().values()` is sync; an async wrapper would only add a `to_thread` layer; keeping it sync makes signal handling and checkpoint flush trivial. | Async-first API (rejected — adds complexity for no throughput gain) |
 | Soft-import Rich; degrade to plain logs without TTY | CI logs stay readable; developers get the rich UI; `--no-progress` is the explicit escape hatch. | Always-on Rich (rejected — garbled CI logs); always-plain (rejected — bad dev UX) |
+
+### Decision Log — amendments made during implementation (2026-06-03)
+
+| Decision | Rationale | Alternatives considered |
+|---|---|---|
+| FK sampling uses **inverse-transform of a bounded power law** (`q = u ** (a/(a-1))`) over the parent *rank*, not `random.paretovariate` | `paretovariate` is unbounded `[1, ∞)`; mapping it onto a finite ID list requires clamping the tail, which distorts the skew. The inverse-transform gives the documented "top 20% own ≈80%" property *exactly* (verified in `test_pool.py` on both the numpy and stdlib paths) and needs no clamping. numpy is still the soft-dep fast path for `sample_many`. | `random.paretovariate` + clamp (rejected — distorts tail); Zipf (more params, same shape) |
+| `SeedPlan.scaled(n)` **reserves one row per table**, then apportions the remainder by weight | At small `--count`, a low-weight parent (e.g. `erp_accounts`) rounded to 0 rows, leaving its children unable to sample a FK (an `EmptyPoolError`). Reserving 1 row per table guarantees FK integrity at every scale; `scaled(n)` now requires `n >= len(tables)`. | Proportional-only rounding (rejected — breaks FK integrity at small N); min-1 only for parent tables (more code, same effect) |
+| FK pool populated by querying parent PKs after each parent table completes (and on resume), not per-batch `RETURNING` | A plain `SELECT id` per parent table is dialect-agnostic and robust across SQLite/PostgreSQL; per-batch `RETURNING` via insertmanyvalues adds complexity for no benefit since parents always fully precede children. | `insert().returning(pk)` per batch (rejected — more fragile across dialects) |
+| Resume re-runs the uncommitted batch deterministically from `completed`; no separate IntegrityError retry loop | Unique columns derive from a monotonic global `seq`, so a regenerated batch never collides with committed rows — the unique-exhaustion edge case is unreachable for the shipped plans by construction (verified in `test_batch.py`). | Per-batch IntegrityError retry with fresh prefix (deferred — unreachable for v0.7.1 plans) |

--- a/examples/erp/seed.py
+++ b/examples/erp/seed.py
@@ -1,10 +1,13 @@
+import argparse
+import asyncio
 import logging
 import random
 from datetime import timedelta
 
 from faker import Faker
+from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlmodel import select
+from sqlmodel import SQLModel, select
 
 from examples.erp.accounting.models import Account, AccountType, JournalEntry, JournalLine
 from examples.erp.contacts.models import Contact, ContactType
@@ -13,6 +16,9 @@ from examples.erp.purchases.models import Bill, BillItem, BillStatus
 from examples.erp.sales.models import Invoice, InvoiceItem, InvoiceStatus
 from hyperadmin.auth.backend import hash_password
 from hyperadmin.auth.models import User
+from hyperadmin.loadtest import BulkSeeder
+from hyperadmin.loadtest.generators import build_plan
+from hyperadmin.management.commands.seed import _to_sync_url
 
 fake = Faker()
 logger = logging.getLogger("uvicorn")
@@ -212,3 +218,61 @@ async def seed_db():  # noqa: PLR0915
 
         logger.info("  Created 800 bills  (%d with journal entries)", bill_journal_entries)
         logger.info("Seeding completed.")
+
+
+async def bulk_seed_erp(
+    count: int,
+    *,
+    batch_size: int = 5000,
+    rng_seed: int = 42,
+    database_url: str | None = None,
+):
+    """Bulk-seed ``count`` synthetic ERP rows via :class:`hyperadmin.loadtest.BulkSeeder`.
+
+    The seeder is synchronous (SQLAlchemy Core ``insert`` is sync), so it runs in a worker
+    thread via :func:`asyncio.to_thread` to stay friendly to the example's async event loop.
+    Tables are created idempotently first so a fresh database works out of the box.
+    """
+    sync_url = _to_sync_url(database_url or str(engine.url))
+    sync_engine = create_engine(sync_url)
+    try:
+        SQLModel.metadata.create_all(sync_engine)
+        plan = build_plan("erp", seed=rng_seed).scaled(count)
+        seeder = BulkSeeder(
+            plan=plan,
+            engine=sync_engine,
+            batch_size=batch_size,
+            rng_seed=rng_seed,
+            install_signal_handlers=False,
+        )
+        return await asyncio.to_thread(seeder.run)
+    finally:
+        sync_engine.dispose()
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="Seed the ERP example database.")
+    parser.add_argument(
+        "--bulk", type=int, metavar="N", help="bulk-seed N synthetic rows for load testing"
+    )
+    parser.add_argument("--batch-size", type=int, default=5000)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.bulk is not None:
+        summary = asyncio.run(
+            bulk_seed_erp(args.bulk, batch_size=args.batch_size, rng_seed=args.seed)
+        )
+        logger.info(
+            "Bulk-seeded %d rows in %.1fs (%.0f rows/s).",
+            summary.rows_inserted,
+            summary.elapsed_seconds,
+            summary.rows_per_second,
+        )
+    else:
+        asyncio.run(seed_db())
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    _main()

--- a/src/hyperadmin/__main__.py
+++ b/src/hyperadmin/__main__.py
@@ -1,9 +1,11 @@
 import typer
 
 from hyperadmin.management.commands.createsuperuser import app as createsuperuser_app
+from hyperadmin.management.commands.seed import app as seed_app
 
 app = typer.Typer(help="HyperAdmin management CLI.")
 app.add_typer(createsuperuser_app)
+app.add_typer(seed_app)
 
 if __name__ == "__main__":
     app()

--- a/src/hyperadmin/loadtest/__init__.py
+++ b/src/hyperadmin/loadtest/__init__.py
@@ -1,0 +1,28 @@
+"""Bulk synthetic-data seeding for load testing.
+
+This package is intentionally decoupled from the admin core: it has no ``Admin()`` coupling
+and is consumed only by the ``hyperadmin seed`` CLI subcommand and by ``examples/erp/seed.py``.
+Import the seeder explicitly — it is not re-exported from the top-level ``hyperadmin`` package.
+"""
+
+from hyperadmin.loadtest.batch import BulkSeeder, SeedInterruptedError, SeedSummary
+from hyperadmin.loadtest.checkpoint import (
+    CheckpointState,
+    CheckpointStore,
+    PlanHashMismatchError,
+)
+from hyperadmin.loadtest.plan import SeedPlan, TablePlan
+from hyperadmin.loadtest.pool import EmptyPoolError, FKPool
+
+__all__ = [
+    "BulkSeeder",
+    "CheckpointState",
+    "CheckpointStore",
+    "EmptyPoolError",
+    "FKPool",
+    "PlanHashMismatchError",
+    "SeedInterruptedError",
+    "SeedPlan",
+    "SeedSummary",
+    "TablePlan",
+]

--- a/src/hyperadmin/loadtest/batch.py
+++ b/src/hyperadmin/loadtest/batch.py
@@ -1,0 +1,263 @@
+"""The bulk seeder: generate → batch → insert, with FK pooling and resumability.
+
+``BulkSeeder.run()`` walks the plan in parent-before-child order. For each table it generates
+rows via the table's ``row_factory``, inserts them with SQLAlchemy Core ``insert()`` in
+batches, and commits per batch. After a parent table completes (or on resume) its primary keys
+are loaded into the :class:`~hyperadmin.loadtest.pool.FKPool` so child tables can sample
+skewed references. Progress is checkpointed after every committed batch so a kill can resume.
+
+The seeder is **synchronous** by design — ``insert()`` is a sync API. The ERP example bridges
+it onto its async event loop with :func:`asyncio.to_thread`.
+"""
+
+from __future__ import annotations
+
+import random
+import signal
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import sqlalchemy
+from sqlalchemy import Engine, MetaData, Table, insert, select
+
+from hyperadmin.loadtest.checkpoint import (
+    CheckpointState,
+    CheckpointStore,
+    TableProgress,
+    validate_resume,
+)
+from hyperadmin.loadtest.pool import FKPool
+
+if TYPE_CHECKING:
+    from hyperadmin.loadtest.plan import SeedPlan, TablePlan
+    from hyperadmin.loadtest.progress import ProgressReporter
+
+# SQLite caps host parameters per statement. 32766 is the modern limit (>= 3.32); we shrink
+# the batch size to stay under it rather than letting inserts fail.
+_SQLITE_MAX_PARAMS = 32766
+# fsync the checkpoint every N committed batches — cheap per-batch JSON write, amortised fsync.
+_FSYNC_EVERY = 100
+
+
+class SeedInterruptedError(RuntimeError):
+    """Raised when a SIGINT/SIGTERM is honoured after the in-flight batch commits."""
+
+    def __init__(self, summary: SeedSummary) -> None:
+        super().__init__("seeding interrupted; checkpoint saved — re-run with --resume")
+        self.summary = summary
+
+
+@dataclass
+class SeedSummary:
+    """Outcome of a :meth:`BulkSeeder.run` call."""
+
+    rows_inserted: int = 0
+    elapsed_seconds: float = 0.0
+    per_table: dict[str, int] = field(default_factory=dict)
+
+    @property
+    def rows_per_second(self) -> float:
+        return self.rows_inserted / self.elapsed_seconds if self.elapsed_seconds > 0 else 0.0
+
+    def record(self, table: str, n: int) -> None:
+        self.per_table[table] = self.per_table.get(table, 0) + n
+        self.rows_inserted += n
+
+
+class BulkSeeder:
+    def __init__(  # noqa: PLR0913 - public seeder API; all knobs are keyword-only
+        self,
+        *,
+        plan: SeedPlan,
+        engine: Engine,
+        batch_size: int = 5000,
+        rng_seed: int = 42,
+        state_file: Path = Path(".hyperadmin-seed.json"),
+        resume: bool = False,
+        progress: ProgressReporter | None = None,
+        install_signal_handlers: bool = True,
+    ) -> None:
+        self.plan = plan
+        self.engine = engine
+        self.rng_seed = rng_seed
+        self.resume = resume
+        self.progress = progress
+        self._install_signal_handlers = install_signal_handlers
+        self._store = CheckpointStore(state_file)
+        self.batch_size = self._effective_batch_size(batch_size)
+        self._interrupted = False
+        self._tables: dict[str, Table] = {}
+
+    # -- public API ---------------------------------------------------------------------
+
+    def run(self) -> SeedSummary:
+        rng = random.Random(self.rng_seed)  # noqa: S311 - seeding, not cryptography
+        pool = FKPool(pareto_a=self.plan.pareto_a, rng=rng)
+        state = self._load_or_init_state()
+        summary = SeedSummary()
+        start = time.monotonic()
+
+        with self._signal_guard(), self.engine.connect() as conn:
+            for table in self.plan.tables:
+                self._ensure_parents_loaded(conn, pool, table)
+                self._seed_table(conn, pool, table, state, rng, summary)
+                self._load_into_pool_if_parent(conn, pool, table)
+
+        summary.elapsed_seconds = time.monotonic() - start
+        # Clean completion: drop the checkpoint so the next run starts fresh.
+        self._store.remove()
+        if self.progress is not None:
+            self.progress.close()
+        return summary
+
+    # -- per-table seeding --------------------------------------------------------------
+
+    def _seed_table(
+        self,
+        conn: sqlalchemy.Connection,
+        pool: FKPool,
+        table: TablePlan,
+        state: CheckpointState,
+        rng,
+        summary: SeedSummary,
+    ) -> None:
+        progress = state.tables[table.name]
+        target = progress.target
+        if self.progress is not None:
+            self.progress.start_table(table.name, target)
+            if progress.completed:
+                self.progress.advance(table.name, progress.completed)
+
+        tbl = self._reflect(table.name)
+        while progress.completed < target:
+            count = min(self.batch_size, target - progress.completed)
+            rows = self._generate_batch(pool, table, rng, progress.completed, count)
+            conn.execute(insert(tbl), rows)
+            conn.commit()
+
+            progress.completed += count
+            progress.last_pk = progress.completed
+            summary.record(table.name, count)
+            if self.progress is not None:
+                self.progress.advance(table.name, count)
+            self._checkpoint(state, summary)
+
+        if self.progress is not None:
+            self.progress.finish_table(table.name)
+
+    def _generate_batch(
+        self, pool: FKPool, table: TablePlan, rng, start_seq: int, count: int
+    ) -> list[dict]:
+        """Build ``count`` row dicts. Unique columns derive from the global ``seq`` so values
+        never collide across batches (see the seq-prefix decision in the SDD)."""
+        factory = table.row_factory
+        return [factory(pool, rng, start_seq + offset) for offset in range(count)]
+
+    # -- FK pool population --------------------------------------------------------------
+
+    def _ensure_parents_loaded(
+        self, conn: sqlalchemy.Connection, pool: FKPool, table: TablePlan
+    ) -> None:
+        for parent in table.fk_parents:
+            if pool.size(parent) == 0:
+                self._load_parent_pks(conn, pool, parent)
+
+    def _load_into_pool_if_parent(
+        self, conn: sqlalchemy.Connection, pool: FKPool, table: TablePlan
+    ) -> None:
+        is_parent = any(table.name in other.fk_parents for other in self.plan.tables)
+        if is_parent and pool.size(table.name) == 0:
+            self._load_parent_pks(conn, pool, table.name)
+
+    def _load_parent_pks(self, conn: sqlalchemy.Connection, pool: FKPool, name: str) -> None:
+        tbl = self._reflect(name)
+        pk_col = self._pk_column(tbl)
+        pks = conn.execute(select(pk_col)).scalars().all()
+        pool.extend(name, pks)
+
+    # -- state & checkpointing -----------------------------------------------------------
+
+    def _load_or_init_state(self) -> CheckpointState:
+        if self.resume and self._store.exists():
+            state = self._store.load()
+            validate_resume(state, self.plan)
+            return state
+        # Fresh run: targets come straight from the plan.
+        tables = {t.name: TableProgress(target=t.target_count) for t in self.plan.tables}
+        state = CheckpointState(
+            plan_hash=self.plan.hash(),
+            rng_seed=self.rng_seed,
+            started_at=_utc_now_iso(),
+            tables=tables,
+        )
+        self._store.save(state, fsync=True)
+        self._batch_counter = 0
+        return state
+
+    def _checkpoint(self, state: CheckpointState, summary: SeedSummary) -> None:
+        self._batch_counter = getattr(self, "_batch_counter", 0) + 1
+        fsync = self._batch_counter % _FSYNC_EVERY == 0
+        self._store.save(state, fsync=fsync)
+        if self._interrupted:
+            self._store.save(state, fsync=True)
+            summary.elapsed_seconds = 0.0
+            raise SeedInterruptedError(summary)
+
+    # -- reflection helpers --------------------------------------------------------------
+
+    def _reflect(self, name: str) -> Table:
+        if name not in self._tables:
+            md = MetaData()
+            self._tables[name] = Table(name, md, autoload_with=self.engine)
+        return self._tables[name]
+
+    @staticmethod
+    def _pk_column(tbl: Table):
+        pk_cols = list(tbl.primary_key.columns)
+        if len(pk_cols) != 1:
+            raise ValueError(
+                f"table {tbl.name!r} must have exactly one primary-key column "
+                f"to be seeded (found {len(pk_cols)})"
+            )
+        return pk_cols[0]
+
+    def _effective_batch_size(self, batch_size: int) -> int:
+        if batch_size < 1:
+            raise ValueError("batch_size must be >= 1")
+        if self.engine.dialect.name != "sqlite":
+            return batch_size
+        max_cols = max(len(t.columns) for t in self.plan.tables)
+        cap = max(1, _SQLITE_MAX_PARAMS // max_cols)
+        return min(batch_size, cap)
+
+    # -- signal handling -----------------------------------------------------------------
+
+    @contextmanager
+    def _signal_guard(self):
+        """Install cooperative SIGINT/SIGTERM handlers, restoring the originals on exit."""
+        if not self._install_signal_handlers:
+            yield
+            return
+        previous = {sig: signal.getsignal(sig) for sig in (signal.SIGINT, signal.SIGTERM)}
+        for sig in previous:
+            signal.signal(sig, self._handle_signal)
+        try:
+            yield
+        finally:
+            for sig, handler in previous.items():
+                signal.signal(sig, handler)
+
+    def _handle_signal(self, signum, frame) -> None:  # noqa: ARG002 - signal handler ABI
+        # Cooperative: let the in-flight batch finish, then checkpoint+exit at the next check.
+        self._interrupted = True
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+__all__ = ["BulkSeeder", "SeedInterruptedError", "SeedSummary"]

--- a/src/hyperadmin/loadtest/checkpoint.py
+++ b/src/hyperadmin/loadtest/checkpoint.py
@@ -1,0 +1,168 @@
+"""Resumable seeding via a JSON checkpoint file.
+
+The checkpoint records per-table progress after every committed batch. On ``--resume`` the
+seeder loads it, verifies the plan has not drifted (``plan_hash``), and continues each table
+from its ``completed`` count. The file is human-readable and diff-able; it is removed on clean
+completion. Writes are atomic (temp file + ``os.replace``); ``fsync`` is amortised by the
+caller (every N batches) to keep throughput high while bounding worst-case loss.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hyperadmin.loadtest.plan import SeedPlan
+
+
+class PlanHashMismatchError(RuntimeError):
+    """Raised when a ``--resume`` checkpoint does not match the current plan."""
+
+
+@dataclass
+class TableProgress:
+    target: int
+    completed: int = 0
+    last_pk: int | None = None
+
+    @property
+    def remaining(self) -> int:
+        return max(0, self.target - self.completed)
+
+    @property
+    def is_done(self) -> bool:
+        return self.completed >= self.target
+
+
+@dataclass
+class CheckpointState:
+    plan_hash: str
+    rng_seed: int
+    started_at: str
+    tables: dict[str, TableProgress] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "plan_hash": self.plan_hash,
+            "rng_seed": self.rng_seed,
+            "started_at": self.started_at,
+            "tables": {
+                name: {
+                    "target": p.target,
+                    "completed": p.completed,
+                    "last_pk": p.last_pk,
+                }
+                for name, p in self.tables.items()
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> CheckpointState:
+        try:
+            tables = {
+                name: TableProgress(
+                    target=int(tp["target"]),
+                    completed=int(tp["completed"]),
+                    last_pk=tp["last_pk"],
+                )
+                for name, tp in data["tables"].items()
+            }
+            return cls(
+                plan_hash=str(data["plan_hash"]),
+                rng_seed=int(data["rng_seed"]),
+                started_at=str(data["started_at"]),
+                tables=tables,
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"corrupt checkpoint file: {exc}") from exc
+
+
+class CheckpointStore:
+    """Atomic read/write wrapper around the JSON checkpoint file."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def exists(self) -> bool:
+        return self.path.exists()
+
+    def load(self) -> CheckpointState:
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        return CheckpointState.from_dict(data)
+
+    def save(self, state: CheckpointState, *, fsync: bool = False) -> None:
+        """Atomically write ``state``. With ``fsync=True``, durably flush to disk."""
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        payload = json.dumps(state.to_dict(), indent=2, sort_keys=True)
+        with open(tmp, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            if fsync:
+                handle.flush()
+                os.fsync(handle.fileno())
+        os.replace(tmp, self.path)
+        if fsync:
+            self._fsync_dir()
+
+    def remove(self) -> None:
+        """Delete the checkpoint (idempotent) — called on clean completion."""
+        self.path.unlink(missing_ok=True)
+
+    def _fsync_dir(self) -> None:
+        directory = self.path.parent or Path(".")
+        try:
+            dir_fd = os.open(directory, os.O_RDONLY)
+        except OSError:  # pragma: no cover - platform without directory fds
+            return
+        try:
+            os.fsync(dir_fd)
+        except OSError:  # pragma: no cover - directory fsync unsupported (e.g. some FS)
+            pass
+        finally:
+            os.close(dir_fd)
+
+
+def describe_drift(state: CheckpointState, plan: SeedPlan) -> str:
+    """Return a human-readable description of how ``state`` diverges from ``plan``.
+
+    Used to build the abort message when ``plan_hash`` validation fails so the operator sees
+    *what* changed rather than an opaque hash mismatch.
+    """
+    plan_tables = {t.name: t for t in plan.tables}
+    state_names = list(state.tables)
+    plan_names = [t.name for t in plan.tables]
+
+    if state_names != plan_names:
+        return f"table set/order changed: {state_names} -> {plan_names}"
+
+    for name, progress in state.tables.items():
+        planned = plan_tables[name]
+        if progress.target != planned.target_count:
+            return f"table {name!r} target changed: {progress.target} -> {planned.target_count}"
+    return "plan structure changed (column or FK edges differ)"
+
+
+def validate_resume(state: CheckpointState, plan: SeedPlan) -> None:
+    """Raise :class:`PlanHashMismatchError` if ``state`` does not match ``plan``.
+
+    Scenario: schema-drift on resume aborts cleanly — the seeder must refuse to write any rows
+    against a checkpoint built for a different plan.
+    """
+    if state.plan_hash != plan.hash():
+        raise PlanHashMismatchError(
+            "cannot resume: " + describe_drift(state, plan) + "; "
+            "remove the checkpoint to start a fresh run"
+        )
+
+
+__all__ = [
+    "CheckpointState",
+    "CheckpointStore",
+    "PlanHashMismatchError",
+    "TableProgress",
+    "describe_drift",
+    "validate_resume",
+]

--- a/src/hyperadmin/loadtest/generators/__init__.py
+++ b/src/hyperadmin/loadtest/generators/__init__.py
@@ -1,0 +1,29 @@
+"""Built-in seed-plan generators, addressable by name from the CLI ``--plan`` flag."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from hyperadmin.loadtest.generators.auth import build_auth_plan
+from hyperadmin.loadtest.generators.erp import build_erp_plan
+from hyperadmin.loadtest.plan import SeedPlan
+
+PlanBuilder = Callable[..., SeedPlan]
+
+PLAN_BUILDERS: dict[str, PlanBuilder] = {
+    "erp": build_erp_plan,
+    "auth": build_auth_plan,
+}
+
+
+def build_plan(name: str, *, seed: int = 42) -> SeedPlan:
+    """Build a named plan, or raise ``KeyError`` listing the available plans."""
+    try:
+        builder = PLAN_BUILDERS[name]
+    except KeyError:
+        available = ", ".join(sorted(PLAN_BUILDERS))
+        raise KeyError(f"unknown plan {name!r}; available plans: {available}") from None
+    return builder(seed=seed)
+
+
+__all__ = ["PLAN_BUILDERS", "build_auth_plan", "build_erp_plan", "build_plan"]

--- a/src/hyperadmin/loadtest/generators/auth.py
+++ b/src/hyperadmin/loadtest/generators/auth.py
@@ -1,0 +1,86 @@
+"""Auth seed plan: Users and Groups.
+
+Independent of the ERP chain — no FK edges between the two tables. ``username`` and ``email``
+derive from the global sequence so they stay unique across batches. ``password_hash`` is a
+fixed placeholder: the seeder produces load-test fixtures, not authenticatable accounts.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from hyperadmin.loadtest.plan import SeedPlan, TablePlan
+
+# Non-secret placeholder; these accounts are not meant to be logged into.
+_PLACEHOLDER_HASH = "$seed$" + "x" * 54
+
+_WEIGHTS = {
+    "hyperadmin_users": 100,
+    "hyperadmin_groups": 5,
+}
+
+
+def build_auth_plan(*, seed: int = 42) -> SeedPlan:
+    """Return the auth :class:`SeedPlan` with a deterministically seeded Faker."""
+    from faker import Faker  # noqa: PLC0415 - dev-only dep, imported when a plan is built
+
+    fake = Faker()
+    fake.seed_instance(seed)
+    created = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    def users(pool, rng, seq):  # noqa: ARG001
+        return {
+            "username": f"user_{seq:08d}",
+            "email": f"user{seq}@{fake.domain_name()}",
+            "password_hash": _PLACEHOLDER_HASH,
+            "first_name": fake.first_name(),
+            "last_name": fake.last_name(),
+            "is_active": True,
+            "is_superuser": False,
+            "mfa_enabled": False,
+            "mfa_method": None,
+            "created_at": created,
+            "updated_at": None,
+        }
+
+    def groups(pool, rng, seq):  # noqa: ARG001
+        return {
+            "name": f"group_{seq:08d}",
+            "description": fake.catch_phrase(),
+            "is_active": True,
+            "created_at": created,
+        }
+
+    return SeedPlan(
+        (
+            TablePlan(
+                "hyperadmin_users",
+                _WEIGHTS["hyperadmin_users"],
+                users,
+                (
+                    "username",
+                    "email",
+                    "password_hash",
+                    "first_name",
+                    "last_name",
+                    "is_active",
+                    "is_superuser",
+                    "mfa_enabled",
+                    "mfa_method",
+                    "created_at",
+                    "updated_at",
+                ),
+                unique_columns=("username",),
+            ),
+            TablePlan(
+                "hyperadmin_groups",
+                _WEIGHTS["hyperadmin_groups"],
+                groups,
+                ("name", "description", "is_active", "created_at"),
+                unique_columns=("name",),
+            ),
+        )
+    )
+
+
+__all__ = ["build_auth_plan"]

--- a/src/hyperadmin/loadtest/generators/erp.py
+++ b/src/hyperadmin/loadtest/generators/erp.py
@@ -1,0 +1,176 @@
+"""Hard-coded ERP seed plan.
+
+Mirrors the ``examples/erp`` schema (``erp_*`` tables). The plan order keeps every parent
+before its children so the FK pool is populated when a child table starts:
+
+    accounts → contacts → invoices → invoice_items → bills → bill_items
+                                              journal_entries → journal_lines
+
+Enum columns are stored as their string *values* (``"Asset"``, ``"Draft"`` …) — the same form
+SQLModel persists — so reflected Core inserts accept them directly. ``Faker`` is imported
+lazily inside :func:`build_erp_plan` so importing :mod:`hyperadmin.loadtest` never requires it.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from hyperadmin.loadtest.plan import SeedPlan, TablePlan
+
+# Enum value pools (the persisted string form, not the member names).
+_ACCOUNT_TYPES = ("Asset", "Liability", "Equity", "Revenue", "Expense")
+_INVOICE_STATUSES = ("Draft", "Sent", "Paid", "Cancelled")
+_BILL_STATUSES = ("Draft", "To Pay", "Paid")
+
+# Probability a journal line is a debit (vs a credit) — a coin flip keeps the ledger balanced.
+_DEBIT_PROBABILITY = 0.5
+
+# Relative weights (rescaled to ``--count`` by SeedPlan.scaled). Shapes a realistic ERP mix:
+# many line items, fewer documents, a small chart of accounts.
+_WEIGHTS = {
+    "erp_accounts": 10,
+    "erp_contacts": 100,
+    "erp_invoices": 1000,
+    "erp_invoice_items": 3000,
+    "erp_bills": 800,
+    "erp_bill_items": 2000,
+    "erp_journal_entries": 1500,
+    "erp_journal_lines": 3000,
+}
+
+
+def build_erp_plan(*, seed: int = 42) -> SeedPlan:
+    """Return the canonical ERP :class:`SeedPlan` with a deterministically seeded Faker."""
+    from faker import Faker  # noqa: PLC0415 - dev-only dep, imported when a plan is built
+
+    fake = Faker()
+    fake.seed_instance(seed)
+
+    def accounts(pool, rng, seq):  # noqa: ARG001 - factory protocol signature
+        return {
+            "code": f"ACC-{seq:08d}",
+            "name": fake.bs().title(),
+            "account_type": rng.choice(_ACCOUNT_TYPES),
+        }
+
+    def contacts(pool, rng, seq):  # noqa: ARG001 - factory protocol signature
+        return {
+            "name": fake.company(),
+            "email": f"contact{seq}@{fake.domain_name()}",
+            "phone": fake.phone_number()[:20],
+            "contact_type": rng.choice(("Customer", "Supplier", "Both")),
+        }
+
+    def invoices(pool, rng, seq):
+        issued = fake.date_between(start_date="-2y", end_date="today")
+        return {
+            "number": f"INV-{seq:08d}",
+            "date_issued": issued,
+            "date_due": issued + timedelta(days=30),
+            "status": rng.choice(_INVOICE_STATUSES),
+            "customer_id": pool.sample("erp_contacts"),
+        }
+
+    def invoice_items(pool, rng, seq):  # noqa: ARG001
+        return {
+            "invoice_id": pool.sample("erp_invoices"),
+            "description": fake.catch_phrase(),
+            "quantity": float(rng.randint(1, 10)),
+            "unit_price": round(rng.uniform(50.0, 500.0), 2),
+        }
+
+    def bills(pool, rng, seq):
+        received = fake.date_between(start_date="-2y", end_date="today")
+        return {
+            "reference": f"BILL-{seq:08d}",
+            "date_received": received,
+            "date_due": received + timedelta(days=15),
+            "status": rng.choice(_BILL_STATUSES),
+            "supplier_id": pool.sample("erp_contacts"),
+        }
+
+    def bill_items(pool, rng, seq):  # noqa: ARG001
+        return {
+            "bill_id": pool.sample("erp_bills"),
+            "description": fake.bs(),
+            "quantity": float(rng.randint(1, 5)),
+            "unit_price": round(rng.uniform(20.0, 300.0), 2),
+        }
+
+    def journal_entries(pool, rng, seq):  # noqa: ARG001
+        return {
+            "date_posted": fake.date_between(start_date="-2y", end_date="today"),
+            "description": fake.sentence(nb_words=6),
+        }
+
+    def journal_lines(pool, rng, seq):  # noqa: ARG001
+        debit = round(rng.uniform(0.0, 1000.0), 2) if rng.random() < _DEBIT_PROBABILITY else 0.0
+        return {
+            "entry_id": pool.sample("erp_journal_entries"),
+            "account_id": pool.sample("erp_accounts"),
+            "debit": debit,
+            "credit": 0.0 if debit else round(rng.uniform(0.0, 1000.0), 2),
+        }
+
+    return SeedPlan(
+        (
+            TablePlan(
+                "erp_accounts",
+                _WEIGHTS["erp_accounts"],
+                accounts,
+                ("code", "name", "account_type"),
+                unique_columns=("code",),
+            ),
+            TablePlan(
+                "erp_contacts",
+                _WEIGHTS["erp_contacts"],
+                contacts,
+                ("name", "email", "phone", "contact_type"),
+            ),
+            TablePlan(
+                "erp_invoices",
+                _WEIGHTS["erp_invoices"],
+                invoices,
+                ("number", "date_issued", "date_due", "status", "customer_id"),
+                fk_parents=("erp_contacts",),
+                unique_columns=("number",),
+            ),
+            TablePlan(
+                "erp_invoice_items",
+                _WEIGHTS["erp_invoice_items"],
+                invoice_items,
+                ("invoice_id", "description", "quantity", "unit_price"),
+                fk_parents=("erp_invoices",),
+            ),
+            TablePlan(
+                "erp_bills",
+                _WEIGHTS["erp_bills"],
+                bills,
+                ("reference", "date_received", "date_due", "status", "supplier_id"),
+                fk_parents=("erp_contacts",),
+            ),
+            TablePlan(
+                "erp_bill_items",
+                _WEIGHTS["erp_bill_items"],
+                bill_items,
+                ("bill_id", "description", "quantity", "unit_price"),
+                fk_parents=("erp_bills",),
+            ),
+            TablePlan(
+                "erp_journal_entries",
+                _WEIGHTS["erp_journal_entries"],
+                journal_entries,
+                ("date_posted", "description"),
+            ),
+            TablePlan(
+                "erp_journal_lines",
+                _WEIGHTS["erp_journal_lines"],
+                journal_lines,
+                ("entry_id", "account_id", "debit", "credit"),
+                fk_parents=("erp_journal_entries", "erp_accounts"),
+            ),
+        )
+    )
+
+
+__all__ = ["build_erp_plan"]

--- a/src/hyperadmin/loadtest/plan.py
+++ b/src/hyperadmin/loadtest/plan.py
@@ -1,0 +1,189 @@
+"""Seed-plan domain models.
+
+A :class:`SeedPlan` is an ordered collection of :class:`TablePlan` entries. Order matters:
+parents are seeded before children so the foreign-key pool is fully populated when a child
+table starts. The plan is the single source of truth for what gets generated, in what
+proportion, and how a resume run validates that the plan has not drifted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from hyperadmin.loadtest.pool import FKPool
+
+# A row factory turns (fk pool, rng, global row sequence number) into a column->value dict.
+# The sequence number is unique within the table and is used to make UNIQUE columns collision
+# free (see ``TablePlan.unique_columns`` and the per-batch sequence prefix in ``batch.py``).
+RowFactory = Callable[["FKPool", random.Random, int], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class TablePlan:
+    """How to generate one table's rows.
+
+    ``target_count`` doubles as the relative *weight* of the table: :meth:`SeedPlan.scaled`
+    rescales every table's ``target_count`` proportionally so the totals sum to ``--count``.
+    """
+
+    name: str
+    target_count: int
+    row_factory: RowFactory
+    columns: tuple[str, ...]
+    fk_parents: tuple[str, ...] = ()
+    unique_columns: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.target_count < 0:
+            raise ValueError(f"target_count for {self.name!r} must be >= 0")
+        if not self.columns:
+            raise ValueError(f"TablePlan {self.name!r} must declare its columns")
+        missing = set(self.unique_columns) - set(self.columns)
+        if missing:
+            raise ValueError(
+                f"unique_columns {sorted(missing)} of {self.name!r} are not in columns"
+            )
+
+
+@dataclass(frozen=True)
+class SeedPlan:
+    """An ordered set of table plans plus the FK skew parameter.
+
+    The ordering invariant — every parent appears before the children that reference it — is
+    validated at construction time. Violations raise :class:`ValueError` rather than failing
+    obscurely at runtime when a child samples an empty pool.
+    """
+
+    tables: tuple[TablePlan, ...]
+    pareto_a: float = 1.16
+
+    def __post_init__(self) -> None:
+        if not self.tables:
+            raise ValueError("SeedPlan must contain at least one table")
+        if self.pareto_a <= 0:
+            raise ValueError("pareto_a must be > 0")
+        seen: set[str] = set()
+        for table in self.tables:
+            for parent in table.fk_parents:
+                if parent not in seen:
+                    raise ValueError(
+                        f"table {table.name!r} references parent {parent!r} "
+                        "which is not seeded earlier in the plan"
+                    )
+            if table.name in seen:
+                raise ValueError(f"duplicate table {table.name!r} in plan")
+            seen.add(table.name)
+
+    def table(self, name: str) -> TablePlan:
+        """Return the table plan with ``name`` or raise ``KeyError``."""
+        for table in self.tables:
+            if table.name == name:
+                return table
+        raise KeyError(name)
+
+    def scaled(self, total_count: int) -> SeedPlan:
+        """Return a copy whose per-table ``target_count`` values sum to ``total_count``.
+
+        Every table is guaranteed **at least one row** (when ``total_count >= len(tables)``):
+        a parent that scaled to zero would leave its children unable to sample a foreign key.
+        One row per table is reserved first, then the remainder is distributed by weight using
+        the largest-remainder method so the totals add up exactly with no drift.
+
+        >>> from hyperadmin.loadtest.plan import SeedPlan, TablePlan
+        >>> f = lambda pool, rng, seq: {"id": seq}
+        >>> plan = SeedPlan(
+        ...     (
+        ...         TablePlan("a", 1, f, ("id",)),
+        ...         TablePlan("b", 3, f, ("id",)),
+        ...     )
+        ... )
+        >>> [t.target_count for t in plan.scaled(100).tables]
+        [25, 75]
+        """
+        if total_count < 0:
+            raise ValueError("total_count must be >= 0")
+        weights = [t.target_count for t in self.tables]
+        if sum(weights) == 0:
+            raise ValueError("cannot scale a plan whose weights sum to 0")
+
+        n = len(self.tables)
+        if total_count == 0:
+            counts = [0] * n
+        elif total_count < n:
+            raise ValueError(
+                f"total_count ({total_count}) must be >= the number of tables ({n}) so every "
+                "table — including FK parents — gets at least one row"
+            )
+        else:
+            # Reserve one row per table, then apportion the rest by weight.
+            remaining = total_count - n
+            counts = [1 + extra for extra in _apportion(weights, remaining)]
+
+        scaled_tables = tuple(
+            _replace_count(table, count) for table, count in zip(self.tables, counts, strict=True)
+        )
+        return SeedPlan(scaled_tables, pareto_a=self.pareto_a)
+
+    def hash(self) -> str:
+        """Return a stable ``sha256:<hex>`` digest of the plan's structure.
+
+        The digest covers table order, target counts, FK edges, unique columns, the declared
+        column names per table, and ``pareto_a`` — everything whose change would invalidate an
+        in-progress resume. The ``row_factory`` callables are deliberately excluded (they are
+        not hashable and their column output is already captured by ``columns``).
+        """
+        canonical = {
+            "pareto_a": self.pareto_a,
+            "tables": [
+                {
+                    "name": t.name,
+                    "target_count": t.target_count,
+                    "columns": list(t.columns),
+                    "fk_parents": list(t.fk_parents),
+                    "unique_columns": list(t.unique_columns),
+                }
+                for t in self.tables
+            ],
+        }
+        payload = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        return f"sha256:{digest}"
+
+
+def _apportion(weights: list[int], total: int) -> list[int]:
+    """Split ``total`` across ``weights`` by the largest-remainder method (sums to ``total``)."""
+    weight_sum = sum(weights)
+    if total == 0 or weight_sum == 0:
+        return [0] * len(weights)
+    exact = [w * total / weight_sum for w in weights]
+    floored = [int(x) for x in exact]
+    leftover = total - sum(floored)
+    order = sorted(
+        range(len(weights)),
+        key=lambda i: (exact[i] - floored[i], weights[i]),
+        reverse=True,
+    )
+    for i in order[:leftover]:
+        floored[i] += 1
+    return floored
+
+
+def _replace_count(table: TablePlan, count: int) -> TablePlan:
+    """Return ``table`` with ``target_count`` replaced (frozen dataclasses are immutable)."""
+    return TablePlan(
+        name=table.name,
+        target_count=count,
+        row_factory=table.row_factory,
+        columns=table.columns,
+        fk_parents=table.fk_parents,
+        unique_columns=table.unique_columns,
+    )
+
+
+__all__ = ["RowFactory", "SeedPlan", "TablePlan"]

--- a/src/hyperadmin/loadtest/pool.py
+++ b/src/hyperadmin/loadtest/pool.py
@@ -1,0 +1,113 @@
+"""Foreign-key ID pool with Pareto-skewed sampling.
+
+A real ERP is *skewed*: a handful of "hot" accounts own most of the invoices. Benchmarks run
+against uniform-random FK references understate index-seek cost and cache pressure, so the
+pool draws parent IDs with an ≈80/20 Pareto skew instead of uniformly.
+
+Sampling uses the inverse-transform of a bounded power law over the *rank* of parent IDs. If a
+parent list has ``n`` entries ranked ``0..n-1`` (insertion order), the probability that a draw
+lands in the top fraction ``f`` of ranks is ``f ** ((a-1)/a)``. For ``a = 1.16`` that makes the
+top 20% of parents own ≈80% of references — the documented skew — with no clamping artefacts.
+
+``numpy`` is a *soft* dependency used to vectorise :meth:`FKPool.sample_many`; without it the
+pool falls back to a pure-stdlib loop over :func:`random.Random.random`. Both paths are
+reproducible under a fixed seed; they are not required to produce byte-identical streams.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# Vectorise sample_many through numpy only above this draw count; below it the per-call
+# overhead of seeding a numpy generator outweighs the stdlib loop.
+_NUMPY_MIN_N = 64
+
+try:  # pragma: no cover - exercised indirectly via both code paths in tests
+    import numpy as _np
+
+    _HAS_NUMPY = True
+except ImportError:  # pragma: no cover - numpy is a dev dep; fallback is still tested
+    _np = None  # type: ignore[assignment]
+    _HAS_NUMPY = False
+
+
+class EmptyPoolError(RuntimeError):
+    """Raised when a child table samples a parent whose pool has not been populated."""
+
+
+class FKPool:
+    """In-memory store of inserted parent primary keys with Pareto-skewed sampling."""
+
+    def __init__(self, *, pareto_a: float = 1.16, rng: random.Random | None = None) -> None:
+        if pareto_a <= 1:
+            # a <= 1 makes (a-1)/a <= 0, which inverts/flattens the skew. Guard it.
+            raise ValueError("pareto_a must be > 1 for a meaningful skew")
+        self._pareto_a = pareto_a
+        self._exponent = pareto_a / (pareto_a - 1.0)  # = 1 / ((a-1)/a); q = u ** exponent
+        self._rng = rng if rng is not None else random.Random()  # noqa: S311 - seeding RNG
+        self._pools: dict[str, list[int]] = {}
+
+    @property
+    def pareto_a(self) -> float:
+        return self._pareto_a
+
+    def extend(self, table: str, pks: Iterable[int]) -> None:
+        """Append freshly-inserted primary keys for ``table`` to its pool."""
+        self._pools.setdefault(table, []).extend(pks)
+
+    def size(self, table: str) -> int:
+        """Number of IDs currently held for ``table`` (0 if never populated)."""
+        return len(self._pools.get(table, ()))
+
+    def __len__(self) -> int:
+        """Total number of IDs held across every table."""
+        return sum(len(ids) for ids in self._pools.values())
+
+    def __contains__(self, table: object) -> bool:
+        return table in self._pools
+
+    def _require(self, table: str) -> list[int]:
+        ids = self._pools.get(table)
+        if not ids:
+            raise EmptyPoolError(
+                f"FK pool for {table!r} is empty — its parent rows must be seeded "
+                "before any child that references it"
+            )
+        return ids
+
+    def _skewed_index(self, n: int) -> int:
+        """Return a power-law-skewed rank index in ``[0, n)`` using one stdlib draw."""
+        q = self._rng.random() ** self._exponent
+        idx = int(q * n)
+        return idx if idx < n else n - 1
+
+    def sample(self, table: str) -> int:
+        """Return one parent ID for ``table`` drawn with the Pareto skew."""
+        ids = self._require(table)
+        return ids[self._skewed_index(len(ids))]
+
+    def sample_many(self, table: str, n: int) -> list[int]:
+        """Return ``n`` parent IDs for ``table`` (with replacement, Pareto-skewed)."""
+        if n < 0:
+            raise ValueError("n must be >= 0")
+        ids = self._require(table)
+        if n == 0:
+            return []
+        size = len(ids)
+        if _HAS_NUMPY and _np is not None and n >= _NUMPY_MIN_N:
+            # Vectorised fast path. Seed a local numpy generator from the shared rng so the
+            # stream stays reproducible and advances the rng for subsequent draws.
+            seed = self._rng.getrandbits(63)
+            gen = _np.random.default_rng(seed)
+            q = gen.random(n) ** self._exponent
+            indices = (q * size).astype(_np.int64)
+            _np.clip(indices, 0, size - 1, out=indices)
+            return [ids[i] for i in indices.tolist()]
+        return [ids[self._skewed_index(size)] for _ in range(n)]
+
+
+__all__ = ["EmptyPoolError", "FKPool"]

--- a/src/hyperadmin/loadtest/progress.py
+++ b/src/hyperadmin/loadtest/progress.py
@@ -1,0 +1,150 @@
+"""Progress reporting for the bulk seeder.
+
+Two reporters implement the :class:`ProgressReporter` protocol:
+
+* :class:`RichReporter` — per-table progress bars with ETA and throughput, used on a TTY.
+* :class:`PlainReporter` — one structured line per batch, used in CI / non-TTY logs.
+
+``rich`` is soft-imported: if it is unavailable, or the output stream is not a TTY, or the
+operator passed ``--no-progress``, the seeder falls back to :class:`PlainReporter`.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import TYPE_CHECKING, Protocol, TextIO
+
+if TYPE_CHECKING:
+    from rich.progress import TaskID
+
+
+class ProgressReporter(Protocol):
+    """Sink for per-table seeding progress."""
+
+    def start_table(self, table: str, total: int) -> None: ...
+    def advance(self, table: str, n: int) -> None: ...
+    def finish_table(self, table: str) -> None: ...
+    def close(self) -> None: ...
+
+
+_RATE_K_THRESHOLD = 1000  # render rows/sec in thousands at or above this rate
+
+
+def _format_rate(rows: int, elapsed: float) -> str:
+    rate = rows / elapsed if elapsed > 0 else 0.0
+    if rate >= _RATE_K_THRESHOLD:
+        return f"{rate / _RATE_K_THRESHOLD:.1f}K/s"
+    return f"{rate:.0f}/s"
+
+
+class PlainReporter:
+    """Emit one ``table=... completed=x/total rate=...`` line per advance."""
+
+    def __init__(self, stream: TextIO | None = None, *, clock=time.monotonic) -> None:
+        self._stream = stream if stream is not None else sys.stderr
+        self._clock = clock
+        self._totals: dict[str, int] = {}
+        self._done: dict[str, int] = {}
+        self._started_at: dict[str, float] = {}
+
+    def start_table(self, table: str, total: int) -> None:
+        self._totals[table] = total
+        self._done[table] = 0
+        self._started_at[table] = self._clock()
+
+    def advance(self, table: str, n: int) -> None:
+        self._done[table] = self._done.get(table, 0) + n
+        started = self._started_at.get(table)
+        elapsed = self._clock() - started if started is not None else 0.0
+        rate = _format_rate(self._done[table], elapsed)
+        print(
+            f"table={table} completed={self._done[table]}/{self._totals.get(table, 0)} rate={rate}",
+            file=self._stream,
+            flush=True,
+        )
+
+    def finish_table(self, table: str) -> None:
+        started = self._started_at.get(table)
+        elapsed = self._clock() - started if started is not None else 0.0
+        rate = _format_rate(self._done.get(table, 0), elapsed)
+        print(
+            f"table={table} done={self._done.get(table, 0)} elapsed={elapsed:.1f}s rate={rate}",
+            file=self._stream,
+            flush=True,
+        )
+
+    def close(self) -> None:
+        """No-op: the plain reporter holds no resources."""
+
+
+class RichReporter:
+    """Per-table Rich progress bars. Constructed only when ``rich`` is importable."""
+
+    def __init__(self) -> None:
+        from rich.progress import (  # noqa: PLC0415 - soft dependency, imported on demand
+            BarColumn,
+            MofNCompleteColumn,
+            Progress,
+            SpinnerColumn,
+            TaskProgressColumn,
+            TextColumn,
+            TimeRemainingColumn,
+        )
+
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TaskProgressColumn(),
+            TimeRemainingColumn(),
+            TextColumn("{task.fields[rate]}"),
+        )
+        self._tasks: dict[str, TaskID] = {}
+        self._done: dict[str, int] = {}
+        self._started_at: dict[str, float] = {}
+        self._progress.start()
+
+    def start_table(self, table: str, total: int) -> None:
+        self._tasks[table] = self._progress.add_task(table, total=total, rate="")
+        self._done[table] = 0
+        self._started_at[table] = time.monotonic()
+
+    def advance(self, table: str, n: int) -> None:
+        self._done[table] += n
+        elapsed = time.monotonic() - self._started_at[table]
+        self._progress.update(
+            self._tasks[table], advance=n, rate=_format_rate(self._done[table], elapsed)
+        )
+
+    def finish_table(self, table: str) -> None:  # noqa: ARG002 - protocol signature
+        # Leave the completed bar visible; nothing else to do.
+        self._progress.refresh()
+
+    def close(self) -> None:
+        self._progress.stop()
+
+
+def make_reporter(*, no_progress: bool, stream: TextIO | None = None) -> ProgressReporter:
+    """Pick the right reporter for the environment.
+
+    Rich is used only on an interactive TTY when available and not disabled. Otherwise the
+    plain reporter keeps CI logs readable.
+    """
+    out = stream if stream is not None else sys.stderr
+    is_tty = bool(getattr(out, "isatty", lambda: False)())
+    if no_progress or not is_tty:
+        return PlainReporter(out)
+    try:
+        return RichReporter()
+    except ImportError:  # pragma: no cover - rich is a dev dep; fallback path
+        return PlainReporter(out)
+
+
+__all__ = [
+    "PlainReporter",
+    "ProgressReporter",
+    "RichReporter",
+    "make_reporter",
+]

--- a/src/hyperadmin/management/commands/seed.py
+++ b/src/hyperadmin/management/commands/seed.py
@@ -1,0 +1,108 @@
+"""``hyperadmin seed`` — bulk synthetic-data generator CLI.
+
+Drives :class:`hyperadmin.loadtest.BulkSeeder` from a single ``--count`` target, scaling the
+chosen plan's per-table ratios. See ``docs/specs/synthetic-data-generator.md`` for the design.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from sqlalchemy import create_engine
+
+from hyperadmin.loadtest.batch import BulkSeeder, SeedInterruptedError
+from hyperadmin.loadtest.checkpoint import PlanHashMismatchError
+from hyperadmin.loadtest.generators import PLAN_BUILDERS, build_plan
+from hyperadmin.loadtest.progress import make_reporter
+
+app = typer.Typer(help="Bulk synthetic-data seeding for load testing.")
+
+# Async drivers cannot back the synchronous Core inserts the seeder uses; map them to their
+# sync equivalents so a single --database-url works whether it came from app config or env.
+_ASYNC_TO_SYNC = {
+    "sqlite+aiosqlite": "sqlite",
+    "postgresql+asyncpg": "postgresql+psycopg2",
+    "postgresql+psycopg_async": "postgresql+psycopg",
+    "mysql+aiomysql": "mysql+pymysql",
+}
+
+
+def _to_sync_url(url: str) -> str:
+    for async_prefix, sync_prefix in _ASYNC_TO_SYNC.items():
+        if url.startswith(async_prefix):
+            return sync_prefix + url[len(async_prefix) :]
+    return url
+
+
+@app.command()
+def seed(  # noqa: PLR0913 - each option is a distinct CLI flag
+    count: Annotated[int, typer.Option("--count", help="Total target rows across the plan.")],
+    database_url: Annotated[
+        str | None,
+        typer.Option("--database-url", envvar="DATABASE_URL", help="SQLAlchemy database URL."),
+    ] = None,
+    batch_size: Annotated[int, typer.Option("--batch-size", help="Rows per INSERT batch.")] = 5000,
+    plan_name: Annotated[
+        str, typer.Option("--plan", help=f"Plan name. One of: {', '.join(PLAN_BUILDERS)}.")
+    ] = "erp",
+    resume: Annotated[
+        bool, typer.Option("--resume", help="Resume from the checkpoint file.")
+    ] = False,
+    rng_seed: Annotated[int, typer.Option("--seed", help="RNG seed for reproducible runs.")] = 42,
+    state_file: Annotated[
+        Path, typer.Option("--state-file", help="Checkpoint file location.")
+    ] = Path(".hyperadmin-seed.json"),
+    no_progress: Annotated[
+        bool, typer.Option("--no-progress", help="Disable the Rich progress UI.")
+    ] = False,
+) -> None:
+    """Seed COUNT rows into the database using the chosen plan."""
+    if count < 0:
+        typer.echo("Error: --count must be >= 0.", err=True)
+        raise typer.Exit(code=1)
+    if not database_url:
+        typer.echo(
+            "Error: provide a database via --database-url or the DATABASE_URL env var.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        plan = build_plan(plan_name, seed=rng_seed).scaled(count)
+    except KeyError as exc:
+        typer.echo(f"Error: {exc.args[0]}", err=True)
+        raise typer.Exit(code=1) from None
+
+    engine = create_engine(_to_sync_url(database_url))
+    reporter = make_reporter(no_progress=no_progress)
+    seeder = BulkSeeder(
+        plan=plan,
+        engine=engine,
+        batch_size=batch_size,
+        rng_seed=rng_seed,
+        state_file=state_file,
+        resume=resume,
+        progress=reporter,
+    )
+
+    try:
+        summary = seeder.run()
+    except PlanHashMismatchError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=2) from None
+    except SeedInterruptedError as exc:
+        typer.echo(f"\nInterrupted: {exc}", err=True)
+        raise typer.Exit(code=130) from None
+    finally:
+        engine.dispose()
+
+    typer.echo(
+        f"Seeded {summary.rows_inserted} rows in {summary.elapsed_seconds:.1f}s "
+        f"({summary.rows_per_second:.0f} rows/s)."
+    )
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/e2e/test_seed_integration.py
+++ b/tests/e2e/test_seed_integration.py
@@ -13,7 +13,6 @@ import examples.erp.accounting.models
 import examples.erp.contacts.models
 import examples.erp.purchases.models
 import examples.erp.sales.models  # noqa: F401
-import pytest
 from sqlalchemy import MetaData, Table, create_engine, func, select
 from sqlmodel import SQLModel
 
@@ -123,13 +122,24 @@ def test_cli_seeds_into_sqlite(tmp_path):
     engine.dispose()
 
 
-@pytest.mark.anyio
-async def test_examples_bulk_seed_wrapper(tmp_path):
-    """The async ``bulk_seed_erp`` wrapper creates the schema and seeds via a worker thread."""
+def test_examples_bulk_seed_wrapper(tmp_path):
+    """The async ``bulk_seed_erp`` wrapper creates the schema and seeds via a worker thread.
+
+    Run synchronously in a dedicated thread (fresh event loop) rather than as an ``async def``
+    test: the e2e suite activates both pytest-asyncio (auto mode) and the anyio plugin, and a
+    plain coroutine test gets claimed by both runners, which collide on loop teardown with
+    "Cannot run the event loop while another loop is running". A sync test sidesteps both.
+    """
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+
     from examples.erp.seed import bulk_seed_erp
 
     url = f"sqlite:///{tmp_path / 'wrapped.db'}"
-    summary = await bulk_seed_erp(300, batch_size=100, database_url=url)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        summary = executor.submit(
+            lambda: asyncio.run(bulk_seed_erp(300, batch_size=100, database_url=url))
+        ).result()
     assert summary.rows_inserted == 300
 
     engine = create_engine(url)

--- a/tests/e2e/test_seed_integration.py
+++ b/tests/e2e/test_seed_integration.py
@@ -1,0 +1,139 @@
+"""Integration test for the bulk seeder against the real ERP schema (#255).
+
+Not a browser test — it exercises ``BulkSeeder``, the ``hyperadmin seed`` CLI, and the
+``examples/erp`` async wrapper end-to-end against a file-backed SQLite database. It lives under
+``tests/e2e`` per the SDD because it validates the full seeding stack, not a single unit.
+"""
+
+import subprocess
+import sys
+
+# Importing the models registers them on SQLModel.metadata so create_all builds erp_* tables.
+import examples.erp.accounting.models
+import examples.erp.contacts.models
+import examples.erp.purchases.models
+import examples.erp.sales.models  # noqa: F401
+import pytest
+from sqlalchemy import MetaData, Table, create_engine, func, select
+from sqlmodel import SQLModel
+
+from hyperadmin.loadtest import BulkSeeder
+from hyperadmin.loadtest.generators import build_plan
+
+# (child table, FK column) -> (parent table, parent PK) edges of the ERP plan.
+_FK_EDGES = [
+    ("erp_invoices", "customer_id", "erp_contacts", "id"),
+    ("erp_invoice_items", "invoice_id", "erp_invoices", "id"),
+    ("erp_bills", "supplier_id", "erp_contacts", "id"),
+    ("erp_bill_items", "bill_id", "erp_bills", "id"),
+    ("erp_journal_lines", "entry_id", "erp_journal_entries", "id"),
+    ("erp_journal_lines", "account_id", "erp_accounts", "id"),
+]
+
+
+def _create_schema(db_path) -> str:
+    url = f"sqlite:///{db_path}"
+    engine = create_engine(url)
+    SQLModel.metadata.create_all(engine)
+    engine.dispose()
+    return url
+
+
+def _row_count(engine, table) -> int:
+    tbl = Table(table, MetaData(), autoload_with=engine)
+    with engine.connect() as conn:
+        return conn.execute(select(func.count()).select_from(tbl)).scalar()
+
+
+def _assert_fk_integrity(engine) -> None:
+    md = MetaData()
+    for child, fk_col, parent, pk_col in _FK_EDGES:
+        child_tbl = Table(child, md, autoload_with=engine)
+        parent_tbl = Table(parent, md, autoload_with=engine)
+        with engine.connect() as conn:
+            fk_values = set(conn.execute(select(child_tbl.c[fk_col])).scalars())
+            parent_ids = set(conn.execute(select(parent_tbl.c[pk_col])).scalars())
+        assert fk_values <= parent_ids, f"{child}.{fk_col} has orphan references to {parent}"
+
+
+def test_seed_1k_records_preserves_fk_integrity(tmp_path):
+    """
+    Scenario: seed 1K records into SQLite, verify FK integrity
+      Given a fresh SQLite database with the ERP schema migrated
+      When  the bulk seeder runs with a total target of 1000 rows
+      Then  the tables hold 1000 rows in total
+      And   every foreign key references an existing parent row
+    """
+    # Given a fresh SQLite database with the ERP schema migrated
+    url = _create_schema(tmp_path / "erp.db")
+    engine = create_engine(url)
+    plan = build_plan("erp", seed=42).scaled(1000)
+
+    # When the bulk seeder runs with a total target of 1000 rows
+    summary = BulkSeeder(
+        plan=plan,
+        engine=engine,
+        batch_size=250,
+        state_file=tmp_path / ".hyperadmin-seed.json",
+        install_signal_handlers=False,
+    ).run()
+
+    # Then the tables hold 1000 rows in total
+    assert summary.rows_inserted == 1000
+    total = sum(_row_count(engine, t.name) for t in plan.tables)
+    assert total == 1000
+
+    # And every foreign key references an existing parent row
+    _assert_fk_integrity(engine)
+    engine.dispose()
+
+
+def test_cli_seeds_into_sqlite(tmp_path):
+    """The ``hyperadmin seed`` CLI seeds a pre-migrated database and exits 0."""
+    url = _create_schema(tmp_path / "erp.db")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hyperadmin",
+            "seed",
+            "--count",
+            "500",
+            "--plan",
+            "erp",
+            "--database-url",
+            url,
+            "--batch-size",
+            "200",
+            "--no-progress",
+            "--state-file",
+            str(tmp_path / ".seed.json"),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Seeded 500 rows" in result.stdout + result.stderr
+
+    engine = create_engine(url)
+    total = sum(_row_count(engine, t.name) for t in build_plan("erp").scaled(500).tables)
+    assert total == 500
+    _assert_fk_integrity(engine)
+    engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_examples_bulk_seed_wrapper(tmp_path):
+    """The async ``bulk_seed_erp`` wrapper creates the schema and seeds via a worker thread."""
+    from examples.erp.seed import bulk_seed_erp
+
+    url = f"sqlite:///{tmp_path / 'wrapped.db'}"
+    summary = await bulk_seed_erp(300, batch_size=100, database_url=url)
+    assert summary.rows_inserted == 300
+
+    engine = create_engine(url)
+    total = sum(_row_count(engine, t.name) for t in build_plan("erp").scaled(300).tables)
+    assert total == 300
+    _assert_fk_integrity(engine)
+    engine.dispose()

--- a/tests/unit/loadtest/__init__.py
+++ b/tests/unit/loadtest/__init__.py
@@ -1,0 +1,1 @@
+"""HyperAdmin loadtest unit tests."""

--- a/tests/unit/loadtest/test_batch.py
+++ b/tests/unit/loadtest/test_batch.py
@@ -1,0 +1,235 @@
+"""Unit/integration tests for BulkSeeder over SQLite (#248/#249)."""
+
+import signal
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    func,
+    select,
+)
+
+from hyperadmin.loadtest.batch import BulkSeeder, SeedInterruptedError, SeedSummary
+from hyperadmin.loadtest.plan import SeedPlan, TablePlan
+
+
+def _account_factory(pool, rng, seq):
+    return {"name": f"Account {seq}"}
+
+
+def _invoice_factory(pool, rng, seq):
+    return {"number": f"INV-{seq:08d}", "account_id": pool.sample("accounts")}
+
+
+def _plan(accounts=50, invoices=200):
+    return SeedPlan(
+        (
+            TablePlan("accounts", accounts, _account_factory, ("name",)),
+            TablePlan(
+                "invoices",
+                invoices,
+                _invoice_factory,
+                ("number", "account_id"),
+                fk_parents=("accounts",),
+                unique_columns=("number",),
+            ),
+        )
+    )
+
+
+@pytest.fixture
+def engine(tmp_path):
+    # File-based SQLite so reflection (separate connection) sees the schema.
+    eng = create_engine(f"sqlite:///{tmp_path / 'erp.db'}")
+    md = MetaData()
+    Table("accounts", md, Column("id", Integer, primary_key=True), Column("name", String))
+    Table(
+        "invoices",
+        md,
+        Column("id", Integer, primary_key=True),
+        Column("number", String, unique=True),
+        Column("account_id", Integer, ForeignKey("accounts.id")),
+    )
+    md.create_all(eng)
+    return eng
+
+
+def _count(engine, table):
+    with engine.connect() as conn:
+        return conn.execute(select(func.count()).select_from(_reflect(engine, table))).scalar()
+
+
+def _reflect(engine, name):
+    return Table(name, MetaData(), autoload_with=engine)
+
+
+def _seeder(plan, engine, tmp_path, **kw):
+    kw.setdefault("install_signal_handlers", False)
+    kw.setdefault("state_file", tmp_path / ".hyperadmin-seed.json")
+    return BulkSeeder(plan=plan, engine=engine, **kw)
+
+
+class TestSeedSummary:
+    def test_rows_per_second(self):
+        s = SeedSummary(rows_inserted=1000, elapsed_seconds=2.0)
+        assert s.rows_per_second == 500.0
+
+    def test_rows_per_second_zero_elapsed(self):
+        assert SeedSummary(rows_inserted=10).rows_per_second == 0.0
+
+
+class TestBasicSeeding:
+    def test_seeds_all_rows(self, engine, tmp_path):
+        """
+        Scenario: bulk seed produces N rows across the plan
+          Given a fresh SQLite database with the schema migrated
+          When  the seeder runs with target 50 accounts + 200 invoices
+          Then  each table contains its planned row count
+        """
+        summary = _seeder(_plan(), engine, tmp_path, batch_size=64).run()
+        assert _count(engine, "accounts") == 50
+        assert _count(engine, "invoices") == 200
+        assert summary.rows_inserted == 250
+        assert summary.per_table == {"accounts": 50, "invoices": 200}
+
+    def test_throughput_is_reported(self, engine, tmp_path):
+        summary = _seeder(_plan(10, 40), engine, tmp_path).run()
+        assert summary.elapsed_seconds > 0
+        assert summary.rows_per_second > 0
+
+    def test_checkpoint_removed_on_clean_completion(self, engine, tmp_path):
+        state_file = tmp_path / ".hyperadmin-seed.json"
+        _seeder(_plan(10, 20), engine, tmp_path, state_file=state_file).run()
+        assert not state_file.exists()
+
+
+class TestForeignKeyIntegrity:
+    def test_every_child_fk_points_at_a_real_parent(self, engine, tmp_path):
+        """
+        Scenario: foreign-key integrity is preserved across batches
+          Given the plan inserts Accounts before Invoices
+          When  the seeder commits the Invoices batches
+          Then  every invoice.account_id references an existing account
+        """
+        _seeder(_plan(30, 300), engine, tmp_path, batch_size=50).run()
+        accounts = _reflect(engine, "accounts")
+        invoices = _reflect(engine, "invoices")
+        with engine.connect() as conn:
+            account_ids = set(conn.execute(select(accounts.c.id)).scalars())
+            fk_ids = set(conn.execute(select(invoices.c.account_id)).scalars())
+        assert fk_ids <= account_ids
+        assert fk_ids  # non-empty: invoices really did reference parents
+
+    def test_unique_column_has_no_collisions_across_batches(self, engine, tmp_path):
+        # seq-derived unique values must stay unique even with a small batch size.
+        _seeder(_plan(5, 137), engine, tmp_path, batch_size=10).run()
+        invoices = _reflect(engine, "invoices")
+        with engine.connect() as conn:
+            numbers = conn.execute(select(invoices.c.number)).scalars().all()
+        assert len(numbers) == len(set(numbers)) == 137
+
+
+class TestResume:
+    def test_interrupt_then_resume_completes_without_gaps_or_dupes(self, engine, tmp_path):
+        """
+        Scenario: Ctrl-C mid-run resumes from the last completed batch
+          Given the seeder is interrupted after some invoice batches commit
+          When  it is re-run with --resume
+          Then  the final row count equals the target with no duplicates
+          And   the checkpoint file is removed on clean completion
+        """
+        state_file = tmp_path / ".hyperadmin-seed.json"
+        seeder_a = _seeder(_plan(20, 100), engine, tmp_path, batch_size=10, state_file=state_file)
+
+        class Interrupting:
+            def __init__(self, seeder):
+                self.seeder = seeder
+                self.done = 0
+
+            def start_table(self, table, total):
+                pass
+
+            def advance(self, table, n):
+                if table == "invoices":
+                    self.done += n
+                    if self.done >= 30:
+                        self.seeder._interrupted = True
+
+            def finish_table(self, table):
+                pass
+
+            def close(self):
+                pass
+
+        seeder_a.progress = Interrupting(seeder_a)
+        with pytest.raises(SeedInterruptedError):
+            seeder_a.run()
+        assert state_file.exists()
+        # Some but not all invoices committed.
+        partial = _count(engine, "invoices")
+        assert 0 < partial < 100
+
+        seeder_b = _seeder(
+            _plan(20, 100), engine, tmp_path, batch_size=10, state_file=state_file, resume=True
+        )
+        summary = seeder_b.run()
+        assert _count(engine, "invoices") == 100
+        assert summary.rows_inserted == 100 - partial  # only the remaining rows this run
+        invoices = _reflect(engine, "invoices")
+        with engine.connect() as conn:
+            numbers = conn.execute(select(invoices.c.number)).scalars().all()
+        assert len(numbers) == len(set(numbers)) == 100
+        assert not state_file.exists()
+
+
+class TestSignalHandling:
+    def test_handlers_installed_and_restored(self, engine, tmp_path):
+        before = signal.getsignal(signal.SIGINT)
+        summary = _seeder(_plan(5, 10), engine, tmp_path, install_signal_handlers=True).run()
+        assert summary.rows_inserted == 15
+        # The seeder restores the original handler after a clean run.
+        assert signal.getsignal(signal.SIGINT) is before
+
+    def test_handle_signal_sets_interrupted_flag(self, engine, tmp_path):
+        seeder = _seeder(_plan(), engine, tmp_path)
+        assert seeder._interrupted is False
+        seeder._handle_signal(signal.SIGINT, None)
+        assert seeder._interrupted is True
+
+
+class TestValidation:
+    def test_zero_batch_size_rejected(self, engine, tmp_path):
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            _seeder(_plan(), engine, tmp_path, batch_size=0)
+
+    def test_sqlite_batch_size_is_capped(self, engine, tmp_path):
+        # max columns in plan = 2 (invoices) -> cap = 32766 // 2 = 16383.
+        seeder = _seeder(_plan(), engine, tmp_path, batch_size=100_000)
+        assert seeder.batch_size == 16383
+
+    def test_non_sqlite_batch_size_passthrough(self, tmp_path):
+        # Only SQLite shrinks the batch size; other dialects pass it through unchanged.
+        fake_engine = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        seeder = _seeder(_plan(), fake_engine, tmp_path, batch_size=99_999)
+        assert seeder.batch_size == 99_999
+
+    def test_composite_pk_table_rejected(self, tmp_path):
+        eng = create_engine(f"sqlite:///{tmp_path / 'composite.db'}")
+        md = MetaData()
+        Table(
+            "composite",
+            md,
+            Column("a", Integer, primary_key=True),
+            Column("b", Integer, primary_key=True),
+        )
+        md.create_all(eng)
+        tbl = _reflect(eng, "composite")
+        with pytest.raises(ValueError, match="exactly one primary-key column"):
+            BulkSeeder._pk_column(tbl)

--- a/tests/unit/loadtest/test_checkpoint.py
+++ b/tests/unit/loadtest/test_checkpoint.py
@@ -1,0 +1,133 @@
+"""Unit tests for the resumable checkpoint store (#252)."""
+
+import json
+
+import pytest
+
+from hyperadmin.loadtest.checkpoint import (
+    CheckpointState,
+    CheckpointStore,
+    PlanHashMismatchError,
+    TableProgress,
+    describe_drift,
+    validate_resume,
+)
+from hyperadmin.loadtest.plan import SeedPlan, TablePlan
+
+
+def _factory(pool, rng, seq):
+    return {"id": seq}
+
+
+def _plan(invoice_target=100, *, columns=("id",)):
+    return SeedPlan(
+        (
+            TablePlan("accounts", 10, _factory, ("id",)),
+            TablePlan("invoices", invoice_target, _factory, columns, fk_parents=("accounts",)),
+        )
+    )
+
+
+def _state(plan, *, completed_invoices=0):
+    return CheckpointState(
+        plan_hash=plan.hash(),
+        rng_seed=42,
+        started_at="2026-05-05T10:15:00Z",
+        tables={
+            "accounts": TableProgress(target=10, completed=10, last_pk=10),
+            "invoices": TableProgress(
+                target=100, completed=completed_invoices, last_pk=completed_invoices or None
+            ),
+        },
+    )
+
+
+class TestTableProgress:
+    def test_remaining_and_done(self):
+        p = TableProgress(target=100, completed=35)
+        assert p.remaining == 65
+        assert not p.is_done
+        p.completed = 100
+        assert p.remaining == 0
+        assert p.is_done
+
+    def test_remaining_never_negative(self):
+        assert TableProgress(target=10, completed=15).remaining == 0
+
+
+class TestRoundTrip:
+    def test_save_then_load_roundtrips(self, tmp_path):
+        store = CheckpointStore(tmp_path / ".hyperadmin-seed.json")
+        plan = _plan()
+        state = _state(plan, completed_invoices=35)
+        store.save(state)
+        loaded = store.load()
+        assert loaded.plan_hash == state.plan_hash
+        assert loaded.rng_seed == 42
+        assert loaded.tables["invoices"].completed == 35
+        assert loaded.tables["invoices"].last_pk == 35
+
+    def test_saved_file_is_human_readable_json(self, tmp_path):
+        store = CheckpointStore(tmp_path / "state.json")
+        plan = _plan()
+        store.save(_state(plan))
+        raw = json.loads((tmp_path / "state.json").read_text())
+        assert raw["rng_seed"] == 42
+        assert set(raw["tables"]) == {"accounts", "invoices"}
+
+    def test_save_with_fsync(self, tmp_path):
+        store = CheckpointStore(tmp_path / "state.json")
+        plan = _plan()
+        store.save(_state(plan), fsync=True)
+        assert store.exists()
+        # No leftover temp file after the atomic replace.
+        assert not (tmp_path / "state.json.tmp").exists()
+
+    def test_remove_is_idempotent(self, tmp_path):
+        store = CheckpointStore(tmp_path / "state.json")
+        store.save(_state(_plan()))
+        assert store.exists()
+        store.remove()
+        assert not store.exists()
+        store.remove()  # no error on second call
+
+    def test_corrupt_file_raises_valueerror(self, tmp_path):
+        path = tmp_path / "state.json"
+        path.write_text('{"plan_hash": "x"}')  # missing required keys
+        with pytest.raises(ValueError, match="corrupt checkpoint"):
+            CheckpointStore(path).load()
+
+
+class TestResumeValidation:
+    def test_matching_plan_validates(self):
+        plan = _plan()
+        validate_resume(_state(plan), plan)  # no raise
+
+    def test_target_drift_aborts_with_named_table(self):
+        """
+        Scenario: schema-drift on resume aborts cleanly
+          Given a checkpoint written for invoices target 100
+          And   the plan now targets 200 invoices
+          When  validate_resume runs
+          Then  it raises naming the invoices target change
+        """
+        old_plan = _plan(invoice_target=100)
+        state = _state(old_plan)
+        new_plan = _plan(invoice_target=200)
+        with pytest.raises(PlanHashMismatchError, match=r"invoices.*100 -> 200"):
+            validate_resume(state, new_plan)
+
+    def test_column_drift_aborts(self):
+        old_plan = _plan(columns=("id",))
+        state = _state(old_plan)
+        new_plan = _plan(columns=("id", "amount"))
+        with pytest.raises(PlanHashMismatchError, match="plan structure changed"):
+            validate_resume(state, new_plan)
+
+    def test_table_set_change_described(self):
+        plan = _plan()
+        state = _state(plan)
+        del state.tables["invoices"]
+        state.plan_hash = "sha256:deadbeef"  # force mismatch
+        msg = describe_drift(state, plan)
+        assert "table set/order changed" in msg

--- a/tests/unit/loadtest/test_generators.py
+++ b/tests/unit/loadtest/test_generators.py
@@ -1,0 +1,74 @@
+"""Unit tests for the built-in ERP/auth seed-plan generators."""
+
+import random
+
+import pytest
+
+from hyperadmin.loadtest.generators import (
+    PLAN_BUILDERS,
+    build_auth_plan,
+    build_erp_plan,
+    build_plan,
+)
+from hyperadmin.loadtest.pool import FKPool
+
+
+class TestRegistry:
+    def test_known_plans_build(self):
+        assert set(PLAN_BUILDERS) == {"erp", "auth"}
+        assert build_plan("erp").tables
+        assert build_plan("auth").tables
+
+    def test_unknown_plan_lists_available(self):
+        with pytest.raises(KeyError, match="available plans: auth, erp"):
+            build_plan("nope")
+
+
+class TestErpPlan:
+    def test_plan_hash_is_seed_independent_and_stable(self):
+        # Structure (and thus hash) does not depend on the Faker seed.
+        assert build_erp_plan(seed=1).hash() == build_erp_plan(seed=999).hash()
+
+    def test_parent_ordering_is_valid(self):
+        # Construction would raise if any child preceded its parent; assert the edges too.
+        plan = build_erp_plan()
+        names = [t.name for t in plan.tables]
+        assert names.index("erp_contacts") < names.index("erp_invoices")
+        assert names.index("erp_invoices") < names.index("erp_invoice_items")
+        assert names.index("erp_accounts") < names.index("erp_journal_lines")
+
+    def test_scaling_sums_exactly(self):
+        plan = build_erp_plan().scaled(10_000)
+        assert sum(t.target_count for t in plan.tables) == 10_000
+
+    def test_factories_emit_declared_columns(self):
+        plan = build_erp_plan(seed=7)
+        rng = random.Random(7)  # noqa: S311 - test RNG
+        pool = FKPool(rng=rng)
+        # Seed parent pools so FK-sampling factories can run.
+        for parent in (
+            "erp_contacts",
+            "erp_invoices",
+            "erp_bills",
+            "erp_journal_entries",
+            "erp_accounts",
+        ):
+            pool.extend(parent, range(1, 50))
+        for table in plan.tables:
+            row = table.row_factory(pool, rng, 1)
+            assert set(row) == set(table.columns), table.name
+
+
+class TestAuthPlan:
+    def test_auth_plan_has_users_and_groups(self):
+        names = [t.name for t in build_auth_plan().tables]
+        assert names == ["hyperadmin_users", "hyperadmin_groups"]
+
+    def test_user_factory_fills_not_null_columns(self):
+        plan = build_auth_plan(seed=3)
+        rng = random.Random(3)  # noqa: S311 - test RNG
+        pool = FKPool(rng=rng)
+        row = plan.table("hyperadmin_users").row_factory(pool, rng, 5)
+        assert row["username"] == "user_00000005"
+        assert row["is_active"] is True
+        assert row["created_at"] is not None

--- a/tests/unit/loadtest/test_plan.py
+++ b/tests/unit/loadtest/test_plan.py
@@ -1,0 +1,174 @@
+"""Unit tests for SeedPlan / TablePlan: ordering invariants, scaling, and plan hashing."""
+
+import pytest
+
+from hyperadmin.loadtest.plan import SeedPlan, TablePlan
+
+
+def _factory(pool, rng, seq):
+    return {"id": seq}
+
+
+def _table(name, count, *, parents=(), unique=(), columns=("id",)):
+    return TablePlan(
+        name=name,
+        target_count=count,
+        row_factory=_factory,
+        columns=columns,
+        fk_parents=parents,
+        unique_columns=unique,
+    )
+
+
+class TestTablePlanValidation:
+    def test_negative_target_count_rejected(self):
+        with pytest.raises(ValueError, match="target_count"):
+            _table("a", -1)
+
+    def test_empty_columns_rejected(self):
+        with pytest.raises(ValueError, match="must declare its columns"):
+            _table("a", 1, columns=())
+
+    def test_unique_column_must_be_in_columns(self):
+        with pytest.raises(ValueError, match="not in columns"):
+            _table("a", 1, columns=("id",), unique=("email",))
+
+
+class TestSeedPlanOrdering:
+    def test_parent_must_precede_child(self):
+        """
+        Scenario: child references a parent not yet seeded
+          Given a plan where Invoices precede Accounts
+          When  the plan is constructed
+          Then  a ValueError naming the missing parent is raised
+        """
+        with pytest.raises(ValueError, match="not seeded earlier"):
+            SeedPlan(
+                (
+                    _table("invoices", 10, parents=("accounts",)),
+                    _table("accounts", 5),
+                )
+            )
+
+    def test_valid_parent_child_order_accepted(self):
+        plan = SeedPlan(
+            (
+                _table("accounts", 5),
+                _table("invoices", 10, parents=("accounts",)),
+            )
+        )
+        assert plan.table("invoices").fk_parents == ("accounts",)
+
+    def test_duplicate_table_rejected(self):
+        with pytest.raises(ValueError, match="duplicate table"):
+            SeedPlan((_table("a", 1), _table("a", 2)))
+
+    def test_empty_plan_rejected(self):
+        with pytest.raises(ValueError, match="at least one table"):
+            SeedPlan(())
+
+    def test_non_positive_pareto_rejected(self):
+        with pytest.raises(ValueError, match="pareto_a"):
+            SeedPlan((_table("a", 1),), pareto_a=0)
+
+    def test_table_lookup_missing_raises_keyerror(self):
+        plan = SeedPlan((_table("a", 1),))
+        with pytest.raises(KeyError):
+            plan.table("nope")
+
+
+class TestSeedPlanScaling:
+    def test_scaling_preserves_ratio_and_sums_exactly(self):
+        """
+        Scenario: --count scales per-table shares proportionally
+          Given a plan with weights 1:3
+          When  scaled to a total of 100
+          Then  the tables get 25 and 75 and the sum is exactly 100
+        """
+        plan = SeedPlan((_table("a", 1), _table("b", 3)))
+        scaled = plan.scaled(100)
+        counts = [t.target_count for t in scaled.tables]
+        assert counts == [25, 75]
+        assert sum(counts) == 100
+
+    def test_largest_remainder_distributes_leftover(self):
+        # 3 equal weights into 100 -> 34/33/33 (sum 100), not 33/33/33.
+        plan = SeedPlan((_table("a", 1), _table("b", 1), _table("c", 1)))
+        counts = [t.target_count for t in plan.scaled(100).tables]
+        assert sum(counts) == 100
+        assert max(counts) - min(counts) <= 1
+
+    def test_scaling_to_zero_yields_zero_rows(self):
+        plan = SeedPlan((_table("a", 1), _table("b", 3)))
+        assert [t.target_count for t in plan.scaled(0).tables] == [0, 0]
+
+    def test_every_table_gets_at_least_one_row(self):
+        # A tiny share must not collapse a low-weight parent to zero rows.
+        plan = SeedPlan((_table("accounts", 1), _table("invoices", 9999)))
+        counts = [t.target_count for t in plan.scaled(100).tables]
+        assert counts[0] >= 1
+        assert sum(counts) == 100
+
+    def test_total_below_table_count_rejected(self):
+        plan = SeedPlan((_table("a", 1), _table("b", 1), _table("c", 1)))
+        with pytest.raises(ValueError, match="number of tables"):
+            plan.scaled(2)
+
+    def test_negative_total_rejected(self):
+        plan = SeedPlan((_table("a", 1),))
+        with pytest.raises(ValueError, match="total_count"):
+            plan.scaled(-5)
+
+    def test_zero_weight_plan_cannot_scale(self):
+        plan = SeedPlan((_table("a", 0),))
+        with pytest.raises(ValueError, match="weights sum to 0"):
+            plan.scaled(10)
+
+    def test_scaling_preserves_pareto_and_factory(self):
+        plan = SeedPlan((_table("a", 1),), pareto_a=2.0)
+        scaled = plan.scaled(10)
+        assert scaled.pareto_a == 2.0
+        assert scaled.tables[0].row_factory is _factory
+
+
+class TestSeedPlanHash:
+    def test_hash_is_deterministic(self):
+        plan_a = SeedPlan((_table("a", 1), _table("b", 2, parents=("a",))))
+        plan_b = SeedPlan((_table("a", 1), _table("b", 2, parents=("a",))))
+        assert plan_a.hash() == plan_b.hash()
+        assert plan_a.hash().startswith("sha256:")
+
+    def test_hash_changes_when_target_count_changes(self):
+        """
+        Scenario: schema-drift on resume aborts cleanly
+          Given a plan hash for invoices target 100
+          When  the invoices target changes to 200
+          Then  the plan hash differs so a resume can detect the drift
+        """
+        before = SeedPlan((_table("invoices", 100),)).hash()
+        after = SeedPlan((_table("invoices", 200),)).hash()
+        assert before != after
+
+    def test_hash_changes_when_columns_change(self):
+        before = SeedPlan((_table("a", 1, columns=("id",)),)).hash()
+        after = SeedPlan((_table("a", 1, columns=("id", "name")),)).hash()
+        assert before != after
+
+    def test_hash_changes_when_fk_edges_change(self):
+        before = SeedPlan((_table("a", 1), _table("b", 1))).hash()
+        after = SeedPlan((_table("a", 1), _table("b", 1, parents=("a",)))).hash()
+        assert before != after
+
+    def test_hash_changes_with_pareto(self):
+        before = SeedPlan((_table("a", 1),), pareto_a=1.16).hash()
+        after = SeedPlan((_table("a", 1),), pareto_a=2.0).hash()
+        assert before != after
+
+    def test_hash_ignores_row_factory_identity(self):
+        # Two distinct factory callables with identical declared columns hash the same.
+        def other_factory(pool, rng, seq):
+            return {"id": seq}
+
+        plan_a = SeedPlan((_table("a", 1),))
+        plan_b = SeedPlan((TablePlan("a", 1, other_factory, ("id",)),))
+        assert plan_a.hash() == plan_b.hash()

--- a/tests/unit/loadtest/test_pool.py
+++ b/tests/unit/loadtest/test_pool.py
@@ -1,0 +1,142 @@
+"""Unit tests for FKPool: population, sampling contract, and Pareto skew (#250/#251)."""
+
+import random
+from collections import Counter
+
+import pytest
+
+from hyperadmin.loadtest import pool as pool_module
+from hyperadmin.loadtest.pool import EmptyPoolError, FKPool
+
+
+def _pool(seed=42, pareto_a=1.16):
+    return FKPool(pareto_a=pareto_a, rng=random.Random(seed))  # noqa: S311 - test RNG
+
+
+class TestPopulation:
+    def test_extend_and_size(self):
+        p = _pool()
+        p.extend("accounts", [1, 2, 3])
+        p.extend("accounts", [4, 5])
+        assert p.size("accounts") == 5
+        assert len(p) == 5
+
+    def test_size_of_unknown_table_is_zero(self):
+        assert _pool().size("nope") == 0
+
+    def test_len_sums_across_tables(self):
+        p = _pool()
+        p.extend("accounts", range(10))
+        p.extend("contacts", range(3))
+        assert len(p) == 13
+
+    def test_contains(self):
+        p = _pool()
+        p.extend("accounts", [1])
+        assert "accounts" in p
+        assert "contacts" not in p
+
+    def test_pareto_a_must_exceed_one(self):
+        with pytest.raises(ValueError, match="pareto_a"):
+            FKPool(pareto_a=1.0)
+
+
+class TestSamplingContract:
+    def test_sample_empty_pool_raises(self):
+        """
+        Scenario: empty FK pool when child batch starts
+          Given a child table whose parent pool was never populated
+          When  the seeder samples the parent
+          Then  an EmptyPoolError naming the parent is raised
+        """
+        with pytest.raises(EmptyPoolError, match="accounts"):
+            _pool().sample("accounts")
+
+    def test_sample_many_empty_pool_raises(self):
+        with pytest.raises(EmptyPoolError):
+            _pool().sample_many("accounts", 5)
+
+    def test_sample_returns_member(self):
+        p = _pool()
+        p.extend("accounts", [10, 20, 30])
+        for _ in range(50):
+            assert p.sample("accounts") in {10, 20, 30}
+
+    def test_sample_many_returns_n_members(self):
+        p = _pool()
+        ids = list(range(100, 200))
+        p.extend("accounts", ids)
+        drawn = p.sample_many("accounts", 500)
+        assert len(drawn) == 500
+        assert set(drawn) <= set(ids)
+
+    def test_sample_many_zero_returns_empty(self):
+        p = _pool()
+        p.extend("accounts", [1, 2, 3])
+        assert p.sample_many("accounts", 0) == []
+
+    def test_sample_many_negative_raises(self):
+        p = _pool()
+        p.extend("accounts", [1, 2, 3])
+        with pytest.raises(ValueError, match="n must be >= 0"):
+            p.sample_many("accounts", -1)
+
+    def test_single_member_pool_always_returns_it(self):
+        p = _pool()
+        p.extend("accounts", [99])
+        assert p.sample("accounts") == 99
+        assert p.sample_many("accounts", 10) == [99] * 10
+
+
+class TestParetoSkew:
+    def _skew_fraction(self, drawn, n_accounts):
+        """Fraction of draws landing in the top 20% of account ranks."""
+        top_cut = n_accounts // 5  # ranks [0, top_cut) are the "hot" 20%
+        hot = sum(1 for pk in drawn if pk < top_cut)
+        return hot / len(drawn)
+
+    def test_top_20_percent_own_roughly_80_percent_numpy_path(self):
+        """
+        Scenario: FK reference distribution follows the configured Pareto skew
+          Given 1000 Accounts and 100000 Invoices
+          When  invoice.account_id values are tallied
+          Then  the top 20% of accounts own ~80% of invoices (within +/- 5%)
+        """
+        p = _pool()
+        p.extend("accounts", range(1000))  # PKs 0..999 == ranks
+        drawn = p.sample_many("accounts", 100_000)  # >= 64 -> numpy fast path
+        fraction = self._skew_fraction(drawn, 1000)
+        assert 0.75 <= fraction <= 0.85
+
+    def test_top_20_percent_skew_stdlib_path(self, monkeypatch):
+        # Force the pure-stdlib fallback and confirm the same skew holds.
+        monkeypatch.setattr(pool_module, "_HAS_NUMPY", False)
+        p = _pool()
+        p.extend("accounts", range(1000))
+        drawn = p.sample_many("accounts", 100_000)
+        fraction = self._skew_fraction(drawn, 1000)
+        assert 0.75 <= fraction <= 0.85
+
+    def test_no_id_referenced_more_than_total_draws(self):
+        p = _pool()
+        p.extend("accounts", range(1000))
+        n = 100_000
+        counts = Counter(p.sample_many("accounts", n))
+        assert max(counts.values()) <= n
+        assert all(pk in range(1000) for pk in counts)
+
+    def test_distribution_is_reproducible_under_fixed_seed(self):
+        a = _pool(seed=7)
+        b = _pool(seed=7)
+        a.extend("accounts", range(500))
+        b.extend("accounts", range(500))
+        assert a.sample_many("accounts", 1000) == b.sample_many("accounts", 1000)
+
+    def test_scalar_sample_is_reproducible(self):
+        a = _pool(seed=7)
+        b = _pool(seed=7)
+        a.extend("accounts", range(500))
+        b.extend("accounts", range(500))
+        assert [a.sample("accounts") for _ in range(200)] == [
+            b.sample("accounts") for _ in range(200)
+        ]

--- a/tests/unit/loadtest/test_progress.py
+++ b/tests/unit/loadtest/test_progress.py
@@ -1,0 +1,80 @@
+"""Unit tests for progress reporters and reporter selection (#253)."""
+
+import io
+
+from hyperadmin.loadtest.progress import (
+    PlainReporter,
+    RichReporter,
+    _format_rate,
+    make_reporter,
+)
+
+
+class FakeTTY(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class TestFormatRate:
+    def test_sub_thousand_rate(self):
+        assert _format_rate(500, 1.0) == "500/s"
+
+    def test_thousands_rate(self):
+        assert _format_rate(28400, 1.0) == "28.4K/s"
+
+    def test_zero_elapsed_is_safe(self):
+        # No division-by-zero; rate is reported as 0 when no time has passed.
+        assert _format_rate(100, 0.0) == "0/s"
+
+
+class TestPlainReporter:
+    def test_advance_emits_progress_line(self):
+        clock = iter([0.0, 1.0]).__next__  # start, advance
+        stream = io.StringIO()
+        reporter = PlainReporter(stream, clock=clock)
+        reporter.start_table("invoices", 100)
+        reporter.advance("invoices", 35)
+        out = stream.getvalue()
+        assert "table=invoices" in out
+        assert "completed=35/100" in out
+        assert "rate=" in out
+
+    def test_finish_line_reports_elapsed(self):
+        clock = iter([0.0, 2.0]).__next__
+        stream = io.StringIO()
+        reporter = PlainReporter(stream, clock=clock)
+        reporter.start_table("accounts", 10)
+        reporter.finish_table("accounts")
+        assert "done=" in stream.getvalue()
+        assert "elapsed=2.0s" in stream.getvalue()
+
+    def test_close_is_noop(self):
+        PlainReporter(io.StringIO()).close()
+
+
+class TestRichReporter:
+    def test_rich_reporter_lifecycle(self):
+        reporter = RichReporter()
+        try:
+            reporter.start_table("invoices", 100)
+            reporter.advance("invoices", 50)
+            reporter.finish_table("invoices")
+        finally:
+            reporter.close()
+
+
+class TestMakeReporter:
+    def test_no_progress_forces_plain(self):
+        reporter = make_reporter(no_progress=True, stream=FakeTTY())
+        assert isinstance(reporter, PlainReporter)
+
+    def test_non_tty_uses_plain(self):
+        reporter = make_reporter(no_progress=False, stream=io.StringIO())
+        assert isinstance(reporter, PlainReporter)
+
+    def test_tty_uses_rich(self):
+        reporter = make_reporter(no_progress=False, stream=FakeTTY())
+        try:
+            assert isinstance(reporter, RichReporter)
+        finally:
+            reporter.close()

--- a/tests/unit/loadtest/test_seed_cli.py
+++ b/tests/unit/loadtest/test_seed_cli.py
@@ -1,0 +1,101 @@
+"""Unit tests for the ``hyperadmin seed`` Typer CLI (#254)."""
+
+from sqlalchemy import create_engine
+from sqlmodel import SQLModel
+from typer.testing import CliRunner
+
+import hyperadmin.auth.models  # noqa: F401 - registers hyperadmin_* tables on metadata
+from hyperadmin.management.commands.seed import _to_sync_url, app
+
+runner = CliRunner()
+
+
+class TestUrlConversion:
+    def test_aiosqlite_to_sqlite(self):
+        assert _to_sync_url("sqlite+aiosqlite:///erp.db") == "sqlite:///erp.db"
+
+    def test_asyncpg_to_psycopg2(self):
+        assert _to_sync_url("postgresql+asyncpg://u@h/db") == "postgresql+psycopg2://u@h/db"
+
+    def test_sync_url_passthrough(self):
+        assert _to_sync_url("postgresql://u@h/db") == "postgresql://u@h/db"
+
+
+class TestErrorPaths:
+    def test_missing_database_url_exits_1(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        result = runner.invoke(app, ["--count", "10"])
+        assert result.exit_code == 1
+        assert "DATABASE_URL" in result.output
+
+    def test_negative_count_exits_1(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        result = runner.invoke(app, ["--count", "-1", "--database-url", "sqlite:///:memory:"])
+        assert result.exit_code == 1
+        assert "--count" in result.output
+
+    def test_unknown_plan_exits_1(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        result = runner.invoke(
+            app,
+            ["--count", "10", "--plan", "bogus", "--database-url", "sqlite:///:memory:"],
+        )
+        assert result.exit_code == 1
+        assert "available plans" in result.output
+
+
+class TestHappyPath:
+    def test_seeds_auth_plan_into_sqlite(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        url = f"sqlite:///{tmp_path / 'auth.db'}"
+        engine = create_engine(url)
+        SQLModel.metadata.create_all(engine)
+        engine.dispose()
+
+        result = runner.invoke(
+            app,
+            [
+                "--count",
+                "50",
+                "--plan",
+                "auth",
+                "--database-url",
+                url,
+                "--no-progress",
+                "--state-file",
+                str(tmp_path / ".seed.json"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Seeded 50 rows" in result.output
+
+    def test_resume_with_drifted_plan_exits_2(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        url = f"sqlite:///{tmp_path / 'auth.db'}"
+        engine = create_engine(url)
+        SQLModel.metadata.create_all(engine)
+        engine.dispose()
+
+        # A checkpoint whose plan_hash cannot match any real plan forces an abort on --resume.
+        state_file = tmp_path / ".seed.json"
+        state_file.write_text(
+            '{"plan_hash": "sha256:stale", "rng_seed": 42, "started_at": "x", '
+            '"tables": {"hyperadmin_users": {"target": 5, "completed": 0, "last_pk": null}}}'
+        )
+        result = runner.invoke(
+            app,
+            [
+                "--count",
+                "50",
+                "--plan",
+                "auth",
+                "--database-url",
+                url,
+                "--no-progress",
+                "--resume",
+                "--state-file",
+                str(state_file),
+            ],
+        )
+        assert result.exit_code == 2
+        assert "cannot resume" in result.output


### PR DESCRIPTION
## Summary

Implements the **Synthetic Data Generator** epic (#246) for v0.7.1 — a bulk seeder that produces 10M+ realistic, FK-correct rows for the v0.7.0 scalability benchmarks. New `src/hyperadmin/loadtest/` package, fully decoupled from the admin core (no `Admin()` coupling, not re-exported from the top-level package). Built bottom-up per the SDD (`docs/specs/synthetic-data-generator.md`, now **Approved**).

Closes the 9 stories under epic #246: #248 #249 #250 #251 #252 #253 #254 #255 #256.

## What's included

- **`plan.py`** — `SeedPlan`/`TablePlan` domain models, deterministic `plan_hash`, proportional `scaled(n)` that reserves ≥1 row per table so FK parents never round to zero.
- **`pool.py`** — `FKPool` with Pareto-skewed sampling (top 20% of parents own ≈80% of references) via inverse-transform of a bounded power law; numpy soft-dep fast path + stdlib fallback (both verified).
- **`checkpoint.py`** — resumable JSON state with `plan_hash` drift detection, atomic writes, amortised `fsync`.
- **`progress.py`** — Rich per-table progress bars with a plain non-TTY/`--no-progress` fallback.
- **`batch.py`** — `BulkSeeder`: generate→batch→`insert()`→commit loop, query-based FK pool population, cooperative SIGINT/SIGTERM handling, `SeedSummary`.
- **`generators/`** — hard-coded `erp` and `auth` plans.
- **`management/commands/seed.py`** — `hyperadmin seed` Typer subcommand (`--count/--batch-size/--database-url/--resume/--seed/--state-file/--plan/--no-progress`).
- **`examples/erp/seed.py`** — async `bulk_seed_erp()` wrapper (`asyncio.to_thread`) + `--bulk N` entrypoint; demo `seed_db()` unchanged.

## Tests

95 new tests (unit + a `tests/e2e` integration test seeding 1K rows into SQLite and verifying FK integrity across every ERP edge). ~97% coverage on the new modules. `ruff`, `mypy`, and `basedpyright` all clean on `src`.

Measured throughput on the integration run: **~38K rows/s on SQLite**, above the SDD's ~30K/s ship floor.

## Design deviations from the draft SDD (recorded in the Decision Log)

- Pareto sampling uses the inverse-transform of a bounded power law (exact 80/20, no tail clamping) instead of `random.paretovariate`.
- `scaled(n)` reserves 1 row per table (requires `n ≥ len(tables)`) to keep FK integrity at small counts.
- FK pool populated by querying parent PKs (dialect-agnostic) rather than per-batch `RETURNING`.

## Manual test scenarios

1. **Bulk seed (ERP):** create a Postgres/SQLite DB with the ERP schema migrated, run `hyperadmin seed --count 100000 --database-url <url>`. Expect exit 0, a final throughput line, and each table holding its planned share.
2. **FK integrity:** after seeding, `SELECT count(*) FROM erp_invoices i LEFT JOIN erp_contacts c ON i.customer_id=c.id WHERE c.id IS NULL` → expect `0`.
3. **Resume:** start a large seed, Ctrl-C mid-run, then re-run with `--resume`. Expect it to continue from the last committed batch and finish at the exact target with no duplicate unique values; `.hyperadmin-seed.json` is removed on clean completion.
4. **Drift guard:** change `--count` and re-run with `--resume` → expect exit 2 with a "cannot resume … target changed" message and no rows written.
5. **Pareto skew:** seed 1000 accounts + 100000 invoices, tally `account_id` → top 20% of accounts own ≈80% of invoices.
6. **CI / non-TTY:** run with `--no-progress` → expect one structured `table=… completed=…/… rate=…` line per batch instead of the Rich UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
