### PR TITLE
docs(specs): approve v0.5.2 OAuth SSO SDD (#438)

### DIFF
--- a/.meta/epics/epicauth-oauth-sso-google-github/epic.md
+++ b/.meta/epics/epicauth-oauth-sso-google-github/epic.md
@@ -2,7 +2,7 @@
 type: epic
 id: hHg_npkJyrk7
 title: "epic(auth): OAuth SSO — Google & GitHub"
-status: todo
+status: in_progress
 priority: medium
 owner: null
 labels:
@@ -57,7 +57,7 @@ Implement OAuth2/OIDC authentication backends for Google and GitHub SSO.
 ```
 
 ## Tasks
-- [ ] #438 — review(spec): approve SDD for OAuth SSO
+- [x] #438 — review(spec): approve SDD for OAuth SSO
 - [ ] #439 — feat(auth): create OAuthToken model
 - [ ] #440 — feat(auth): create OAuth provider configuration
 - [ ] #441 — feat(auth): create OAuth2/OIDC backend

--- a/docs/specs/oauth-sso.md
+++ b/docs/specs/oauth-sso.md
@@ -3,11 +3,11 @@
 | Field | Value |
 |---|---|
 | Author | Claude Code |
-| Status | Draft |
+| Status | Approved |
 | Issue | #420 (epic), #438 (review gate) |
 | Milestone | v0.5.2 — OAuth SSO |
 | Created | 2026-05-10 |
-| Last updated | 2026-05-10 |
+| Last updated | 2026-06-04 |
 
 ---
 


### PR DESCRIPTION
Clears the **spec-review gate (#438)** for the v0.5.2 OAuth SSO epic so implementation can be dispatched.

## Review summary (against the SDD reviewer checklist)

- ✅ Problem scoped; goals measurable (2 providers via generic `OAuthBackend` + config)
- ✅ Non-goals prevent scope creep (SAML2, RP-logout, session revocation, group sync — all deferred)
- ✅ BDD scenarios cover happy + failure paths
- ✅ **Backward compatible** — additive `__init__.py` exports; `User.password_hash → Optional` is read-compatible; host app owns the single-table migration
- ✅ All 4 **Open Questions resolved**: `httpx-oauth` (pinned `>=0.13,<1.0`); encrypt-at-rest via Fernet; **interstitial** account-linking (no email auto-link — avoids the classic SSO takeover); OAuth-only users may have no password (gated on unlink check)
- ✅ Security-forward: PKCE (S256) on all flows; MFA bridge preserves the v0.5.1 partial-auth session
- ✅ Forward-compat with v0.5.3: optional `tenant_id_claim` mapping

## Changes

- `docs/specs/oauth-sso.md`: Status `Draft → Approved`
- `.meta/.../epic.md`: gate `#438` checked; epic `status: todo → in_progress`

Unblocks the 7-story DAG (#439–#446).

🤖 Generated with [Claude Code](https://claude.com/claude-code)